### PR TITLE
Bootstrap: Task Contract・role routing・cold-start validationを実装する

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -26,3 +26,62 @@
 
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。
 `CLAUDE.md` は `AGENTS.md` を参照する thin adapter であり、canonical rule を複製しません。
+
+## Task Protocol
+
+Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く
+参照し、別の長文 handoff を正本として増やしません。Task Contract は、次の内容を表現できる
+semantic contract です。
+
+- Goal
+- Acceptance Criteria
+- In Scope / Out of Scope
+- Decisions / Invariants
+- Verification
+- Allowed Discretion / Escalate When
+- Execution State（Phase: `design` / `implementation` / `review` / `closure`、Role: `high` /
+  `balanced` / `fast`）
+
+すべての Task に全項目を機械的に必須化するのではなく、downstream agent が product または
+architecture の判断を推測せずに着手できることを目的とします。
+
+Semantic Contract は何を成立させるかを表し、Goal、Acceptance Criteria、Scope、Decisions、
+Invariants、Verification で構成します。repository、branch、cwd、sandbox、permission、
+available tools、runtime constraints は Execution Envelope として別に扱います。Execution
+Envelope の制約や事故を semantic decision として吸収してはいけません。
+
+### Role routing
+
+Role は provider-neutral な意味で選びます。
+
+- **High**: product、architecture、protocol の判断、曖昧性解消、または複数の妥当解からの
+  選択が残る。
+- **Balanced**: intent と主要 decision は固定済みだが、実装上の裁量または局所設計が残る。
+- **Fast**: correctness をほぼ機械的に判定でき、semantic choice が小さい。
+
+Task 開始時には次を診断します。
+
+1. Goal と Acceptance Criteria を一意に解釈できるか。
+2. 必要な product、architecture、policy の decision は固定済みか。
+3. 残りの correctness を主に機械的に判定できるか。
+
+1 または 2 が No なら High、1 と 2 が Yes で 3 が No なら Balanced、1 から 3 が Yes
+で裁量が小さければ Fast とします。これは数値スコアや絶対的な不変条件ではない diagnostic
+heuristic です。
+
+### Handoff and escalation
+
+Task boundary と agent/session boundary は一致しません。一つの Task を複数の agent で
+処理してよく、一つの agent が複数工程を継続しても構いません。High から Balanced への
+handoff を毎 Task で義務化しませんが、High role を終える時点では、次の agent が product
+または architecture choice をせず実装できる状態にします。
+
+- **planned handoff** は、固定済みの semantic contract を次の工程または agent に渡すことです。
+- **capability escalation** は、必要な技術的能力、tool、または専門的な adjudication を得ることです。
+- **authority escalation** は、product intent、権限、または受容不能な trade-off を決める
+  authority に判断を求めることです。
+
+未確定の product または architecture decision に遭遇した実装 agent は、silent decision を
+してはいけません。pure technical dispute は原則として technical adjudication で解決し、
+人間を message bus にしません。人間への escalation は、product intent、authority、権限、
+または受容不能な trade-off に限ります。

--- a/policy/core.md
+++ b/policy/core.md
@@ -31,7 +31,7 @@
 
 Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く
 参照し、別の長文 handoff を正本として増やしません。Task Contract は、次の内容を表現できる
-semantic contract です。
+contract です。
 
 - Goal
 - Acceptance Criteria
@@ -49,6 +49,9 @@ Semantic Contract は何を成立させるかを表し、Goal、Acceptance Crite
 Invariants、Verification で構成します。repository、branch、cwd、sandbox、permission、
 available tools、runtime constraints は Execution Envelope として別に扱います。Execution
 Envelope の制約や事故を semantic decision として吸収してはいけません。
+
+Task Contract は Semantic Contract と同義ではありません。Allowed Discretion / Escalate When
+と Execution State は Task Contract の handoff/control context です。
 
 ### Role routing
 
@@ -76,7 +79,9 @@ Task boundary と agent/session boundary は一致しません。一つの Task 
 handoff を毎 Task で義務化しませんが、High role を終える時点では、次の agent が product
 または architecture choice をせず実装できる状態にします。
 
-- **planned handoff** は、固定済みの semantic contract を次の工程または agent に渡すことです。
+- **planned handoff** は、Issue を canonical context として短く参照し、Semantic Contract に
+  加えて Allowed Discretion / Escalate When と Execution State の handoff/control context を
+  失わず次の工程または agent に渡すことです。これは長文 handoff への複製を要求しません。
 - **capability escalation** は、必要な技術的能力、tool、または専門的な adjudication を得ることです。
 - **authority escalation** は、product intent、権限、または受容不能な trade-off を決める
   authority に判断を求めることです。

--- a/test/cold-start-validation.md
+++ b/test/cold-start-validation.md
@@ -6,7 +6,7 @@
 ## Representative task
 
 - Canonical context: GitHub Issue #8
-- Validation target: `59a9db8d363b63746fd56a100ae9b68ddc196e33`。
+- Validation target: `6a9155216c2784f555935f1e69ebb0de9b603ed3`。
 - Repository rules: validation target上のrepository root `AGENTS.md` と
   `policy/core.md`
 - Execution Envelope: repository root を cwd とした新規 CLI process。既存 session の
@@ -29,8 +29,8 @@
 
 | Provider | Fresh-session result | Status |
 | --- | --- | --- |
-| Codex | `--ephemeral` の新規CLI processで実施。Issue #8とtarget上のrulesをread-onlyで取得し、Goal / Scope / Invariants、Verification、Escalation条件を復元した。Roleは、canonical composition内の最小配置などにarchitecture choiceが残るという根拠で`High`と判断した。provider固有contractやsilent decisionは追加しなかった。 | final pass |
-| Claude | `--no-session-persistence` の新規CLI processで実施。Issue #8とtarget上のrulesを取得し、Goal / Scope / Invariants、Verification、Escalation条件を復元した。Roleは、主要decisionは固定済みで局所的な実装裁量が残るという根拠で`Balanced`と判断した。provider固有contractやsilent decisionは追加しなかった。 | final pass |
+| Codex | `--ephemeral` の新規CLI processで実施。Issue #8とtarget上のrulesをread-onlyで取得し、6項目すべてを復元した。Roleは、主要decisionが固定済みで局所設計の裁量が残るという根拠で`Balanced`と判断した。planned handoffでSemantic Contractに加えAllowed Discretion / Escalate WhenとExecution Stateを失わず、Issueを短く参照することを復元し、provider固有contractやsilent decisionは追加しなかった。 | final pass |
+| Claude | `--no-session-persistence` の新規CLI processで実施。Issue #8とtarget上のrulesを取得し、6項目すべてを復元した。Roleは、主要decisionが固定済みで残りのcorrectnessに解釈裁量が残るという根拠で`Balanced`と判断した。planned handoffでSemantic Contractに加えAllowed Discretion / Escalate WhenとExecution Stateを失わず、Issueを短く参照することを復元し、provider固有contractやsilent decisionは追加しなかった。 | final pass |
 
 両sessionは既存sessionをresumeせず、Issue #8とvalidation target上のrepository rulesだけを
 canonical contextとして使用した。Roleの判断はいずれもIssueのrouting heuristicに基づくもので、

--- a/test/cold-start-validation.md
+++ b/test/cold-start-validation.md
@@ -1,0 +1,36 @@
+# Cold-start validation record
+
+この記録は Task Protocol の canonical source ではありません。規範的な定義は
+`policy/core.md` を参照します。
+
+## Representative task
+
+- Canonical context: GitHub Issue #8
+- Validation target: worktree based on `70adc6774548d20f33f2142ad157ba412412be38`。
+- Repository rules: repository root の `AGENTS.md`、および生成された consumer の
+  `AGENTS.md` / `CLAUDE.md`
+- Execution Envelope: repository root を cwd とした新規 CLI process。既存 session の
+  resume、長文 handoff、provider 固有の model 指定は使わない。
+
+## Procedure
+
+各 provider で新規 session を起動し、Issue #8 と repository rules だけを読ませ、次を
+短く回答させる。
+
+1. Goal、scope、invariants
+2. 選ぶ Role と routing の根拠
+3. 勝手に決めてはいけない未確定 decision
+4. verification と escalation 条件
+
+回答を Issue の canonical context と照合し、必要な semantic contract を復元でき、provider
+固有の contract を追加していないことを確認する。
+
+## Result
+
+| Provider | Fresh-session result | Status |
+| --- | --- | --- |
+| Codex | この Issue の実装 session で実施。Issue #8 と root `AGENTS.md` のみから、Task Protocol を `High` と判定し、Task field の全機械必須化・provider 固有 rule・orchestrator の追加を未確定判断として保持した。`npm test` と consumer `npm run verify` を verification として特定した。 | pass |
+| Claude | `claude -p --no-session-persistence` を2回実行したが、認証済みのCLIが120秒以内に応答を返さなかった。sandbox外での再試行では weekly limit に到達したと返された。`--bare` は OAuth 認証を使えず、fresh validationには利用できなかった。成功出力は記録していない。 | runtime pending |
+
+Claude の記録が未完了の場合、Task Protocol の変更ではなく provider runtime がこの実行環境で
+利用可能かどうかの検証待ちとして扱います。

--- a/test/cold-start-validation.md
+++ b/test/cold-start-validation.md
@@ -6,9 +6,9 @@
 ## Representative task
 
 - Canonical context: GitHub Issue #8
-- Validation target: worktree based on `70adc6774548d20f33f2142ad157ba412412be38`。
-- Repository rules: repository root の `AGENTS.md`、および生成された consumer の
-  `AGENTS.md` / `CLAUDE.md`
+- Validation target: `59a9db8d363b63746fd56a100ae9b68ddc196e33`。
+- Repository rules: validation target上のrepository root `AGENTS.md` と
+  `policy/core.md`
 - Execution Envelope: repository root を cwd とした新規 CLI process。既存 session の
   resume、長文 handoff、provider 固有の model 指定は使わない。
 
@@ -29,8 +29,9 @@
 
 | Provider | Fresh-session result | Status |
 | --- | --- | --- |
-| Codex | この Issue の実装 session で実施。Issue #8 と root `AGENTS.md` のみから、Task Protocol を `High` と判定し、Task field の全機械必須化・provider 固有 rule・orchestrator の追加を未確定判断として保持した。`npm test` と consumer `npm run verify` を verification として特定した。 | pass |
-| Claude | `claude -p --no-session-persistence` を2回実行したが、認証済みのCLIが120秒以内に応答を返さなかった。sandbox外での再試行では weekly limit に到達したと返された。`--bare` は OAuth 認証を使えず、fresh validationには利用できなかった。成功出力は記録していない。 | runtime pending |
+| Codex | `--ephemeral` の新規CLI processで実施。Issue #8とtarget上のrulesをread-onlyで取得し、Goal / Scope / Invariants、Verification、Escalation条件を復元した。Roleは、canonical composition内の最小配置などにarchitecture choiceが残るという根拠で`High`と判断した。provider固有contractやsilent decisionは追加しなかった。 | final pass |
+| Claude | `--no-session-persistence` の新規CLI processで実施。Issue #8とtarget上のrulesを取得し、Goal / Scope / Invariants、Verification、Escalation条件を復元した。Roleは、主要decisionは固定済みで局所的な実装裁量が残るという根拠で`Balanced`と判断した。provider固有contractやsilent decisionは追加しなかった。 | final pass |
 
-Claude の記録が未完了の場合、Task Protocol の変更ではなく provider runtime がこの実行環境で
-利用可能かどうかの検証待ちとして扱います。
+両sessionは既存sessionをresumeせず、Issue #8とvalidation target上のrepository rulesだけを
+canonical contextとして使用した。Roleの判断はいずれもIssueのrouting heuristicに基づくもので、
+このheuristicは数値スコアや絶対的な不変条件ではない。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -39,7 +39,7 @@
 
 Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く
 参照し、別の長文 handoff を正本として増やしません。Task Contract は、次の内容を表現できる
-semantic contract です。
+contract です。
 
 - Goal
 - Acceptance Criteria
@@ -57,6 +57,9 @@ Semantic Contract は何を成立させるかを表し、Goal、Acceptance Crite
 Invariants、Verification で構成します。repository、branch、cwd、sandbox、permission、
 available tools、runtime constraints は Execution Envelope として別に扱います。Execution
 Envelope の制約や事故を semantic decision として吸収してはいけません。
+
+Task Contract は Semantic Contract と同義ではありません。Allowed Discretion / Escalate When
+と Execution State は Task Contract の handoff/control context です。
 
 ### Role routing
 
@@ -84,7 +87,9 @@ Task boundary と agent/session boundary は一致しません。一つの Task 
 handoff を毎 Task で義務化しませんが、High role を終える時点では、次の agent が product
 または architecture choice をせず実装できる状態にします。
 
-- **planned handoff** は、固定済みの semantic contract を次の工程または agent に渡すことです。
+- **planned handoff** は、Issue を canonical context として短く参照し、Semantic Contract に
+  加えて Allowed Discretion / Escalate When と Execution State の handoff/control context を
+  失わず次の工程または agent に渡すことです。これは長文 handoff への複製を要求しません。
 - **capability escalation** は、必要な技術的能力、tool、または専門的な adjudication を得ることです。
 - **authority escalation** は、product intent、権限、または受容不能な trade-off を決める
   authority に判断を求めることです。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -35,6 +35,65 @@
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。
 `CLAUDE.md` は `AGENTS.md` を参照する thin adapter であり、canonical rule を複製しません。
 
+## Task Protocol
+
+Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く
+参照し、別の長文 handoff を正本として増やしません。Task Contract は、次の内容を表現できる
+semantic contract です。
+
+- Goal
+- Acceptance Criteria
+- In Scope / Out of Scope
+- Decisions / Invariants
+- Verification
+- Allowed Discretion / Escalate When
+- Execution State（Phase: `design` / `implementation` / `review` / `closure`、Role: `high` /
+  `balanced` / `fast`）
+
+すべての Task に全項目を機械的に必須化するのではなく、downstream agent が product または
+architecture の判断を推測せずに着手できることを目的とします。
+
+Semantic Contract は何を成立させるかを表し、Goal、Acceptance Criteria、Scope、Decisions、
+Invariants、Verification で構成します。repository、branch、cwd、sandbox、permission、
+available tools、runtime constraints は Execution Envelope として別に扱います。Execution
+Envelope の制約や事故を semantic decision として吸収してはいけません。
+
+### Role routing
+
+Role は provider-neutral な意味で選びます。
+
+- **High**: product、architecture、protocol の判断、曖昧性解消、または複数の妥当解からの
+  選択が残る。
+- **Balanced**: intent と主要 decision は固定済みだが、実装上の裁量または局所設計が残る。
+- **Fast**: correctness をほぼ機械的に判定でき、semantic choice が小さい。
+
+Task 開始時には次を診断します。
+
+1. Goal と Acceptance Criteria を一意に解釈できるか。
+2. 必要な product、architecture、policy の decision は固定済みか。
+3. 残りの correctness を主に機械的に判定できるか。
+
+1 または 2 が No なら High、1 と 2 が Yes で 3 が No なら Balanced、1 から 3 が Yes
+で裁量が小さければ Fast とします。これは数値スコアや絶対的な不変条件ではない diagnostic
+heuristic です。
+
+### Handoff and escalation
+
+Task boundary と agent/session boundary は一致しません。一つの Task を複数の agent で
+処理してよく、一つの agent が複数工程を継続しても構いません。High から Balanced への
+handoff を毎 Task で義務化しませんが、High role を終える時点では、次の agent が product
+または architecture choice をせず実装できる状態にします。
+
+- **planned handoff** は、固定済みの semantic contract を次の工程または agent に渡すことです。
+- **capability escalation** は、必要な技術的能力、tool、または専門的な adjudication を得ることです。
+- **authority escalation** は、product intent、権限、または受容不能な trade-off を決める
+  authority に判断を求めることです。
+
+未確定の product または architecture decision に遭遇した実装 agent は、silent decision を
+してはいけません。pure technical dispute は原則として technical adjudication で解決し、
+人間を message bus にしません。人間への escalation は、product intent、authority、権限、
+または受容不能な trade-off に限ります。
+
 ## Technology profile: Next.js + Supabase
 
 # Next.js + Supabase profile

--- a/test/task-protocol.test.mjs
+++ b/test/task-protocol.test.mjs
@@ -25,7 +25,7 @@ test("core policy defines the provider-neutral Task Protocol", async () => {
   assert.match(core, /\*\*Balanced\*\*/);
   assert.match(core, /\*\*Fast\*\*/);
   assert.match(core, /Task boundary と agent\/session boundary は一致しません/);
-  assert.match(core, /silent decision を\nしてはいけません/);
-  assert.match(core, /Execution\nEnvelope の制約や事故を semantic decision として吸収してはいけません/);
+  assert.match(core, /silent decision を\s+してはいけません/);
+  assert.match(core, /Execution\s+Envelope の制約や事故を semantic decision として吸収してはいけません/);
   assert.doesNotMatch(core, /claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
 });

--- a/test/task-protocol.test.mjs
+++ b/test/task-protocol.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("core policy defines the provider-neutral Task Protocol", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  for (const heading of [
+    "Goal",
+    "Acceptance Criteria",
+    "In Scope / Out of Scope",
+    "Decisions / Invariants",
+    "Verification",
+    "Allowed Discretion / Escalate When",
+    "Execution State",
+  ]) {
+    assert.ok(core.includes(heading), `missing Task Contract item: ${heading}`);
+  }
+
+  assert.match(core, /\*\*High\*\*/);
+  assert.match(core, /\*\*Balanced\*\*/);
+  assert.match(core, /\*\*Fast\*\*/);
+  assert.match(core, /Task boundary と agent\/session boundary は一致しません/);
+  assert.match(core, /silent decision を\nしてはいけません/);
+  assert.match(core, /Execution\nEnvelope の制約や事故を semantic decision として吸収してはいけません/);
+  assert.doesNotMatch(core, /claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});


### PR DESCRIPTION
Closes #8

## Summary

- Task Contract、provider-neutral role routing、handoff / escalation contractを `policy/core.md` のcanonical sourceに追加しました。
- 既存compositionでconsumer fixtureの生成済み `AGENTS.md` を更新しました。
- Task Protocolのdeterministic testとcold-start validation記録を追加しました。

## Canonical source

`policy/core.md`

## Verification

- `npm test` — pass（5 tests、guardrail fixture 8件）
- `npm run check:fixture` — pass
- `npm run --prefix test/fixtures/consumer verify` — pass
- `git diff --check` — pass

## Cold-start validation

Validation target:
`6a9155216c2784f555935f1e69ebb0de9b603ed3`

- Codex cold-start: final pass (`--ephemeral` fresh process)
- Claude cold-start: final pass (`--no-session-persistence` fresh process)
- 両providerともIssue #8とvalidation target上のrepository rulesからGoal / Scope / Invariants、Role、未確定decision、Verification、Escalationを復元できました。
- planned handoffでSemantic Contractに加え `Allowed Discretion / Escalate When` と `Execution State` を失わず、Issueをcanonical contextとして短く参照することを復元できました。
- 両providerともRoleはBalancedと判断し、主要decisionが固定済みで局所的な実装・解釈裁量が残ることを根拠としました。
- provider固有contractの追加、silent decisionは確認されませんでした。

Issue #8のcold-start Acceptance Criterionは充足済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Task Protocolを追加し、契約、実行範囲、役割分担、引き継ぎ、エスカレーションの運用ルールを明文化しました。
  * 未確定のプロダクト・アーキテクチャ判断を適切にエスカレーションする基準を追加しました。
  * コールドスタート時の検証手順、実行条件、判定結果を記録しました。

* **テスト**
  * Task Protocolの必須項目や実行ルールを自動検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->