### PR TITLE
Bootstrap: Review Protocol・review skills・triage contractを実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ consumer repository が必要とする provider 向けの小さなファイル�
 ## 構成
 
 - `policy/` は Foundation 全体に適用する規範的なルールを定義します。
+- `skills/` は policy を使った作業手順を保持し、規範的なルールを複製しません。
 - `profiles/` は product-domain rule を含めず、技術固有のルールを追加します。
 - `templates/` は生成ファイルの雛形を保持します。
 - `tooling/` は consumer adapter の合成と検証を担います。

--- a/policy/core.md
+++ b/policy/core.md
@@ -174,12 +174,18 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
-Validity の判定は、Selection Contract の expected target と、
-record の `target_sha`（reviewed target）または acquired evidence 上の
-reviewed target を比較して行います。
+Validity の判定は、reviewed target を確定させた上で、Selection Contract の
+expected target と比較して行います。reviewed target は次のように確定します。
 
-reviewed SHA / range が target と一致しない場合、completion していても invalid です。
-この場合、record は `status: completed` かつ `validity: invalid` として表現します。
+- record の `target_sha` と acquired evidence 上の reviewed target が
+  両方存在する場合、両者は一致していなければなりません。
+  一致しない場合は invalid です。
+- reviewed target を Validity 判定に必要な精度で確認できない場合は unknown
+  です。
+
+確定した reviewed target が expected target と一致しない場合、
+completion していても invalid です。この場合、record は `status: completed`
+かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、

--- a/policy/core.md
+++ b/policy/core.md
@@ -93,9 +93,11 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 
 ## Review Protocol
 
-Review の canonical context は本節です。実行手順は `skills/review-code.md` と
-`skills/review-doc.md` に置き、本節の規範的なルールを複製しません。Review Protocol は
-provider 名や model 名を Kernel に固定しません。
+Review の canonical context は本節です。
+本節は generated adapter として配布される自己完結した規範的内容であり、
+実行手順（review skill）は Foundation リポジトリ側に別途保持し、
+本節の規範的なルールを複製しません。
+Review Protocol は provider 名や model 名を Kernel に固定しません。
 
 ### Artifact classification
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -266,6 +266,11 @@ classification が要求する precondition check を再成立させ、Selection
 target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
+Selection Contract で commit range を expected target として使う場合、head
+SHA が不変でも range の endpoint が変われば、それも target の変更です。この
+場合も、old discovery / closure evidence を新しい target の merge /
+completion evidence として使いません。
+
 Code review:
 
 ```text
@@ -291,7 +296,7 @@ deterministic verify
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
        -> merge
-  -> accepted fix が無く candidate SHA が変更されていない場合:
+  -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
        -> merge
 ```
@@ -301,7 +306,7 @@ targeted closure を行い、その review run も Acquisition & Validity Contra
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
 merge しません。
-accepted fix が無く candidate SHA が変更されていない場合は、
+accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -321,6 +321,10 @@ deterministic verify
             -> aggregate / triage
             -> accepted finding があれば batch fix
             -> target が変われば deterministic verify
+            -> この fix でさらに追加の full discovery が必要と判断される
+               場合: 3rd full discovery は起動せず、merge もせず、
+               upstream task/design の不安定さを疑い、必要に応じて
+               escalate する
        -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認
@@ -347,6 +351,10 @@ required review 数の valid discovery と Resolution の完了をもって、
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
 upstream task/design の不安定さを疑います。
+2nd discovery の accepted finding を fix した後も、その fix が behavior /
+blast radius をさらに materially 変えた場合は、3rd full discovery を起動
+せず、targeted closure だけで merge へ進まず、upstream task/design の
+不安定さを疑い、必要に応じて escalate します。
 
 Normative document review:
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -147,6 +147,7 @@ review run ごとに少なくとも次を記録可能にします。
   "reviewer": "...",
   "target_sha": "...",
   "status": "completed",
+  "validity": "valid",
   "finding_count": 0,
   "result_locator": "...",
   "started_at": "...",
@@ -154,6 +155,10 @@ review run ごとに少なくとも次を記録可能にします。
   "failure": null
 }
 ```
+
+record の `target_sha` は、Selection Contract の expected target（SHA / commit
+range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
+`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。
 
 Completion は少なくとも次を要求します。
 
@@ -169,7 +174,12 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
+Validity の判定は、Selection Contract の expected target と、
+record の `target_sha`（reviewed target）または acquired evidence 上の
+reviewed target を比較して行います。
+
 reviewed SHA / range が target と一致しない場合、completion していても invalid です。
+この場合、record は `status: completed` かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、

--- a/policy/core.md
+++ b/policy/core.md
@@ -206,6 +206,9 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
+- targeted closure / closure verification の finding も Resolution Contract
+  の対象であり、Resolution が完了するまで merge / review completion の
+  根拠にしない
 
 ### Review Adapter boundary
 
@@ -242,12 +245,17 @@ precondition の evidence は自動的に持ち越しません。target 変更�
 review / closure / merge の根拠とする前に、artifact classification が要求する
 precondition check（Executable の deterministic verify、Normative の mechanical
 check）を新しい target に対して再成立させます。
+review / closure / merge の根拠として使う precondition evidence は、review 対象
+として確定した（freeze / Selection された）target と一致していなければなりません。
+一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
+check を再実行します。
 
 Code review:
 
 ```text
 deterministic verify
   -> freeze candidate SHA
+  -> verify target と freeze target の consistency 確認
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
@@ -256,6 +264,7 @@ deterministic verify
        -> deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
        -> merge
   -> accepted fix が無く candidate SHA が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
@@ -264,7 +273,9 @@ deterministic verify
 
 accepted finding の batch fix によって candidate SHA が変更された場合のみ
 targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認してから merge します。
+に従って completion / acquisition / validity を確認します。targeted closure
+の finding も Resolution Contract の対象とし、Resolution が完了するまで
+merge しません。
 accepted fix が無く candidate SHA が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
@@ -277,12 +288,14 @@ Normative document review:
 
 ```text
 mechanical check
+  -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
        mechanical check
        -> closure verification
        -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
@@ -292,7 +305,9 @@ mechanical check
 accepted finding の fix によって target SHA / range が変更された場合のみ、
 新しい target に対して mechanical check を再実行してから closure
 verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。
+に従って completion / acquisition / validity を確認します。closure
+verification の finding も Resolution Contract の対象とし、Resolution が
+完了するまで review を完了しません。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/policy/core.md
+++ b/policy/core.md
@@ -329,6 +329,20 @@ deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> accepted closure finding があれば:
+            batch fix
+            -> deterministic verify
+            -> Review stopping rules の再評価
+            -> 2nd full discovery 未使用かつ必要な場合:
+                 second discovery target の Selection / Execution から
+                 上記の full discovery route へ進み、完了後 targeted
+                 closure を再実行する
+            -> 2nd full discovery 使用済みでなお必要な場合:
+                 3rd full discovery は起動せず、merge もせず、
+                 upstream task/design の不安定さを疑い、必要に応じて
+                 escalate する
+            -> 追加の full discovery が不要な場合:
+                 targeted closure を再実行する
        -> required discovery stage(s) の Resolution 完了
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
@@ -344,6 +358,13 @@ merge しません。
 targeted closure の Resolution に加えて、この review flow で実行した
 discovery stage（2nd full discovery を含む）すべての Resolution が
 完了していることも merge の条件です。完了順序は問いません。
+targeted closure の finding に accepted fix がある場合も、fix 後の
+deterministic verify を経て Review stopping rules を再評価します。2nd
+full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
+に targeted closure をやり直します。2nd full discovery を使用済みでなお
+full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
+追加の full discovery が不要なら、targeted closure をやり直します。
 accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。

--- a/policy/core.md
+++ b/policy/core.md
@@ -125,6 +125,15 @@ Execution Contract に従って起動します。Selection Contract が required
 completed かつ valid な run が揃うまで triage / Resolution / merge / review
 completion へ進みません。不足する run の扱いは Failure / retry に従います。
 
+Selection Contract で required とした review stage（discovery、2nd full
+discovery を含む）の finding は、その stage で accepted fix があったか
+どうかに関係なく、Resolution Contract に従って Resolution が完了するまで
+merge / review completion へ進みません。同じ review flow で複数の
+discovery stage を行った場合は、実行した discovery stage すべての
+Resolution が完了している必要があります。discovery Resolution を closure
+より先に完了させる順序を強制するものではなく、merge / review completion
+の時点で揃っていれば十分です。
+
 #### Selection Contract
 
 - artifact classification
@@ -220,9 +229,12 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
-- targeted closure / closure verification の finding も Resolution Contract
-  の対象であり、Resolution が完了するまで merge / review completion の
-  根拠にしない
+- discovery（2nd full discovery を含む）と targeted closure / closure
+  verification のいずれの finding も Resolution Contract の対象であり、
+  triage category を付けただけでは Resolution 完了ではない。unresolved
+  の finding（未解決の needs-verification / technical-dispute /
+  intent-question 等を含む）が残る間は、その review stage の Resolution
+  は完了せず、merge / review completion の根拠にしない
 
 ### Review Adapter boundary
 
@@ -313,6 +325,7 @@ deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> required discovery stage(s) の Resolution 完了
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
@@ -324,6 +337,9 @@ targeted closure を行い、その review run も Acquisition & Validity Contra
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
 merge しません。
+targeted closure の Resolution に加えて、この review flow で実行した
+discovery stage（2nd full discovery を含む）すべての Resolution が
+完了していることも merge の条件です。完了順序は問いません。
 accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
@@ -345,6 +361,7 @@ mechanical check
        -> closure verification
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> semantic discovery の Resolution 完了
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
@@ -357,6 +374,9 @@ verification を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。closure
 verification の finding も Resolution Contract の対象とし、Resolution が
 完了するまで review を完了しません。
+closure verification の Resolution に加えて、semantic discovery（手順 3）
+の Resolution が完了していることも review completion の条件です。完了
+順序は問いません。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/policy/core.md
+++ b/policy/core.md
@@ -301,6 +301,13 @@ range の endpoint が変わった場合、また expected target SHA / commit r
 して同じ scope です。この場合も、old discovery / closure evidence を
 新しい target の merge / completion evidence として使いません。
 
+closure Resolution で accepted fix が生じ、その fix を closure review で
+確認する cycle（Executable の targeted closure、Normative の closure
+verification のいずれも）が繰り返し発生する場合、無制限に継続せず、
+upstream task/design または policy/document 自体の instability を疑い、
+必要に応じて escalate します。これは Failure / retry の retry count とは
+別の stopping semantics です。
+
 Code review:
 
 ```text
@@ -310,7 +317,7 @@ deterministic verify
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
-  -> accepted finding の batch fix で candidate SHA が変更された場合:
+  -> accepted finding の batch fix で review target が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
        -> fix が behavior / blast radius を materially 変えた場合のみ:
@@ -350,7 +357,7 @@ deterministic verify
        -> merge
 ```
 
-accepted finding の batch fix によって candidate SHA が変更された場合のみ
+accepted finding の batch fix によって review target が変更された場合のみ
 targeted closure を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
@@ -384,7 +391,7 @@ mechanical check
   -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
-  -> accepted finding の fix で target SHA / range が変更された場合:
+  -> accepted finding の fix で review target が変更された場合:
        mechanical check
        -> closure target の Selection / Execution
        -> closure verification
@@ -392,12 +399,12 @@ mechanical check
        -> closure finding の Resolution
        -> semantic discovery の Resolution 完了
        -> 完了
-  -> accepted fix が無く target が変更されていない場合:
+  -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
        -> 完了
 ```
 
-accepted finding の fix によって target SHA / range が変更された場合のみ、
+accepted finding の fix によって review target が変更された場合のみ、
 新しい target に対して mechanical check を再実行してから closure
 verification を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。closure
@@ -406,7 +413,7 @@ verification の finding も Resolution Contract の対象とし、Resolution �
 closure verification の Resolution に加えて、semantic discovery（手順 3）
 の Resolution が完了していることも review completion の条件です。完了
 順序は問いません。
-accepted fix が無く target が変更されていない場合は、
+accepted fix が無く review target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -136,9 +136,13 @@ completion へ進みません。不足する run の扱いは Failure / retry �
 #### Execution Contract
 
 - trigger 方法
-- target SHA
+- Selection で確定した expected target SHA / commit range
 - required context
 - timeout / retry policy
+
+Selection Contract で commit range を expected target として選択した場合、
+Execution ではその selected range を reviewer の trigger へ渡し、実際に
+渡した target を記録します。head SHA だけへ黙って縮退させません。
 
 provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -137,12 +137,15 @@ completion へ進みません。不足する run の扱いは Failure / retry �
 
 - trigger 方法
 - Selection で確定した expected target SHA / commit range
+- Selection で確定した target artifact set
 - required context
 - timeout / retry policy
 
-Selection Contract で commit range を expected target として選択した場合、
-Execution ではその selected range を reviewer の trigger へ渡し、実際に
-渡した target を記録します。head SHA だけへ黙って縮退させません。
+Selection Contract で確定した expected target（SHA / commit range）と
+target artifact set は、Execution で reviewer の trigger へ渡し、実際に
+渡した target と artifact set を記録します。commit range を選択した場合に
+head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
+黙って縮小・変更しません。
 
 provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
 
@@ -270,10 +273,13 @@ classification が要求する precondition check を再成立させ、Selection
 target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
-Selection Contract で commit range を expected target として使う場合、head
-SHA が不変でも range の endpoint が変われば、それも target の変更です。この
-場合も、old discovery / closure evidence を新しい target の merge /
-completion evidence として使いません。
+この節における review target は、Selection Contract で確定した expected
+target SHA / commit range と target artifact set の組を指します。どちらか
+一方でも変われば review target の変更です。head SHA が不変でも commit
+range の endpoint が変わった場合、また expected target SHA / commit range
+が不変でも target artifact set が変わった場合も、review target の変更と
+して同じ scope です。この場合も、old discovery / closure evidence を
+新しい target の merge / completion evidence として使いません。
 
 Code review:
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -264,6 +264,14 @@ review / closure / merge の根拠として使う precondition evidence は、re
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
+この一致確認は SHA / range だけでなく、selected target artifact set にも
+及びます。Selection で確定した target artifact set が、その precondition
+check の対象 scope に含まれることを確認します。precondition check を
+Selection より前に実行した場合は、Selection 後にこの binding を確認し
+ます。selected artifact set を precondition evidence がカバーしていると
+確認できない場合は、確定した target に対して precondition check を
+再実行してから先へ進みます。
+
 precondition evidence だけでなく、discovery / closure evidence も target-specific
 です。valid な discovery の後、accepted-fix による closure target の変更以外の
 理由で review target が変わった場合、その discovery を新しい target の

--- a/policy/core.md
+++ b/policy/core.md
@@ -237,6 +237,12 @@ capability/profile の更新時に再検証可能にします。
 
 ### Review stopping rules
 
+target が変更された場合、その新しい target に対する mechanical / deterministic
+precondition の evidence は自動的に持ち越しません。target 変更後にその target を
+review / closure / merge の根拠とする前に、artifact classification が要求する
+precondition check（Executable の deterministic verify、Normative の mechanical
+check）を新しい target に対して再成立させます。
+
 Code review:
 
 ```text
@@ -274,7 +280,8 @@ mechanical check
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
-       closure verification
+       mechanical check
+       -> closure verification
        -> closure completion / acquisition / validity 確認
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
@@ -282,9 +289,10 @@ mechanical check
        -> 完了
 ```
 
-accepted finding の fix によって target SHA / range が変更された場合のみ
-closure verification を行い、その review run も Acquisition & Validity
-Contract に従って completion / acquisition / validity を確認します。
+accepted finding の fix によって target SHA / range が変更された場合のみ、
+新しい target に対して mechanical check を再実行してから closure
+verification を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/policy/core.md
+++ b/policy/core.md
@@ -278,6 +278,14 @@ deterministic verify
   -> accepted finding の batch fix で candidate SHA が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
+       -> fix が behavior / blast radius を materially 変えた場合のみ:
+            second discovery target の Selection / Execution
+            -> full discovery（2nd round、独立 reviewer）
+            -> completion / acquisition / validity 確認
+            -> required review 数の valid run 確認
+            -> aggregate / triage
+            -> accepted finding があれば batch fix
+            -> target が変われば deterministic verify
        -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認

--- a/policy/core.md
+++ b/policy/core.md
@@ -245,15 +245,23 @@ deterministic verify
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
-  -> batch fix + root-cause sweep
-  -> deterministic verify
-  -> targeted closure
-  -> closure completion / acquisition / validity 確認
-  -> merge
+  -> accepted finding の batch fix で candidate SHA が変更された場合:
+       batch fix + root-cause sweep
+       -> deterministic verify
+       -> targeted closure
+       -> closure completion / acquisition / validity 確認
+       -> merge
+  -> accepted fix が無く candidate SHA が変更されていない場合:
+       required review 数の valid discovery と Resolution の完了
+       -> merge
 ```
 
-targeted closure の review run も Acquisition & Validity Contract に従って
-completion / acquisition / validity を確認してから merge します。
+accepted finding の batch fix によって candidate SHA が変更された場合のみ
+targeted closure を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認してから merge します。
+accepted fix が無く candidate SHA が変更されていない場合は、
+required review 数の valid discovery と Resolution の完了をもって、
+新たな closure run を要求せずに merge できます。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
@@ -265,8 +273,21 @@ Normative document review:
 mechanical check
   -> semantic discovery（1 round）
   -> triage / fix
-  -> closure
+  -> accepted finding の fix で target SHA / range が変更された場合:
+       closure verification
+       -> closure completion / acquisition / validity 確認
+       -> 完了
+  -> accepted fix が無く target が変更されていない場合:
+       required review 数の valid semantic discovery と Resolution の完了
+       -> 完了
 ```
+
+accepted finding の fix によって target SHA / range が変更された場合のみ
+closure verification を行い、その review run も Acquisition & Validity
+Contract に従って completion / acquisition / validity を確認します。
+accepted fix が無く target が変更されていない場合は、
+required review 数の valid semantic discovery と Resolution の完了をもって、
+新たな closure run を要求せずに review を完了できます。
 
 ### Observed evidence is not a permanent provider rule
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -157,14 +157,14 @@ review run ごとに少なくとも次を記録可能にします。
 
 Completion は少なくとも次を要求します。
 
-- intended SHA / range を対象にしている
 - run が terminate している
 - required surface を取得済み
 - finding count が known
-- quota / timeout / structural failure がない
+- quota / timeout / structural な execution / acquisition failure がない
 
 Validity はさらに次を要求します。
 
+- reviewed SHA / range が intended target と一致している
 - intended artifact set が review 対象になっている
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
@@ -185,6 +185,8 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - human を raw finding の message bus にしない
 - pure technical dispute は technical adjudication で解決する
 - human escalation は product intent / authority に限る
+- P0/P1 相当の重大 finding を dismiss する場合は、
+  必要に応じて独立 reviewer の確認を要求する
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
@@ -205,6 +207,9 @@ normalizeFindings()
 workflow log、edited comment 等）は provider capability として扱います。「この provider は
 この surface に出ない」という negative claim を恒久仕様にしてはいけません。
 capability/profile の更新時に再検証可能にします。
+
+収集した evidence は、comment ID / review ID / run ID / timestamp / target SHA
+または commit range を可能な範囲で保持します。
 
 ### Failure / retry
 
@@ -227,8 +232,12 @@ deterministic verify
   -> batch fix + root-cause sweep
   -> deterministic verify
   -> targeted closure
+  -> closure completion / acquisition / validity 確認
   -> merge
 ```
+
+targeted closure の review run も Acquisition & Validity Contract に従って
+completion / acquisition / validity を確認してから merge します。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、

--- a/policy/core.md
+++ b/policy/core.md
@@ -118,6 +118,13 @@ Review 強度と停止条件は artifact の種類で分けます。
 Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
 Adapter boundary へ閉じ込め、Kernel に固定しません。
 
+各 Contract は discovery だけでなく、同じ Contract を使って起動する closure review run
+にも適用されます。closure target も Selection Contract で expected target として確定し、
+Execution Contract に従って起動します。Selection Contract が required review 数を
+定めた review stage では、discovery か closure かを問わず、その required 数の
+completed かつ valid な run が揃うまで triage / Resolution / merge / review
+completion へ進みません。不足する run の扱いは Failure / retry に従います。
+
 #### Selection Contract
 
 - artifact classification
@@ -250,6 +257,15 @@ review / closure / merge の根拠として使う precondition evidence は、re
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
+precondition evidence だけでなく、discovery / closure evidence も target-specific
+です。valid な discovery の後、accepted-fix による closure target の変更以外の
+理由で review target が変わった場合、その discovery を新しい target の
+merge / completion evidence として使いません。新しい target について artifact
+classification が要求する precondition check を再成立させ、Selection / Execution
+を再確立した上で、その target に必要な discovery を行います。accepted fix による
+target 変更は、既存の targeted closure（Executable）/ closure verification
+（Normative）の扱いに従います。
+
 Code review:
 
 ```text
@@ -262,6 +278,7 @@ deterministic verify
   -> accepted finding の batch fix で candidate SHA が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
+       -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
@@ -293,6 +310,7 @@ mechanical check
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
        mechanical check
+       -> closure target の Selection / Execution
        -> closure verification
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution

--- a/policy/core.md
+++ b/policy/core.md
@@ -90,3 +90,163 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 してはいけません。pure technical dispute は原則として technical adjudication で解決し、
 人間を message bus にしません。人間への escalation は、product intent、authority、権限、
 または受容不能な trade-off に限ります。
+
+## Review Protocol
+
+Review の canonical context は本節です。実行手順は `skills/review-code.md` と
+`skills/review-doc.md` に置き、本節の規範的なルールを複製しません。Review Protocol は
+provider 名や model 名を Kernel に固定しません。
+
+### Artifact classification
+
+Review 強度と停止条件は artifact の種類で分けます。
+
+- **Executable**: TS/TSX/SQL/workflow/config 等、実行される、または実行に影響するコード。
+  deterministic verify を先に実行し、candidate SHA を freeze した上で、原則として独立
+  AI reviewer による discovery -> triage -> batch fix -> verify -> targeted closure を行います。
+- **Normative**: AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 agent や実装を
+  拘束する文書。mechanical markdown check の後、semantic discovery は原則 1 round とし、
+  triage / fix の後は closure verification のみを行います。重要な normative contract は
+  独立 reviewer を 2 系統使ってよいですが、各 reviewer の discovery は 1 回を基本とします。
+- **Informational**: README / research note / log 等。mechanical check を中心とし、
+  open-ended AI review を通常の merge gate にしません。
+
+### Review contracts
+
+Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
+Adapter boundary へ閉じ込め、Kernel に固定しません。
+
+#### Selection Contract
+
+- artifact classification
+- reviewer / capability の選択
+- required review 数
+- target artifact set
+- expected target SHA / commit range
+
+#### Execution Contract
+
+- trigger 方法
+- target SHA
+- required context
+- timeout / retry policy
+
+provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
+
+#### Acquisition & Validity Contract
+
+**CI status は review completion と同義ではありません。** status/check の green 化のみを
+review 完了の証跡にしてはいけません。
+
+review run ごとに少なくとも次を記録可能にします。
+
+```json
+{
+  "reviewer": "...",
+  "target_sha": "...",
+  "status": "completed",
+  "finding_count": 0,
+  "result_locator": "...",
+  "started_at": "...",
+  "completed_at": "...",
+  "failure": null
+}
+```
+
+Completion は少なくとも次を要求します。
+
+- intended SHA / range を対象にしている
+- run が terminate している
+- required surface を取得済み
+- finding count が known
+- quota / timeout / structural failure がない
+
+Validity はさらに次を要求します。
+
+- intended artifact set が review 対象になっている
+- required context へアクセスできた
+- execution / acquisition が途中で欠落していない
+
+reviewed SHA / range が target と一致しない場合、completion していても invalid です。
+intended artifact set が review されていない場合も invalid です。
+
+**0 findings は positive evidence を必要とします。** reaction なし、comment なし、
+parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
+completion evidence のない empty output は `unknown` として扱います。
+
+review run の状態は少なくとも `none` / `unknown` / `failure` を区別し、混同してはいけません。
+
+#### Resolution Contract
+
+- finding を fix / false-positive / needs-verification / technical-dispute /
+  intent-question へ triage する
+- human を raw finding の message bus にしない
+- pure technical dispute は technical adjudication で解決する
+- human escalation は product intent / authority に限る
+- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
+- fix 後は全 discovery をやり直さず、targeted closure を基本とする
+- review を新しい scope の探索に使わない
+
+### Review Adapter boundary
+
+provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
+定義し、provider 固有の実装や恒久的な capability 台帳を持ちません。
+
+```text
+trigger()
+pollCompletion()
+collectOutputs()
+normalizeFindings()
+```
+
+収集対象の surface（top-level comment、inline/thread、review submission、status/check、
+workflow log、edited comment 等）は provider capability として扱います。「この provider は
+この surface に出ない」という negative claim を恒久仕様にしてはいけません。
+capability/profile の更新時に再検証可能にします。
+
+### Failure / retry
+
+- transient failure: bounded retry
+- quota / rate limit: `unknown` または `failure` として明示し、success に潰さない
+- structural capability mismatch: 同じ trigger を無限 retry せず、alternate reviewer /
+  escalation
+- empty output: positive completion evidence がなければ `unknown`
+
+### Review stopping rules
+
+Code review:
+
+```text
+deterministic verify
+  -> freeze candidate SHA
+  -> discovery（独立 reviewer）
+  -> completion / acquisition / validity 確認
+  -> aggregate / triage
+  -> batch fix + root-cause sweep
+  -> deterministic verify
+  -> targeted closure
+  -> merge
+```
+
+full discovery は原則 1 round です。fix が behavior / blast radius を materially
+変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
+upstream task/design の不安定さを疑います。
+
+Normative document review:
+
+```text
+mechanical check
+  -> semantic discovery（1 round）
+  -> triage / fix
+  -> closure
+```
+
+### Observed evidence is not a permanent provider rule
+
+Review Protocol の contract は実測された failure mode を反映しますが、observed な
+provider 挙動を Kernel の恒久 rule にはしません。expected trigger behavior は
+completion evidence と同義ではありません。expected trigger behavior に反して
+completion evidence が得られない場合は、trigger 前提を疑い、Acquisition & Validity
+Contract に従って `unknown` として扱います。特定 provider が常に特定の trigger 方法を
+要求するという恒久仕様は Kernel に置かず、observed evidence として capability/profile
+側で再検証可能な形にします。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -8,9 +8,10 @@ stopping rules）を使った実行手順です。規範的なルールはここ
 ## 対象
 
 Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
-review target は Selection Contract に従い、candidate SHA と、applicable
-な場合は commit range を含みます。以降の手順で SHA について述べる箇所は、
-commit range を使う review でも同じ意味で適用します。
+review target は Selection Contract に従い、candidate SHA、applicable な
+場合は commit range、および target artifact set を含みます。以降の手順で
+SHA について述べる箇所は、commit range や target artifact set を使う
+review でも同じ意味で適用します。
 
 ## 手順
 
@@ -41,11 +42,14 @@ commit range を使う review でも同じ意味で適用します。
    capability、required review 数、target artifact set、expected target
    SHA / applicable な commit range を決めます。commit range を使う場合は、
    対象範囲が曖昧にならない形で確定します。
+   target artifact set を確定した時点から、その artifact set も review
+   target の一部として扱い、手順 2 の target mutation semantics を
+   artifact set にも同じ意味で適用します。
    Executable artifact では原則として独立 reviewer を使います。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
-   target SHA / applicable な commit range を各 reviewer の trigger へ
-   渡して起動します。trigger 方法、実際に渡した target、required context
-   を記録します。
+   target SHA / applicable な commit range と target artifact set を各
+   reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
+   target と artifact set、required context を記録します。
 5. **Acquisition & Validity** — reviewer の run ごとに Acquisition & Validity
    Contract（`policy/core.md`）に従って record schema を埋めます。
    completion と validity は独立した判定とし、completed な run についてのみ
@@ -67,9 +71,9 @@ commit range を使う review でも同じ意味で適用します。
    あれば root-cause ごとにまとめて fix します。
    accepted finding が無ければ candidate SHA は変更されません。
    fix による変更を超えて target が動いた場合（例えば commit range の
-   一方の endpoint が accepted fix と無関係に変わった場合）、その独立
-   した変更分は手順 2 の non-fix target mutation semantics に従い、
-   targeted closure だけでは扱いません。
+   一方の endpoint や target artifact set が accepted fix と無関係に
+   変わった場合）、その独立した変更分は手順 2 の non-fix target mutation
+   semantics に従い、targeted closure だけでは扱いません。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
    変更された場合のみ、fix 後に手順 1 の verify を再実行します。
 9. **Second full discovery（条件付き）** — Review stopping rules

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -71,6 +71,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
     validity を確認します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
+    closure 用 Selection Contract で required とした review 数ぶんの valid
+    な closure run が揃うまで Closure Resolution へ進みません。不足する
+    run の扱いは Failure / retry（`policy/core.md`）に従います。
 11. **Closure Resolution** — targeted closure の finding を Resolution
     Contract（`policy/core.md`）に従って triage します。unresolved の
     finding がある間は merge しません。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -16,8 +16,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    Task に応じたもの）を実行します。
 2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
    discovery の completion / validity が確定する前にこの SHA が変わった場合、
-   その review target / run を invalid として扱い、新しい SHA で re-freeze して
-   必要な discovery をやり直します。
+   その review target / run を invalid として扱います。
+   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
+   re-freeze して必要な discovery をやり直します。
    valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
    re-freeze はしますが手順を最初からやり直さず、
    手順 8〜11（deterministic verify -> targeted closure -> merge）に進みます。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -1,0 +1,72 @@
+# review-code skill
+
+このファイルは `policy/core.md` の Review Protocol（Artifact classification の
+Executable、Review contracts、Review Adapter boundary、Failure / retry、Review
+stopping rules）を使った実行手順です。規範的なルールはここで再定義せず、
+`policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先します。
+
+## 対象
+
+Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
+
+## 手順
+
+1. **Deterministic verify** — AI review を要求する前に、repository が定義する verify
+   （`npm test` / `npm run check:fixture` / consumer `verify` / `git diff --check` 等、
+   Task に応じたもの）を実行します。
+2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。以降にその SHA を
+   変える変更が入った場合、re-freeze して手順を最初からやり直します。
+3. **Selection** — Selection Contract に従い、artifact classification、reviewer /
+   capability、required review 数、target artifact set、expected target SHA を決めます。
+   Executable artifact では原則として独立 reviewer を使います。
+4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
+   起動します。trigger 方法と target SHA、渡した required context を記録します。
+5. **Acquisition & Validity** — reviewer の run ごとに `policy/core.md` の record
+   schema を埋めます。CI green を review completion の代わりにしない、コメントが
+   無いことを positive evidence なしに `0 findings` と扱わない、run の状態を
+   `none` / `unknown` / `failure` のいずれかに区別する、を徹底します。
+6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract の
+   カテゴリ（fix / false-positive / needs-verification / technical-dispute /
+   intent-question）へ仕分けます。human escalation は product intent / authority の
+   論点に限り、pure technical dispute は技術的な adjudication（別 reviewer の意見等）
+   で解決します。
+7. **Batch fix + root-cause** — accepted finding を root-cause ごとにまとめ、
+   1 件ずつの drip fix にしません。
+8. **Deterministic verify** — fix 後に手順 1 の verify を再実行します。
+9. **Targeted closure** — fix した箇所に対応する範囲のみ再確認します。fix が
+   behavior / blast radius を materially 変えた場合のみ、追加で 1 round の discovery
+   を許容します。それ以上 round が必要に見える場合は review を増やさず、upstream の
+   task/design が不安定である可能性を疑い、escalate します。
+10. **Merge** — targeted closure が通った時点で merge します。
+
+## Adapter boundary（manual pilot）
+
+provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()` /
+`collectOutputs()` / `normalizeFindings()` を人手で埋めます。
+
+- `trigger()`: reviewer をどう起動したか（PR 更新での automatic trigger、
+  `@reviewer review` のような明示的な command 等）を記録します。
+- `pollCompletion()`: completion をどう確認したか（status の変化、comment の投稿、
+  run の所要時間等）を記録します。CI/status のみでの判断はしません。
+- `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
+  inline/thread comment、review submission/summary、status/check、必要なら
+  workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
+  確認したか」を記録します。
+- `normalizeFindings()`: 集めた出力を record schema と triage category へ変換し、
+  finding ごとに出典 surface と locator を残します。
+
+### Observed example（provider 固有の恒久 rule ではない）
+
+ある PR では、Draft -> Ready の automatic review trigger が確認できず、明示的な
+manual trigger command を送って初めて review completion の evidence が得られたことが
+あります。これは「expected trigger behavior は completion evidence と同義ではない」
+という一般原則の実測例として扱い、特定 provider が常に manual trigger を要求すると
+いう恒久仕様には昇格させません。同種の provider を扱う際は、automatic trigger を
+仮定せず、completion evidence が得られるまで `unknown` として扱ってください。
+
+## Manual review pilot
+
+次の manual pilot では、Claude / Codex / CodeRabbit のそれぞれについて、本 skill と
+同じ Review Contract を使って Selection / Completion / Acquisition / Validity /
+Resolution を人手で判定できることを確認します。この skill の範囲では pilot 自体を
+実施・拡張せず、contract を適用できる準備を整えるところまでとします。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -16,9 +16,11 @@ review でも同じ意味で適用します。
 ## 手順
 
 1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
-   を記録した上で、repository が定義する verify（`npm test` / `npm run
-   check:fixture` / consumer `verify` / `git diff --check` 等、Task に応じた
-   もの）を実行します。
+   と、その verify が対象とした artifact / package / repository scope を
+   必要な精度で記録した上で、repository が定義する verify（`npm test` / `npm
+   run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
+   応じたもの）を実行します。repository 全体を対象とする verify であれば
+   repo-wide として記録すれば十分です。
 2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
    commit range を review target として使う場合は、対象となる range も
    同時に freeze し、以降 SHA について述べる target mutation semantics を
@@ -45,6 +47,12 @@ review でも同じ意味で適用します。
    target artifact set を確定した時点から、その artifact set も review
    target の一部として扱い、手順 2 の target mutation semantics を
    artifact set にも同じ意味で適用します。
+   target artifact set を確定したら、直近の successful deterministic
+   verify evidence が、確定した SHA / range と target artifact set の
+   両方をカバーしているかを確認します。selected artifact set をその
+   verify evidence がカバーしていると確認できない場合は、確定した
+   target に対して手順 1 の deterministic verify を再実行し、成功して
+   から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
@@ -85,7 +93,12 @@ review でも同じ意味で適用します。
       を使わず、確定した second discovery target に対して
       deterministic verify を行い、成功したら re-freeze して
       Selection / Execution へ進みます。
-   2. Selection Contract をこの second discovery stage へ適用します。
+   2. Selection Contract をこの second discovery stage へ適用し、確定
+      した target artifact set まで直近の successful deterministic
+      verify evidence がカバーしているかを確認します。カバーしていると
+      確認できない場合は、確定した second discovery target に対して
+      deterministic verify を再実行し、成功してから Execution へ
+      進みます。
    3. Execution Contract に従って full discovery（独立 reviewer）を
       起動します。
    4. Acquisition & Validity Contract をこの discovery run に適用します。
@@ -114,7 +127,11 @@ review でも同じ意味で適用します。
     verify evidence を使わず、確定した closure target に対して
     deterministic verify を行い、成功したら re-freeze します。
     Selection Contract に従ってこの closure target を expected target
-    として確定し、Execution Contract に従って closure run を起動します。
+    として確定し、確定した closure artifact set まで直近の successful
+    deterministic verify evidence がカバーしているかを確認します。
+    カバーしていると確認できない場合は、確定した closure target に対
+    して deterministic verify を再実行し、成功してから Execution
+    Contract に従って closure run を起動します。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -61,11 +61,12 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 9. **Second full discovery（条件付き）** — Review stopping rules
    （`policy/core.md`）に従って 2nd full discovery が必要と判断された
    場合のみ、targeted closure の前に行います。
-   1. 直近の successful deterministic verify target を second discovery
-      target として re-freeze し、consistency を確認します。一致しない
-      場合は、その verify evidence を使わず、確定した second discovery
-      target に対して deterministic verify を行い、成功したら re-freeze
-      して Selection / Execution へ進みます。
+   1. 現在の post-fix SHA を second discovery target として re-freeze
+      し、直近の successful deterministic verify target との
+      consistency を確認します。一致しない場合は、その verify evidence
+      を使わず、確定した second discovery target に対して
+      deterministic verify を行い、成功したら re-freeze して
+      Selection / Execution へ進みます。
    2. Selection Contract をこの second discovery stage へ適用します。
    3. Execution Contract に従って full discovery（独立 reviewer）を
       起動します。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -27,9 +27,12 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
    起動します。trigger 方法と target SHA、渡した required context を記録します。
 5. **Acquisition & Validity** — reviewer の run ごとに Acquisition & Validity
-   Contract（`policy/core.md`）に従って record schema を埋め、run を completion /
-   validity / `none` / `unknown` / `failure` のいずれかに判定します。判定条件は
-   policy の Contract 定義に従い、ここでは再定義しません。
+   Contract（`policy/core.md`）に従って record schema を埋めます。
+   completion と validity は独立した判定とし、completed な run についてのみ
+   validity を判定します（target SHA / artifact set 等が一致しない completed run
+   は invalid として表現できます）。
+   `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
+   の定義に従って記録します。
 6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract
    （`policy/core.md`）のカテゴリ（fix / false-positive / needs-verification /
    technical-dispute / intent-question）へ仕分けます。human escalation と

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -8,6 +8,9 @@ stopping rules）を使った実行手順です。規範的なルールはここ
 ## 対象
 
 Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
+review target は Selection Contract に従い、candidate SHA と、applicable
+な場合は commit range を含みます。以降の手順で SHA について述べる箇所は、
+commit range を使う review でも同じ意味で適用します。
 
 ## 手順
 
@@ -16,6 +19,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    check:fixture` / consumer `verify` / `git diff --check` 等、Task に応じた
    もの）を実行します。
 2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
+   commit range を review target として使う場合は、対象となる range も
+   同時に freeze し、以降 SHA について述べる target mutation semantics を
+   range にも同じ意味で適用します。
    手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致する
    ことを確認します。一致しない場合は、freeze した SHA に対して手順 1 の
    deterministic verify を再実行し、成功してから先へ進みます。
@@ -32,7 +38,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
    re-freeze して必要な discovery をやり直します。
 3. **Selection** — Selection Contract に従い、artifact classification、reviewer /
-   capability、required review 数、target artifact set、expected target SHA を決めます。
+   capability、required review 数、target artifact set、expected target
+   SHA / applicable な commit range を決めます。commit range を使う場合は、
+   対象範囲が曖昧にならない形で確定します。
    Executable artifact では原則として独立 reviewer を使います。
 4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
    起動します。trigger 方法と target SHA、渡した required context を記録します。
@@ -56,6 +64,10 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding が
    あれば root-cause ごとにまとめて fix します。
    accepted finding が無ければ candidate SHA は変更されません。
+   fix による変更を超えて target が動いた場合（例えば commit range の
+   一方の endpoint が accepted fix と無関係に変わった場合）、その独立
+   した変更分は手順 2 の non-fix target mutation semantics に従い、
+   targeted closure だけでは扱いません。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
    変更された場合のみ、fix 後に手順 1 の verify を再実行します。
 9. **Second full discovery（条件付き）** — Review stopping rules

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -33,22 +33,33 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    は invalid として表現できます）。
    `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
    の定義に従って記録します。
-6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract
-   （`policy/core.md`）のカテゴリ（fix / false-positive / needs-verification /
-   technical-dispute / intent-question）へ仕分けます。human escalation と
-   technical dispute の扱い、重大 finding を dismiss する際の確認要否は
-   Resolution Contract に従います。
-7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding を
-   root-cause ごとにまとめて fix します。
-8. **Deterministic verify** — fix 後に手順 1 の verify を再実行します。
-9. **Targeted closure** — Review stopping rules（`policy/core.md`）に従い、fix した
-   箇所に対応する範囲のみ再確認します。追加 discovery の要否も同 stopping rules に
-   従います。
-10. **Closure Acquisition & Validity** — targeted closure の review run も手順 5 と
-    同じ Acquisition & Validity Contract に従って completion / acquisition /
-    validity を確認します。
-    確認できなければ merge せず、targeted closure をやり直します。
-11. **Merge** — Closure Acquisition & Validity が確認できた時点で merge します。
+6. **Required review gate & aggregate / triage** — Selection Contract で
+   required とした review 数ぶんの `validity: valid` な run が揃うまで triage
+   へ進みません。
+   揃わない run（invalid / unknown / failure）の扱いは Failure / retry
+   （`policy/core.md`）に従います。
+   required 数の valid run が揃ったら、valid な run から finding を集約し、
+   Resolution Contract（`policy/core.md`）のカテゴリ（fix / false-positive /
+   needs-verification / technical-dispute / intent-question）へ仕分けます。
+   human escalation と technical dispute の扱い、重大 finding を dismiss する
+   際の確認要否は Resolution Contract に従います。
+7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding が
+   あれば root-cause ごとにまとめて fix します。
+   accepted finding が無ければ candidate SHA は変更されません。
+8. **Deterministic verify** — 手順 7 で candidate SHA が変更された場合のみ、
+   fix 後に手順 1 の verify を再実行します。
+9. **Targeted closure** — candidate SHA が変更された場合のみ、Review stopping
+   rules（`policy/core.md`）に従い、fix した箇所に対応する範囲のみ再確認します。
+   追加 discovery の要否も同 stopping rules に従います。
+10. **Closure Acquisition & Validity** — candidate SHA が変更された場合のみ、
+    targeted closure の review run も手順 5 と同じ Acquisition & Validity
+    Contract に従って completion / acquisition / validity を確認します。
+    確認できなければ merge せず、その後の扱いは Failure / retry
+    （`policy/core.md`）に従います。
+11. **Merge** — candidate SHA が変更されていなければ、required review 数の
+    valid discovery と Resolution が完了した時点で merge します。
+    変更されていれば、Closure Acquisition & Validity が確認できた時点で
+    merge します。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -61,8 +61,11 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 9. **Second full discovery（条件付き）** — Review stopping rules
    （`policy/core.md`）に従って 2nd full discovery が必要と判断された
    場合のみ、targeted closure の前に行います。
-   1. 手順 8 で verify した post-fix SHA を second discovery target として
-      re-freeze し、手順 8 の verify target との consistency を確認します。
+   1. 直近の successful deterministic verify target を second discovery
+      target として re-freeze し、consistency を確認します。一致しない
+      場合は、その verify evidence を使わず、確定した second discovery
+      target に対して deterministic verify を行い、成功したら re-freeze
+      して Selection / Execution へ進みます。
    2. Selection Contract をこの second discovery stage へ適用します。
    3. Execution Contract に従って full discovery（独立 reviewer）を
       起動します。
@@ -87,9 +90,12 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 10. **Targeted closure** — この review flow で accepted finding の fix
     によって target が変更された場合のみ（手順 9 の second full
     discovery を挟んだ場合を含む）行います。最終的な post-fix SHA を
-    closure target として re-freeze し、Selection Contract に従ってこの
-    closure target を expected target として確定し、Execution Contract
-    に従って closure run を起動します。
+    closure target として re-freeze し、直近の successful deterministic
+    verify target との consistency を確認します。一致しない場合は、その
+    verify evidence を使わず、確定した closure target に対して
+    deterministic verify を行い、成功したら re-freeze します。
+    Selection Contract に従ってこの closure target を expected target
+    として確定し、Execution Contract に従って closure run を起動します。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted
@@ -106,10 +112,18 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 12. **Closure Resolution** — targeted closure の finding を Resolution
     Contract（`policy/core.md`）に従って triage します。unresolved の
     finding がある間は merge しません。
-    accepted な closure finding があれば、手順 7・8・10・11 と同じ
-    procedure（root-cause を確認した batch fix -> deterministic verify
-    -> targeted closure -> Closure Acquisition & Validity。手順 9 の
-    second full discovery はこの経路には含みません）に従って解決します。
+    accepted な closure finding があれば、手順 7 と同じ batch fix
+    semantics でまとめて fix し、手順 8 と同じ deterministic verify を
+    行います。
+    その上で Review stopping rules（`policy/core.md`）を再評価します。
+    - この review flow で手順 9 をまだ使っておらず、2nd full discovery
+      が必要と判断される場合は、手順 9 へ進み、完了後に手順 10 へ
+      進みます。
+    - 手順 9 を既に使っており、なお追加の full discovery が必要と
+      判断される場合は、3rd full discovery は起動せず merge もせず、
+      upstream task/design の不安定さを疑い、必要に応じて escalate
+      します。
+    - 追加の full discovery が不要な場合は、手順 10 へ進みます。
     この cycle が繰り返し発生する場合は無制限に続けず、Review stopping
     rules（`policy/core.md`）に従って upstream task/design の不安定さを
     疑い、必要に応じて escalate します。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -23,8 +23,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    手順 8〜11（deterministic verify -> targeted closure -> merge）に進みます。
    手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
    scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
-   この review target / run を invalid として扱い、新しい SHA で re-freeze して
-   必要な discovery をやり直します。
+   この review target / run を invalid として扱います。
+   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
+   re-freeze して必要な discovery をやり直します。
 3. **Selection** — Selection Contract に従い、artifact classification、reviewer /
    capability、required review 数、target artifact set、expected target SHA を決めます。
    Executable artifact では原則として独立 reviewer を使います。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -42,8 +42,10 @@ commit range を使う review でも同じ意味で適用します。
    SHA / applicable な commit range を決めます。commit range を使う場合は、
    対象範囲が曖昧にならない形で確定します。
    Executable artifact では原則として独立 reviewer を使います。
-4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
-   起動します。trigger 方法と target SHA、渡した required context を記録します。
+4. **Execution** — Execution Contract に従い、Selection で確定した expected
+   target SHA / applicable な commit range を各 reviewer の trigger へ
+   渡して起動します。trigger 方法、実際に渡した target、required context
+   を記録します。
 5. **Acquisition & Validity** — reviewer の run ごとに Acquisition & Validity
    Contract（`policy/core.md`）に従って record schema を埋めます。
    completion と validity は独立した判定とし、completed な run についてのみ

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -14,17 +14,24 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 1. **Deterministic verify** — AI review を要求する前に、repository が定義する verify
    （`npm test` / `npm run check:fixture` / consumer `verify` / `git diff --check` 等、
    Task に応じたもの）を実行します。
-2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。以降にその SHA を
-   変える変更が入った場合、re-freeze して手順を最初からやり直します。
+2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
+   discovery の completion / validity が確定する前にこの SHA が変わった場合、
+   その review target / run を invalid として扱い、新しい SHA で re-freeze して
+   必要な discovery をやり直します。
+   valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
+   re-freeze はしますが手順を最初からやり直さず、
+   手順 8〜9（deterministic verify -> targeted closure）に進みます。
 3. **Selection** — Selection Contract に従い、artifact classification、reviewer /
    capability、required review 数、target artifact set、expected target SHA を決めます。
    Executable artifact では原則として独立 reviewer を使います。
 4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
    起動します。trigger 方法と target SHA、渡した required context を記録します。
 5. **Acquisition & Validity** — reviewer の run ごとに `policy/core.md` の record
-   schema を埋めます。CI green を review completion の代わりにしない、コメントが
-   無いことを positive evidence なしに `0 findings` と扱わない、run の状態を
-   `none` / `unknown` / `failure` のいずれかに区別する、を徹底します。
+   schema を埋めます。
+   CI green を review completion の代わりにしない、
+   コメントが無いことを positive evidence なしに `0 findings` と扱わない、
+   completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ
+   `none` / `unknown` / `failure` として区別する、を徹底します。
 6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract の
    カテゴリ（fix / false-positive / needs-verification / technical-dispute /
    intent-question）へ仕分けます。human escalation は product intent / authority の

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -165,10 +165,12 @@ review でも同じ意味で適用します。
     疑い、必要に応じて escalate します。
 13. **Merge** — この review flow で accepted finding の fix による target
     変更が一度も発生していなければ、required review 数の valid discovery
-    と Resolution が完了した時点で merge します。
-    target 変更が発生していれば（手順 9 を挟んだ場合を含む）、Closure
-    Acquisition & Validity と Closure Resolution が完了した時点で
-    merge します。
+    と Resolution（手順 6）が完了した時点で merge します。
+    target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
+    discovery Resolution（手順 9 を使った場合はその Resolution も含む）
+    と、Closure Acquisition & Validity・Closure Resolution が完了した
+    時点で merge します。discovery Resolution と closure の完了順序は
+    問いません。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -53,13 +53,16 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
    変更された場合のみ、fix 後に手順 1 の verify を再実行します。
 9. **Targeted closure** — 手順 7 の batch fix によって candidate SHA が変更
-   された場合のみ、Review stopping rules（`policy/core.md`）に従い、fix した
-   箇所に対応する範囲のみ再確認します。追加 discovery の要否も同 stopping
-   rules に従います。
+   された場合のみ行います。修正後の SHA を closure target として re-freeze
+   し、Selection Contract に従ってこの closure target を expected target
+   として確定し、Execution Contract に従って closure run を起動します。
+   Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応する
+   範囲のみ再確認します。追加 discovery の要否も同 stopping rules に従います。
 10. **Closure Acquisition & Validity** — 手順 7 の batch fix によって
-    candidate SHA が変更された場合のみ、targeted closure の review run も
-    手順 5 と同じ Acquisition & Validity Contract に従って completion /
-    acquisition / validity を確認します。
+    candidate SHA が変更された場合のみ、この closure target を expected
+    target として、targeted closure の review run に手順 5 と同じ
+    Acquisition & Validity Contract を適用し、completion / acquisition /
+    validity を確認します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
 11. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -11,17 +11,21 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 
 ## 手順
 
-1. **Deterministic verify** — AI review を要求する前に、repository が定義する verify
-   （`npm test` / `npm run check:fixture` / consumer `verify` / `git diff --check` 等、
-   Task に応じたもの）を実行します。
+1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
+   を記録した上で、repository が定義する verify（`npm test` / `npm run
+   check:fixture` / consumer `verify` / `git diff --check` 等、Task に応じた
+   もの）を実行します。
 2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
+   手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致する
+   ことを確認します。一致しない場合は、freeze した SHA に対して手順 1 の
+   deterministic verify を再実行し、成功してから先へ進みます。
    discovery の completion / validity が確定する前にこの SHA が変わった場合、
    その review target / run を invalid として扱います。
    新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
    re-freeze して必要な discovery をやり直します。
    valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
    re-freeze はしますが手順を最初からやり直さず、
-   手順 8〜11（deterministic verify -> targeted closure -> merge）に進みます。
+   手順 8〜12（deterministic verify -> targeted closure -> merge）に進みます。
    手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
    scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
    この review target / run を invalid として扱います。
@@ -67,11 +71,17 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
     validity を確認します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
-11. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて
+11. **Closure Resolution** — targeted closure の finding を Resolution
+    Contract（`policy/core.md`）に従って triage します。unresolved の
+    finding がある間は merge しません。
+    accepted な closure finding があれば、手順 7〜10 と同じ procedure
+    （root-cause を確認した batch fix -> deterministic verify -> targeted
+    closure -> Closure Acquisition & Validity）に従って解決します。
+12. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて
     いなければ、required review 数の valid discovery と Resolution が完了
     した時点で merge します。
-    変更されていれば、Closure Acquisition & Validity が確認できた時点で
-    merge します。
+    変更されていれば、Closure Acquisition & Validity と Closure Resolution
+    が完了した時点で merge します。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -25,7 +25,7 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    re-freeze して必要な discovery をやり直します。
    valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
    re-freeze はしますが手順を最初からやり直さず、
-   手順 8〜12（deterministic verify -> targeted closure -> merge）に進みます。
+   手順 8〜13（deterministic verify -> targeted closure -> merge）に進みます。
    手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
    scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
    その旧 review target / run を現在 target の evidence として扱いません。
@@ -58,36 +58,67 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    accepted finding が無ければ candidate SHA は変更されません。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
    変更された場合のみ、fix 後に手順 1 の verify を再実行します。
-9. **Targeted closure** — 手順 7 の batch fix によって candidate SHA が変更
-   された場合のみ行います。修正後の SHA を closure target として re-freeze
-   し、Selection Contract に従ってこの closure target を expected target
-   として確定し、Execution Contract に従って closure run を起動します。
-   Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応する
-   範囲のみ再確認します。追加 discovery の要否も同 stopping rules に従います。
-10. **Closure Acquisition & Validity** — 手順 7 の batch fix によって
-    candidate SHA が変更された場合のみ、この closure target を expected
-    target として、targeted closure の review run に手順 5 と同じ
-    Acquisition & Validity Contract を適用し、completion / acquisition /
-    validity を確認します。
+9. **Second full discovery（条件付き）** — Review stopping rules
+   （`policy/core.md`）に従って 2nd full discovery が必要と判断された
+   場合のみ、targeted closure の前に行います。
+   1. 手順 8 で verify した post-fix SHA を second discovery target として
+      re-freeze し、手順 8 の verify target との consistency を確認します。
+   2. Selection Contract をこの second discovery stage へ適用します。
+   3. Execution Contract に従って full discovery（独立 reviewer）を
+      起動します。
+   4. Acquisition & Validity Contract をこの discovery run に適用します。
+   5. Selection で required とした review 数ぶんの valid run が揃うまで
+      triage へ進みません。揃わない run の扱いは Failure / retry
+      （`policy/core.md`）に従います。
+   6. valid な run の finding を Resolution Contract で triage します。
+   7. accepted finding があれば、手順 7 と同じ batch fix semantics で
+      まとめて fix します。
+   8. その fix によって target が変わった場合、手順 8 と同じ
+      deterministic verify を行います。
+
+   second discovery の実行中、または completion / validity 確定前後に
+   accepted fix 以外の理由で target が変わった場合は、手順 2 と同じ
+   target-specific evidence の扱いに従います。
+   この second discovery の accepted finding の fix について、さらに
+   追加の discovery round が必要と判断される場合、3rd full discovery は
+   起動せず merge もせず、Review stopping rules（`policy/core.md`）に
+   従って upstream task/design の不安定さを疑い、必要に応じて escalate
+   します。
+10. **Targeted closure** — この review flow で accepted finding の fix
+    によって target が変更された場合のみ（手順 9 の second full
+    discovery を挟んだ場合を含む）行います。最終的な post-fix SHA を
+    closure target として re-freeze し、Selection Contract に従ってこの
+    closure target を expected target として確定し、Execution Contract
+    に従って closure run を起動します。
+    Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
+    する範囲のみ再確認します。
+11. **Closure Acquisition & Validity** — この review flow で accepted
+    finding の fix によって target が変更された場合のみ（手順 9 を
+    挟んだ場合を含む）、この closure target を expected target として、
+    targeted closure の review run に手順 5 と同じ Acquisition &
+    Validity Contract を適用し、completion / acquisition / validity を
+    確認します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
     closure 用 Selection Contract で required とした review 数ぶんの valid
     な closure run が揃うまで Closure Resolution へ進みません。不足する
     run の扱いは Failure / retry（`policy/core.md`）に従います。
-11. **Closure Resolution** — targeted closure の finding を Resolution
+12. **Closure Resolution** — targeted closure の finding を Resolution
     Contract（`policy/core.md`）に従って triage します。unresolved の
     finding がある間は merge しません。
-    accepted な closure finding があれば、手順 7〜10 と同じ procedure
-    （root-cause を確認した batch fix -> deterministic verify -> targeted
-    closure -> Closure Acquisition & Validity）に従って解決します。
+    accepted な closure finding があれば、手順 7・8・10・11 と同じ
+    procedure（root-cause を確認した batch fix -> deterministic verify
+    -> targeted closure -> Closure Acquisition & Validity。手順 9 の
+    second full discovery はこの経路には含みません）に従って解決します。
     この cycle が繰り返し発生する場合は無制限に続けず、Review stopping
     rules（`policy/core.md`）に従って upstream task/design の不安定さを
     疑い、必要に応じて escalate します。
-12. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて
-    いなければ、required review 数の valid discovery と Resolution が完了
-    した時点で merge します。
-    変更されていれば、Closure Acquisition & Validity と Closure Resolution
-    が完了した時点で merge します。
+13. **Merge** — この review flow で accepted finding の fix による target
+    変更が一度も発生していなければ、required review 数の valid discovery
+    と Resolution が完了した時点で merge します。
+    target 変更が発生していれば（手順 9 を挟んだ場合を含む）、Closure
+    Acquisition & Validity と Closure Resolution が完了した時点で
+    merge します。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -26,25 +26,26 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    Executable artifact では原則として独立 reviewer を使います。
 4. **Execution** — Execution Contract に従い、各 reviewer をそれぞれの trigger 方法で
    起動します。trigger 方法と target SHA、渡した required context を記録します。
-5. **Acquisition & Validity** — reviewer の run ごとに `policy/core.md` の record
-   schema を埋めます。
-   CI green を review completion の代わりにしない、
-   コメントが無いことを positive evidence なしに `0 findings` と扱わない、
-   completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ
-   `none` / `unknown` / `failure` として区別する、を徹底します。
-6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract の
-   カテゴリ（fix / false-positive / needs-verification / technical-dispute /
-   intent-question）へ仕分けます。human escalation は product intent / authority の
-   論点に限り、pure technical dispute は技術的な adjudication（別 reviewer の意見等）
-   で解決します。
-7. **Batch fix + root-cause** — accepted finding を root-cause ごとにまとめ、
-   1 件ずつの drip fix にしません。
+5. **Acquisition & Validity** — reviewer の run ごとに Acquisition & Validity
+   Contract（`policy/core.md`）に従って record schema を埋め、run を completion /
+   validity / `none` / `unknown` / `failure` のいずれかに判定します。判定条件は
+   policy の Contract 定義に従い、ここでは再定義しません。
+6. **Aggregate & triage** — valid な run から finding を集約し、Resolution Contract
+   （`policy/core.md`）のカテゴリ（fix / false-positive / needs-verification /
+   technical-dispute / intent-question）へ仕分けます。human escalation と
+   technical dispute の扱い、重大 finding を dismiss する際の確認要否は
+   Resolution Contract に従います。
+7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding を
+   root-cause ごとにまとめて fix します。
 8. **Deterministic verify** — fix 後に手順 1 の verify を再実行します。
-9. **Targeted closure** — fix した箇所に対応する範囲のみ再確認します。fix が
-   behavior / blast radius を materially 変えた場合のみ、追加で 1 round の discovery
-   を許容します。それ以上 round が必要に見える場合は review を増やさず、upstream の
-   task/design が不安定である可能性を疑い、escalate します。
-10. **Merge** — targeted closure が通った時点で merge します。
+9. **Targeted closure** — Review stopping rules（`policy/core.md`）に従い、fix した
+   箇所に対応する範囲のみ再確認します。追加 discovery の要否も同 stopping rules に
+   従います。
+10. **Closure Acquisition & Validity** — targeted closure の review run も手順 5 と
+    同じ Acquisition & Validity Contract に従って completion / acquisition /
+    validity を確認します。
+    確認できなければ merge せず、targeted closure をやり直します。
+11. **Merge** — Closure Acquisition & Validity が確認できた時点で merge します。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -77,6 +77,9 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
     accepted な closure finding があれば、手順 7〜10 と同じ procedure
     （root-cause を確認した batch fix -> deterministic verify -> targeted
     closure -> Closure Acquisition & Validity）に従って解決します。
+    この cycle が繰り返し発生する場合は無制限に続けず、Review stopping
+    rules（`policy/core.md`）に従って upstream task/design の不安定さを
+    疑い、必要に応じて escalate します。
 12. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて
     いなければ、required review 数の valid discovery と Resolution が完了
     した時点で merge します。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -20,7 +20,7 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    ことを確認します。一致しない場合は、freeze した SHA に対して手順 1 の
    deterministic verify を再実行し、成功してから先へ進みます。
    discovery の completion / validity が確定する前にこの SHA が変わった場合、
-   その review target / run を invalid として扱います。
+   その旧 review target / run を現在 target の evidence として扱いません。
    新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
    re-freeze して必要な discovery をやり直します。
    valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
@@ -28,7 +28,7 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    手順 8〜12（deterministic verify -> targeted closure -> merge）に進みます。
    手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
    scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
-   この review target / run を invalid として扱います。
+   その旧 review target / run を現在 target の evidence として扱いません。
    新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
    re-freeze して必要な discovery をやり直します。
 3. **Selection** — Selection Contract に従い、artifact classification、reviewer /

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -20,7 +20,11 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
    必要な discovery をやり直します。
    valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
    re-freeze はしますが手順を最初からやり直さず、
-   手順 8〜9（deterministic verify -> targeted closure）に進みます。
+   手順 8〜11（deterministic verify -> targeted closure -> merge）に進みます。
+   手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
+   scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
+   この review target / run を invalid として扱い、新しい SHA で re-freeze して
+   必要な discovery をやり直します。
 3. **Selection** — Selection Contract に従い、artifact classification、reviewer /
    capability、required review 数、target artifact set、expected target SHA を決めます。
    Executable artifact では原則として独立 reviewer を使います。
@@ -46,18 +50,21 @@ Executable artifact（TS / TSX / SQL / workflow / config 等）の review。
 7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding が
    あれば root-cause ごとにまとめて fix します。
    accepted finding が無ければ candidate SHA は変更されません。
-8. **Deterministic verify** — 手順 7 で candidate SHA が変更された場合のみ、
-   fix 後に手順 1 の verify を再実行します。
-9. **Targeted closure** — candidate SHA が変更された場合のみ、Review stopping
-   rules（`policy/core.md`）に従い、fix した箇所に対応する範囲のみ再確認します。
-   追加 discovery の要否も同 stopping rules に従います。
-10. **Closure Acquisition & Validity** — candidate SHA が変更された場合のみ、
-    targeted closure の review run も手順 5 と同じ Acquisition & Validity
-    Contract に従って completion / acquisition / validity を確認します。
+8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
+   変更された場合のみ、fix 後に手順 1 の verify を再実行します。
+9. **Targeted closure** — 手順 7 の batch fix によって candidate SHA が変更
+   された場合のみ、Review stopping rules（`policy/core.md`）に従い、fix した
+   箇所に対応する範囲のみ再確認します。追加 discovery の要否も同 stopping
+   rules に従います。
+10. **Closure Acquisition & Validity** — 手順 7 の batch fix によって
+    candidate SHA が変更された場合のみ、targeted closure の review run も
+    手順 5 と同じ Acquisition & Validity Contract に従って completion /
+    acquisition / validity を確認します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
-11. **Merge** — candidate SHA が変更されていなければ、required review 数の
-    valid discovery と Resolution が完了した時点で merge します。
+11. **Merge** — 手順 7 の batch fix によって candidate SHA が変更されて
+    いなければ、required review 数の valid discovery と Resolution が完了
+    した時点で merge します。
     変更されていれば、Closure Acquisition & Validity が確認できた時点で
     merge します。
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -42,14 +42,19 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
 7. **Closure** — accepted finding の fix によって target SHA / range が変わった
-   場合、修正後の SHA / range を closure target として re-freeze し、
-   Selection / Execution Contract（`policy/core.md`）を closure review run に
-   適用します。
-   triage した finding に対応しているかの closure verification のみを
-   行い、full な再 discovery はしません。
+   場合のみ行います。修正後の SHA / range を closure target として re-freeze
+   し、Selection / Execution Contract（`policy/core.md`）を closure review
+   run に適用します。
+   その上で、triage した finding に対応しているかの closure verification
+   のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
    この closure target を expected target として Acquisition & Validity
    Contract に従って確認します。
+   accepted finding の fix が無く target も変更されていない場合（例えば
+   0 findings の場合や、finding を false-positive 等として Resolution
+   した場合）は、required review 数の valid semantic discovery と
+   Resolution が完了した時点で review procedure を完了とし、新たな
+   closure run を要求しません。
 
 ## 停止条件
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -22,20 +22,23 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    target が一致することを確認します。一致しない場合は、確定した target に
    対して手順 1 の mechanical check を再実行してから先へ進みます。
    手順 3 の semantic discovery の completion / validity が確定する前に
-   target SHA / range が変わった場合、その review target / run を現在
-   target の evidence として扱いません。
+   target SHA / range または target artifact set が変わった場合、その
+   review target / run を現在 target の evidence として扱いません。
    新しい target に対して手順 1 の mechanical check を再実行し、成功したら
    Selection をやり直し、手順 3 の semantic discovery を新しい target に
    対して行います。
    valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
-   batch fix 以外の理由で target SHA / range が変わった場合（並行作業や
-   scope 追加、finding 対応ではない文書変更、無関係な commit 等）は、
+   batch fix 以外の理由で target SHA / range または target artifact set が
+   変わった場合（並行作業や scope 追加、finding 対応ではない文書変更、
+   無関係な commit 等）は、
    旧 review target / run を現在 target の evidence として扱いません。
    新しい target に対して手順 1 の mechanical check を再実行し、成功したら
    re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic
    discovery を新しい target に対して行います。
-3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い
-   reviewer を起動し、trigger 方法と required context を記録した上で、独立
+3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い、
+   Selection で確定した target SHA / range と target artifact set を
+   reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
+   target と artifact set、required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
    Artifact classification / Review stopping rules（`policy/core.md`）に従います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -23,15 +23,16 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
-   確認できない run の finding は triage へ進めず、
-   `unknown` / `failure` として扱います。
+   valid な run の finding だけを triage へ進めます。
+   invalid / unknown / failure な run の finding は triage に使用しません。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
-7. **Closure** — triage した finding に対応しているかの closure verification のみを
-   行い、full な再 discovery はしません。
+7. **Closure** — 原則として、triage した finding に対応する範囲の targeted
+   closure verification を行います。追加 discovery の要否は Review stopping
+   rules（`policy/core.md`）に従います。
    closure verification 自体の completion / acquisition / validity も
    Acquisition & Validity Contract に従って確認します。
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -62,6 +62,9 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    closure verification 自体の completion / acquisition / validity も、
    この closure target を expected target として Acquisition & Validity
    Contract に従って確認します。
+   closure 用 Selection Contract で required とした review 数ぶんの valid
+   な closure run が揃うまで Closure Resolution へ進みません。不足する
+   run の扱いは Failure / retry（`policy/core.md`）に従います。
    accepted finding の fix が無く target も変更されていない場合（例えば
    0 findings の場合や、finding を false-positive 等として Resolution
    した場合）は、required review 数の valid semantic discovery と

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -30,9 +30,8 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    仕分けます。
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
-7. **Closure** — 原則として、triage した finding に対応する範囲の targeted
-   closure verification を行います。追加 discovery の要否は Review stopping
-   rules（`policy/core.md`）に従います。
+7. **Closure** — triage した finding に対応しているかの closure verification のみを
+   行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も
    Acquisition & Validity Contract に従って確認します。
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -20,9 +20,10 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
    batch fix 以外の理由で target SHA / range が変わった場合（並行作業や
    scope 追加、finding 対応ではない文書変更、無関係な commit 等）は、
-   旧 review target / run を現在 target の evidence として扱わず、新しい
-   target を re-freeze して手順 2（Selection）からやり直し、手順 3 の
-   semantic discovery を新しい target に対して行います。
+   旧 review target / run を現在 target の evidence として扱いません。
+   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
+   re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic
+   discovery を新しい target に対して行います。
 3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い
    reviewer を起動し、trigger 方法と required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
@@ -42,7 +43,8 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
 7. **Closure** — accepted finding の fix によって target SHA / range が変わった
-   場合のみ行います。修正後の SHA / range を closure target として re-freeze
+   場合のみ行います。修正後の target に対して手順 1 の mechanical check を
+   再実行し、成功したらその SHA / range を closure target として re-freeze
    し、Selection / Execution Contract（`policy/core.md`）を closure review
    run に適用します。
    その上で、triage した finding に対応しているかの closure verification

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -90,6 +90,9 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    accepted な closure finding があれば、手順 6〜7 と同じ procedure（fix ->
    mechanical check -> closure verification -> closure Acquisition &
    Validity）に従って解決します。
+   closure Resolution に加えて、手順 5 の semantic discovery Resolution
+   も完了していることが review procedure 完了の条件です。完了順序は
+   問いません。
    この cycle が繰り返し発生する場合は、本 skill の停止条件および Review
    stopping rules（`policy/core.md`）に従います。
    手順 7 の closure が行われなかった場合（accepted fix が無く target も

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -35,10 +35,15 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    仕分けます。
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
-7. **Closure** — triage した finding に対応しているかの closure verification のみを
+7. **Closure** — accepted finding の fix によって target SHA / range が変わった
+   場合、修正後の SHA / range を closure target として re-freeze し、
+   Selection / Execution Contract（`policy/core.md`）を closure review run に
+   適用します。
+   triage した finding に対応しているかの closure verification のみを
    行い、full な再 discovery はしません。
-   closure verification 自体の completion / acquisition / validity も
-   Acquisition & Validity Contract に従って確認します。
+   closure verification 自体の completion / acquisition / validity も、
+   この closure target を expected target として Acquisition & Validity
+   Contract に従って確認します。
 
 ## 停止条件
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -17,6 +17,12 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
    range、target artifact set、reviewer / capability、required review 数を
    確定します。
+   手順 3 の semantic discovery の completion / validity が確定する前に
+   target SHA / range が変わった場合、その review target / run を現在
+   target の evidence として扱いません。
+   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
+   Selection をやり直し、手順 3 の semantic discovery を新しい target に
+   対して行います。
    valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
    batch fix 以外の理由で target SHA / range が変わった場合（並行作業や
    scope 追加、finding 対応ではない文書変更、無関係な commit 等）は、

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -1,0 +1,34 @@
+# review-doc skill
+
+このファイルは `policy/core.md` の Review Protocol（Artifact classification の
+Normative、Review contracts、Review stopping rules）を使った実行手順です。規範的な
+ルールはここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
+矛盾する場合は policy が優先します。
+
+## 対象
+
+Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 agent や
+実装を拘束する文書）の review。
+
+## 手順
+
+1. **Mechanical check** — markdown の形式チェック（lint / format / link 切れ等、
+   repository が持つ機械的な check）を実行します。
+2. **Semantic discovery（1 round）** — 独立 reviewer による意味的な discovery を
+   1 回行います。Foundation の重要な normative contract では、独立した 2 系統の
+   reviewer を使ってよいですが、各 reviewer の discovery はそれぞれ 1 回のままとし、
+   同じ reviewer に discovery を繰り返させて網羅性を上げようとしません。
+3. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
+   false-positive / needs-verification / technical-dispute / intent-question）へ
+   仕分けます。
+4. **Fix** — accepted finding を batch でまとめて fix します。1 件ずつの drip fix は
+   しません。
+5. **Closure** — triage した finding に対応しているかの closure verification のみを
+   行い、full な再 discovery はしません。
+
+## 停止条件
+
+reviewer の不確実性を補うために 2 回目の full discovery を追加しません。同種の
+finding が複数の文書や round にまたがって繰り返し出る場合は、review loop を増やす
+のではなく、上流の policy / document 自体に defect がある兆候として扱い、escalate
+します。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -73,6 +73,8 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    accepted な closure finding があれば、手順 6〜7 と同じ procedure（fix ->
    mechanical check -> closure verification -> closure Acquisition &
    Validity）に従って解決します。
+   この cycle が繰り返し発生する場合は、本 skill の停止条件および Review
+   stopping rules（`policy/core.md`）に従います。
    手順 7 の closure が行われなかった場合（accepted fix が無く target も
    変更されていない場合）、この手順は不要です。
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -15,7 +15,8 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 1. **Mechanical check** — markdown の形式チェック（lint / format / link 切れ等、
    repository が持つ機械的な check）を実行します。
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
-   range、target artifact set、reviewer / capability を確定します。
+   range、target artifact set、reviewer / capability、required review 数を
+   確定します。
 3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い
    reviewer を起動し、trigger 方法と required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
@@ -23,6 +24,10 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
+   Selection Contract で required とした review 数ぶんの `validity: valid`
+   な run が揃うまで triage へ進みません。
+   揃わない run（invalid / unknown / failure）の扱いは Failure / retry
+   （`policy/core.md`）に従います。
    valid な run の finding だけを triage へ進めます。
    invalid / unknown / failure な run の finding は triage に使用しません。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -18,12 +18,17 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    1 回行います。Foundation の重要な normative contract では、独立した 2 系統の
    reviewer を使ってよいですが、各 reviewer の discovery はそれぞれ 1 回のままとし、
    同じ reviewer に discovery を繰り返させて網羅性を上げようとしません。
-3. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
+3. **Acquisition & Validity 確認** — `policy/core.md` の Acquisition & Validity
+   Contract に従い、target SHA / range、target artifact set、completion、
+   acquisition、validity を確認します。
+   確認できない run の finding は triage へ進めず、
+   `unknown` / `failure` として扱います。
+4. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
-4. **Fix** — accepted finding を batch でまとめて fix します。1 件ずつの drip fix は
+5. **Fix** — accepted finding を batch でまとめて fix します。1 件ずつの drip fix は
    しません。
-5. **Closure** — triage した finding に対応しているかの closure verification のみを
+6. **Closure** — triage した finding に対応しているかの closure verification のみを
    行い、full な再 discovery はしません。
 
 ## 停止条件

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -12,11 +12,15 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 
 ## 手順
 
-1. **Mechanical check** — markdown の形式チェック（lint / format / link 切れ等、
-   repository が持つ機械的な check）を実行します。
+1. **Mechanical check** — その時点の target SHA / range を記録した上で、
+   markdown の形式チェック（lint / format / link 切れ等、repository が持つ
+   機械的な check）を実行します。
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
    range、target artifact set、reviewer / capability、required review 数を
    確定します。
+   手順 1 で記録した mechanical check 対象の target と、ここで確定する
+   target が一致することを確認します。一致しない場合は、確定した target に
+   対して手順 1 の mechanical check を再実行してから先へ進みます。
    手順 3 の semantic discovery の completion / validity が確定する前に
    target SHA / range が変わった場合、その review target / run を現在
    target の evidence として扱いません。
@@ -63,6 +67,14 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    した場合）は、required review 数の valid semantic discovery と
    Resolution が完了した時点で review procedure を完了とし、新たな
    closure run を要求しません。
+8. **Closure Resolution** — closure verification（手順 7）の finding を
+   Resolution Contract（`policy/core.md`）に従って triage します。
+   unresolved の finding がある間は review procedure を完了としません。
+   accepted な closure finding があれば、手順 6〜7 と同じ procedure（fix ->
+   mechanical check -> closure verification -> closure Acquisition &
+   Validity）に従って解決します。
+   手順 7 の closure が行われなかった場合（accepted fix が無く target も
+   変更されていない場合）、この手順は不要です。
 
 ## 停止条件
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -12,15 +12,22 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 
 ## 手順
 
-1. **Mechanical check** — その時点の target SHA / range を記録した上で、
-   markdown の形式チェック（lint / format / link 切れ等、repository が持つ
-   機械的な check）を実行します。
+1. **Mechanical check** — その時点の target SHA / range と、その mechanical
+   check が対象とした document / artifact scope を必要な精度で記録した
+   上で、markdown の形式チェック（lint / format / link 切れ等、repository
+   が持つ機械的な check）を実行します。
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
    range、target artifact set、reviewer / capability、required review 数を
    確定します。
    手順 1 で記録した mechanical check 対象の target と、ここで確定する
    target が一致することを確認します。一致しない場合は、確定した target に
    対して手順 1 の mechanical check を再実行してから先へ進みます。
+   target artifact set を確定したら、直近の successful mechanical-check
+   evidence が、確定した target SHA / range と target artifact set の
+   両方をカバーしているかを確認します。selected artifact set をその
+   mechanical check evidence がカバーしていると確認できない場合は、
+   確定した target に対して手順 1 の mechanical check を再実行してから
+   手順 3（semantic discovery）へ進みます。
    手順 3 の semantic discovery の completion / validity が確定する前に
    target SHA / range または target artifact set が変わった場合、その
    review target / run を現在 target の evidence として扱いません。
@@ -58,8 +65,12 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 7. **Closure** — accepted finding の fix によって target SHA / range が変わった
    場合のみ行います。修正後の target に対して手順 1 の mechanical check を
    再実行し、成功したらその SHA / range を closure target として re-freeze
-   し、Selection / Execution Contract（`policy/core.md`）を closure review
-   run に適用します。
+   し、Selection Contract（`policy/core.md`）をこの closure review run に
+   適用します。確定した closure artifact set を、直近の mechanical-check
+   evidence がカバーしていることを確認します。確認できない場合は、確定
+   した closure target に対して mechanical check を再実行してから、
+   Execution Contract（`policy/core.md`）を closure review run に適用
+   します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -17,6 +17,12 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
    range、target artifact set、reviewer / capability、required review 数を
    確定します。
+   valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
+   batch fix 以外の理由で target SHA / range が変わった場合（並行作業や
+   scope 追加、finding 対応ではない文書変更、無関係な commit 等）は、
+   旧 review target / run を現在 target の evidence として扱わず、新しい
+   target を re-freeze して手順 2（Selection）からやり直し、手順 3 の
+   semantic discovery を新しい target に対して行います。
 3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い
    reviewer を起動し、trigger 方法と required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -14,26 +14,30 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
 
 1. **Mechanical check** — markdown の形式チェック（lint / format / link 切れ等、
    repository が持つ機械的な check）を実行します。
-2. **Semantic discovery（1 round）** — 独立 reviewer による意味的な discovery を
-   1 回行います。Foundation の重要な normative contract では、独立した 2 系統の
-   reviewer を使ってよいですが、各 reviewer の discovery はそれぞれ 1 回のままとし、
-   同じ reviewer に discovery を繰り返させて網羅性を上げようとしません。
-3. **Acquisition & Validity 確認** — `policy/core.md` の Acquisition & Validity
-   Contract に従い、target SHA / range、target artifact set、completion、
-   acquisition、validity を確認します。
+2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
+   range、target artifact set、reviewer / capability を確定します。
+3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い
+   reviewer を起動し、trigger 方法と required context を記録した上で、独立
+   reviewer による意味的な discovery を 1 回行います。round 数の扱いは
+   Artifact classification / Review stopping rules（`policy/core.md`）に従います。
+4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
+   （`policy/core.md`）に従い、target SHA / range、target artifact set、
+   completion、acquisition、validity を確認します。
    確認できない run の finding は triage へ進めず、
    `unknown` / `failure` として扱います。
-4. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
+5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
-5. **Fix** — accepted finding を batch でまとめて fix します。1 件ずつの drip fix は
-   しません。
-6. **Closure** — triage した finding に対応しているかの closure verification のみを
+6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
+   fix します。
+7. **Closure** — triage した finding に対応しているかの closure verification のみを
    行い、full な再 discovery はしません。
+   closure verification 自体の completion / acquisition / validity も
+   Acquisition & Validity Contract に従って確認します。
 
 ## 停止条件
 
-reviewer の不確実性を補うために 2 回目の full discovery を追加しません。同種の
-finding が複数の文書や round にまたがって繰り返し出る場合は、review loop を増やす
-のではなく、上流の policy / document 自体に defect がある兆候として扱い、escalate
-します。
+同種の finding が複数の文書や round にまたがって繰り返し出る場合は、review loop
+を増やすのではなく、上流の policy / document 自体に defect がある兆候として扱い、
+escalate します。round 数の扱いは Review stopping rules（`policy/core.md`）に
+従います。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -62,15 +62,15 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    仕分けます。
 6. **Fix** — Resolution Contract に従い、accepted finding を batch でまとめて
    fix します。
-7. **Closure** — accepted finding の fix によって target SHA / range が変わった
-   場合のみ行います。修正後の target に対して手順 1 の mechanical check を
-   再実行し、成功したらその SHA / range を closure target として re-freeze
-   し、Selection Contract（`policy/core.md`）をこの closure review run に
-   適用します。確定した closure artifact set を、直近の mechanical-check
-   evidence がカバーしていることを確認します。確認できない場合は、確定
-   した closure target に対して mechanical check を再実行してから、
-   Execution Contract（`policy/core.md`）を closure review run に適用
-   します。
+7. **Closure** — accepted finding の fix によって target SHA / range または
+   target artifact set が変わった場合のみ行います。修正後の target に
+   対して手順 1 の mechanical check を再実行し、成功したらその SHA /
+   range を closure target として re-freeze し、Selection Contract
+   （`policy/core.md`）をこの closure review run に適用します。確定した
+   closure artifact set を、直近の mechanical-check evidence がカバー
+   していることを確認します。確認できない場合は、確定した closure
+   target に対して mechanical check を再実行してから、Execution
+   Contract（`policy/core.md`）を closure review run に適用します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
@@ -79,11 +79,11 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    closure 用 Selection Contract で required とした review 数ぶんの valid
    な closure run が揃うまで Closure Resolution へ進みません。不足する
    run の扱いは Failure / retry（`policy/core.md`）に従います。
-   accepted finding の fix が無く target も変更されていない場合（例えば
-   0 findings の場合や、finding を false-positive 等として Resolution
-   した場合）は、required review 数の valid semantic discovery と
-   Resolution が完了した時点で review procedure を完了とし、新たな
-   closure run を要求しません。
+   accepted finding の fix が無く target SHA / range も target artifact
+   set も変更されていない場合（例えば 0 findings の場合や、finding を
+   false-positive 等として Resolution した場合）は、required review 数の
+   valid semantic discovery と Resolution が完了した時点で review
+   procedure を完了とし、新たな closure run を要求しません。
 8. **Closure Resolution** — closure verification（手順 7）の finding を
    Resolution Contract（`policy/core.md`）に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。
@@ -95,8 +95,9 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    問いません。
    この cycle が繰り返し発生する場合は、本 skill の停止条件および Review
    stopping rules（`policy/core.md`）に従います。
-   手順 7 の closure が行われなかった場合（accepted fix が無く target も
-   変更されていない場合）、この手順は不要です。
+   手順 7 の closure が行われなかった場合（accepted fix が無く target
+   SHA / range も target artifact set も変更されていない場合）、この
+   手順は不要です。
 
 ## 停止条件
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -274,6 +274,11 @@ classification が要求する precondition check を再成立させ、Selection
 target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
+Selection Contract で commit range を expected target として使う場合、head
+SHA が不変でも range の endpoint が変われば、それも target の変更です。この
+場合も、old discovery / closure evidence を新しい target の merge /
+completion evidence として使いません。
+
 Code review:
 
 ```text
@@ -299,7 +304,7 @@ deterministic verify
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
        -> merge
-  -> accepted fix が無く candidate SHA が変更されていない場合:
+  -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
        -> merge
 ```
@@ -309,7 +314,7 @@ targeted closure を行い、その review run も Acquisition & Validity Contra
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
 merge しません。
-accepted fix が無く candidate SHA が変更されていない場合は、
+accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -245,6 +245,12 @@ capability/profile の更新時に再検証可能にします。
 
 ### Review stopping rules
 
+target が変更された場合、その新しい target に対する mechanical / deterministic
+precondition の evidence は自動的に持ち越しません。target 変更後にその target を
+review / closure / merge の根拠とする前に、artifact classification が要求する
+precondition check（Executable の deterministic verify、Normative の mechanical
+check）を新しい target に対して再成立させます。
+
 Code review:
 
 ```text
@@ -282,7 +288,8 @@ mechanical check
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
-       closure verification
+       mechanical check
+       -> closure verification
        -> closure completion / acquisition / validity 確認
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
@@ -290,9 +297,10 @@ mechanical check
        -> 完了
 ```
 
-accepted finding の fix によって target SHA / range が変更された場合のみ
-closure verification を行い、その review run も Acquisition & Validity
-Contract に従って completion / acquisition / validity を確認します。
+accepted finding の fix によって target SHA / range が変更された場合のみ、
+新しい target に対して mechanical check を再実行してから closure
+verification を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -155,6 +155,7 @@ review run ごとに少なくとも次を記録可能にします。
   "reviewer": "...",
   "target_sha": "...",
   "status": "completed",
+  "validity": "valid",
   "finding_count": 0,
   "result_locator": "...",
   "started_at": "...",
@@ -162,6 +163,10 @@ review run ごとに少なくとも次を記録可能にします。
   "failure": null
 }
 ```
+
+record の `target_sha` は、Selection Contract の expected target（SHA / commit
+range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
+`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。
 
 Completion は少なくとも次を要求します。
 
@@ -177,7 +182,12 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
+Validity の判定は、Selection Contract の expected target と、
+record の `target_sha`（reviewed target）または acquired evidence 上の
+reviewed target を比較して行います。
+
 reviewed SHA / range が target と一致しない場合、completion していても invalid です。
+この場合、record は `status: completed` かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -253,15 +253,23 @@ deterministic verify
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
-  -> batch fix + root-cause sweep
-  -> deterministic verify
-  -> targeted closure
-  -> closure completion / acquisition / validity 確認
-  -> merge
+  -> accepted finding の batch fix で candidate SHA が変更された場合:
+       batch fix + root-cause sweep
+       -> deterministic verify
+       -> targeted closure
+       -> closure completion / acquisition / validity 確認
+       -> merge
+  -> accepted fix が無く candidate SHA が変更されていない場合:
+       required review 数の valid discovery と Resolution の完了
+       -> merge
 ```
 
-targeted closure の review run も Acquisition & Validity Contract に従って
-completion / acquisition / validity を確認してから merge します。
+accepted finding の batch fix によって candidate SHA が変更された場合のみ
+targeted closure を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認してから merge します。
+accepted fix が無く candidate SHA が変更されていない場合は、
+required review 数の valid discovery と Resolution の完了をもって、
+新たな closure run を要求せずに merge できます。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
@@ -273,8 +281,21 @@ Normative document review:
 mechanical check
   -> semantic discovery（1 round）
   -> triage / fix
-  -> closure
+  -> accepted finding の fix で target SHA / range が変更された場合:
+       closure verification
+       -> closure completion / acquisition / validity 確認
+       -> 完了
+  -> accepted fix が無く target が変更されていない場合:
+       required review 数の valid semantic discovery と Resolution の完了
+       -> 完了
 ```
+
+accepted finding の fix によって target SHA / range が変更された場合のみ
+closure verification を行い、その review run も Acquisition & Validity
+Contract に従って completion / acquisition / validity を確認します。
+accepted fix が無く target が変更されていない場合は、
+required review 数の valid semantic discovery と Resolution の完了をもって、
+新たな closure run を要求せずに review を完了できます。
 
 ### Observed evidence is not a permanent provider rule
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -144,9 +144,13 @@ completion へ進みません。不足する run の扱いは Failure / retry �
 #### Execution Contract
 
 - trigger 方法
-- target SHA
+- Selection で確定した expected target SHA / commit range
 - required context
 - timeout / retry policy
+
+Selection Contract で commit range を expected target として選択した場合、
+Execution ではその selected range を reviewer の trigger へ渡し、実際に
+渡した target を記録します。head SHA だけへ黙って縮退させません。
 
 provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -133,6 +133,15 @@ Execution Contract に従って起動します。Selection Contract が required
 completed かつ valid な run が揃うまで triage / Resolution / merge / review
 completion へ進みません。不足する run の扱いは Failure / retry に従います。
 
+Selection Contract で required とした review stage（discovery、2nd full
+discovery を含む）の finding は、その stage で accepted fix があったか
+どうかに関係なく、Resolution Contract に従って Resolution が完了するまで
+merge / review completion へ進みません。同じ review flow で複数の
+discovery stage を行った場合は、実行した discovery stage すべての
+Resolution が完了している必要があります。discovery Resolution を closure
+より先に完了させる順序を強制するものではなく、merge / review completion
+の時点で揃っていれば十分です。
+
 #### Selection Contract
 
 - artifact classification
@@ -228,9 +237,12 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
-- targeted closure / closure verification の finding も Resolution Contract
-  の対象であり、Resolution が完了するまで merge / review completion の
-  根拠にしない
+- discovery（2nd full discovery を含む）と targeted closure / closure
+  verification のいずれの finding も Resolution Contract の対象であり、
+  triage category を付けただけでは Resolution 完了ではない。unresolved
+  の finding（未解決の needs-verification / technical-dispute /
+  intent-question 等を含む）が残る間は、その review stage の Resolution
+  は完了せず、merge / review completion の根拠にしない
 
 ### Review Adapter boundary
 
@@ -321,6 +333,7 @@ deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> required discovery stage(s) の Resolution 完了
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
@@ -332,6 +345,9 @@ targeted closure を行い、その review run も Acquisition & Validity Contra
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
 merge しません。
+targeted closure の Resolution に加えて、この review flow で実行した
+discovery stage（2nd full discovery を含む）すべての Resolution が
+完了していることも merge の条件です。完了順序は問いません。
 accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
@@ -353,6 +369,7 @@ mechanical check
        -> closure verification
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> semantic discovery の Resolution 完了
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
@@ -365,6 +382,9 @@ verification を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。closure
 verification の finding も Resolution Contract の対象とし、Resolution が
 完了するまで review を完了しません。
+closure verification の Resolution に加えて、semantic discovery（手順 3）
+の Resolution が完了していることも review completion の条件です。完了
+順序は問いません。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -126,6 +126,13 @@ Review 強度と停止条件は artifact の種類で分けます。
 Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
 Adapter boundary へ閉じ込め、Kernel に固定しません。
 
+各 Contract は discovery だけでなく、同じ Contract を使って起動する closure review run
+にも適用されます。closure target も Selection Contract で expected target として確定し、
+Execution Contract に従って起動します。Selection Contract が required review 数を
+定めた review stage では、discovery か closure かを問わず、その required 数の
+completed かつ valid な run が揃うまで triage / Resolution / merge / review
+completion へ進みません。不足する run の扱いは Failure / retry に従います。
+
 #### Selection Contract
 
 - artifact classification
@@ -258,6 +265,15 @@ review / closure / merge の根拠として使う precondition evidence は、re
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
+precondition evidence だけでなく、discovery / closure evidence も target-specific
+です。valid な discovery の後、accepted-fix による closure target の変更以外の
+理由で review target が変わった場合、その discovery を新しい target の
+merge / completion evidence として使いません。新しい target について artifact
+classification が要求する precondition check を再成立させ、Selection / Execution
+を再確立した上で、その target に必要な discovery を行います。accepted fix による
+target 変更は、既存の targeted closure（Executable）/ closure verification
+（Normative）の扱いに従います。
+
 Code review:
 
 ```text
@@ -270,6 +286,7 @@ deterministic verify
   -> accepted finding の batch fix で candidate SHA が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
+       -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
@@ -301,6 +318,7 @@ mechanical check
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
        mechanical check
+       -> closure target の Selection / Execution
        -> closure verification
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -101,9 +101,11 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 
 ## Review Protocol
 
-Review の canonical context は本節です。実行手順は `skills/review-code.md` と
-`skills/review-doc.md` に置き、本節の規範的なルールを複製しません。Review Protocol は
-provider 名や model 名を Kernel に固定しません。
+Review の canonical context は本節です。
+本節は generated adapter として配布される自己完結した規範的内容であり、
+実行手順（review skill）は Foundation リポジトリ側に別途保持し、
+本節の規範的なルールを複製しません。
+Review Protocol は provider 名や model 名を Kernel に固定しません。
 
 ### Artifact classification
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -165,14 +165,14 @@ review run ごとに少なくとも次を記録可能にします。
 
 Completion は少なくとも次を要求します。
 
-- intended SHA / range を対象にしている
 - run が terminate している
 - required surface を取得済み
 - finding count が known
-- quota / timeout / structural failure がない
+- quota / timeout / structural な execution / acquisition failure がない
 
 Validity はさらに次を要求します。
 
+- reviewed SHA / range が intended target と一致している
 - intended artifact set が review 対象になっている
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
@@ -193,6 +193,8 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - human を raw finding の message bus にしない
 - pure technical dispute は technical adjudication で解決する
 - human escalation は product intent / authority に限る
+- P0/P1 相当の重大 finding を dismiss する場合は、
+  必要に応じて独立 reviewer の確認を要求する
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
@@ -213,6 +215,9 @@ normalizeFindings()
 workflow log、edited comment 等）は provider capability として扱います。「この provider は
 この surface に出ない」という negative claim を恒久仕様にしてはいけません。
 capability/profile の更新時に再検証可能にします。
+
+収集した evidence は、comment ID / review ID / run ID / timestamp / target SHA
+または commit range を可能な範囲で保持します。
 
 ### Failure / retry
 
@@ -235,8 +240,12 @@ deterministic verify
   -> batch fix + root-cause sweep
   -> deterministic verify
   -> targeted closure
+  -> closure completion / acquisition / validity 確認
   -> merge
 ```
+
+targeted closure の review run も Acquisition & Validity Contract に従って
+completion / acquisition / validity を確認してから merge します。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -309,6 +309,13 @@ range の endpoint が変わった場合、また expected target SHA / commit r
 して同じ scope です。この場合も、old discovery / closure evidence を
 新しい target の merge / completion evidence として使いません。
 
+closure Resolution で accepted fix が生じ、その fix を closure review で
+確認する cycle（Executable の targeted closure、Normative の closure
+verification のいずれも）が繰り返し発生する場合、無制限に継続せず、
+upstream task/design または policy/document 自体の instability を疑い、
+必要に応じて escalate します。これは Failure / retry の retry count とは
+別の stopping semantics です。
+
 Code review:
 
 ```text
@@ -318,7 +325,7 @@ deterministic verify
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
-  -> accepted finding の batch fix で candidate SHA が変更された場合:
+  -> accepted finding の batch fix で review target が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
        -> fix が behavior / blast radius を materially 変えた場合のみ:
@@ -358,7 +365,7 @@ deterministic verify
        -> merge
 ```
 
-accepted finding の batch fix によって candidate SHA が変更された場合のみ
+accepted finding の batch fix によって review target が変更された場合のみ
 targeted closure を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。targeted closure
 の finding も Resolution Contract の対象とし、Resolution が完了するまで
@@ -392,7 +399,7 @@ mechanical check
   -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
-  -> accepted finding の fix で target SHA / range が変更された場合:
+  -> accepted finding の fix で review target が変更された場合:
        mechanical check
        -> closure target の Selection / Execution
        -> closure verification
@@ -400,12 +407,12 @@ mechanical check
        -> closure finding の Resolution
        -> semantic discovery の Resolution 完了
        -> 完了
-  -> accepted fix が無く target が変更されていない場合:
+  -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
        -> 完了
 ```
 
-accepted finding の fix によって target SHA / range が変更された場合のみ、
+accepted finding の fix によって review target が変更された場合のみ、
 新しい target に対して mechanical check を再実行してから closure
 verification を行い、その review run も Acquisition & Validity Contract
 に従って completion / acquisition / validity を確認します。closure
@@ -414,7 +421,7 @@ verification の finding も Resolution Contract の対象とし、Resolution �
 closure verification の Resolution に加えて、semantic discovery（手順 3）
 の Resolution が完了していることも review completion の条件です。完了
 順序は問いません。
-accepted fix が無く target が変更されていない場合は、
+accepted fix が無く review target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -272,6 +272,14 @@ review / closure / merge の根拠として使う precondition evidence は、re
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
+この一致確認は SHA / range だけでなく、selected target artifact set にも
+及びます。Selection で確定した target artifact set が、その precondition
+check の対象 scope に含まれることを確認します。precondition check を
+Selection より前に実行した場合は、Selection 後にこの binding を確認し
+ます。selected artifact set を precondition evidence がカバーしていると
+確認できない場合は、確定した target に対して precondition check を
+再実行してから先へ進みます。
+
 precondition evidence だけでなく、discovery / closure evidence も target-specific
 です。valid な discovery の後、accepted-fix による closure target の変更以外の
 理由で review target が変わった場合、その discovery を新しい target の

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -145,12 +145,15 @@ completion へ進みません。不足する run の扱いは Failure / retry �
 
 - trigger 方法
 - Selection で確定した expected target SHA / commit range
+- Selection で確定した target artifact set
 - required context
 - timeout / retry policy
 
-Selection Contract で commit range を expected target として選択した場合、
-Execution ではその selected range を reviewer の trigger へ渡し、実際に
-渡した target を記録します。head SHA だけへ黙って縮退させません。
+Selection Contract で確定した expected target（SHA / commit range）と
+target artifact set は、Execution で reviewer の trigger へ渡し、実際に
+渡した target と artifact set を記録します。commit range を選択した場合に
+head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
+黙って縮小・変更しません。
 
 provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
 
@@ -278,10 +281,13 @@ classification が要求する precondition check を再成立させ、Selection
 target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
-Selection Contract で commit range を expected target として使う場合、head
-SHA が不変でも range の endpoint が変われば、それも target の変更です。この
-場合も、old discovery / closure evidence を新しい target の merge /
-completion evidence として使いません。
+この節における review target は、Selection Contract で確定した expected
+target SHA / commit range と target artifact set の組を指します。どちらか
+一方でも変われば review target の変更です。head SHA が不変でも commit
+range の endpoint が変わった場合、また expected target SHA / commit range
+が不変でも target artifact set が変わった場合も、review target の変更と
+して同じ scope です。この場合も、old discovery / closure evidence を
+新しい target の merge / completion evidence として使いません。
 
 Code review:
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -337,6 +337,20 @@ deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
+       -> accepted closure finding があれば:
+            batch fix
+            -> deterministic verify
+            -> Review stopping rules の再評価
+            -> 2nd full discovery 未使用かつ必要な場合:
+                 second discovery target の Selection / Execution から
+                 上記の full discovery route へ進み、完了後 targeted
+                 closure を再実行する
+            -> 2nd full discovery 使用済みでなお必要な場合:
+                 3rd full discovery は起動せず、merge もせず、
+                 upstream task/design の不安定さを疑い、必要に応じて
+                 escalate する
+            -> 追加の full discovery が不要な場合:
+                 targeted closure を再実行する
        -> required discovery stage(s) の Resolution 完了
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
@@ -352,6 +366,13 @@ merge しません。
 targeted closure の Resolution に加えて、この review flow で実行した
 discovery stage（2nd full discovery を含む）すべての Resolution が
 完了していることも merge の条件です。完了順序は問いません。
+targeted closure の finding に accepted fix がある場合も、fix 後の
+deterministic verify を経て Review stopping rules を再評価します。2nd
+full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
+に targeted closure をやり直します。2nd full discovery を使用済みでなお
+full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
+追加の full discovery が不要なら、targeted closure をやり直します。
 accepted fix が無く review target が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -99,6 +99,166 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 人間を message bus にしません。人間への escalation は、product intent、authority、権限、
 または受容不能な trade-off に限ります。
 
+## Review Protocol
+
+Review の canonical context は本節です。実行手順は `skills/review-code.md` と
+`skills/review-doc.md` に置き、本節の規範的なルールを複製しません。Review Protocol は
+provider 名や model 名を Kernel に固定しません。
+
+### Artifact classification
+
+Review 強度と停止条件は artifact の種類で分けます。
+
+- **Executable**: TS/TSX/SQL/workflow/config 等、実行される、または実行に影響するコード。
+  deterministic verify を先に実行し、candidate SHA を freeze した上で、原則として独立
+  AI reviewer による discovery -> triage -> batch fix -> verify -> targeted closure を行います。
+- **Normative**: AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 agent や実装を
+  拘束する文書。mechanical markdown check の後、semantic discovery は原則 1 round とし、
+  triage / fix の後は closure verification のみを行います。重要な normative contract は
+  独立 reviewer を 2 系統使ってよいですが、各 reviewer の discovery は 1 回を基本とします。
+- **Informational**: README / research note / log 等。mechanical check を中心とし、
+  open-ended AI review を通常の merge gate にしません。
+
+### Review contracts
+
+Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
+Adapter boundary へ閉じ込め、Kernel に固定しません。
+
+#### Selection Contract
+
+- artifact classification
+- reviewer / capability の選択
+- required review 数
+- target artifact set
+- expected target SHA / commit range
+
+#### Execution Contract
+
+- trigger 方法
+- target SHA
+- required context
+- timeout / retry policy
+
+provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
+
+#### Acquisition & Validity Contract
+
+**CI status は review completion と同義ではありません。** status/check の green 化のみを
+review 完了の証跡にしてはいけません。
+
+review run ごとに少なくとも次を記録可能にします。
+
+```json
+{
+  "reviewer": "...",
+  "target_sha": "...",
+  "status": "completed",
+  "finding_count": 0,
+  "result_locator": "...",
+  "started_at": "...",
+  "completed_at": "...",
+  "failure": null
+}
+```
+
+Completion は少なくとも次を要求します。
+
+- intended SHA / range を対象にしている
+- run が terminate している
+- required surface を取得済み
+- finding count が known
+- quota / timeout / structural failure がない
+
+Validity はさらに次を要求します。
+
+- intended artifact set が review 対象になっている
+- required context へアクセスできた
+- execution / acquisition が途中で欠落していない
+
+reviewed SHA / range が target と一致しない場合、completion していても invalid です。
+intended artifact set が review されていない場合も invalid です。
+
+**0 findings は positive evidence を必要とします。** reaction なし、comment なし、
+parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
+completion evidence のない empty output は `unknown` として扱います。
+
+review run の状態は少なくとも `none` / `unknown` / `failure` を区別し、混同してはいけません。
+
+#### Resolution Contract
+
+- finding を fix / false-positive / needs-verification / technical-dispute /
+  intent-question へ triage する
+- human を raw finding の message bus にしない
+- pure technical dispute は technical adjudication で解決する
+- human escalation は product intent / authority に限る
+- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
+- fix 後は全 discovery をやり直さず、targeted closure を基本とする
+- review を新しい scope の探索に使わない
+
+### Review Adapter boundary
+
+provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
+定義し、provider 固有の実装や恒久的な capability 台帳を持ちません。
+
+```text
+trigger()
+pollCompletion()
+collectOutputs()
+normalizeFindings()
+```
+
+収集対象の surface（top-level comment、inline/thread、review submission、status/check、
+workflow log、edited comment 等）は provider capability として扱います。「この provider は
+この surface に出ない」という negative claim を恒久仕様にしてはいけません。
+capability/profile の更新時に再検証可能にします。
+
+### Failure / retry
+
+- transient failure: bounded retry
+- quota / rate limit: `unknown` または `failure` として明示し、success に潰さない
+- structural capability mismatch: 同じ trigger を無限 retry せず、alternate reviewer /
+  escalation
+- empty output: positive completion evidence がなければ `unknown`
+
+### Review stopping rules
+
+Code review:
+
+```text
+deterministic verify
+  -> freeze candidate SHA
+  -> discovery（独立 reviewer）
+  -> completion / acquisition / validity 確認
+  -> aggregate / triage
+  -> batch fix + root-cause sweep
+  -> deterministic verify
+  -> targeted closure
+  -> merge
+```
+
+full discovery は原則 1 round です。fix が behavior / blast radius を materially
+変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
+upstream task/design の不安定さを疑います。
+
+Normative document review:
+
+```text
+mechanical check
+  -> semantic discovery（1 round）
+  -> triage / fix
+  -> closure
+```
+
+### Observed evidence is not a permanent provider rule
+
+Review Protocol の contract は実測された failure mode を反映しますが、observed な
+provider 挙動を Kernel の恒久 rule にはしません。expected trigger behavior は
+completion evidence と同義ではありません。expected trigger behavior に反して
+completion evidence が得られない場合は、trigger 前提を疑い、Acquisition & Validity
+Contract に従って `unknown` として扱います。特定 provider が常に特定の trigger 方法を
+要求するという恒久仕様は Kernel に置かず、observed evidence として capability/profile
+側で再検証可能な形にします。
+
 ## Technology profile: Next.js + Supabase
 
 # Next.js + Supabase profile

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -329,6 +329,10 @@ deterministic verify
             -> aggregate / triage
             -> accepted finding があれば batch fix
             -> target が変われば deterministic verify
+            -> この fix でさらに追加の full discovery が必要と判断される
+               場合: 3rd full discovery は起動せず、merge もせず、
+               upstream task/design の不安定さを疑い、必要に応じて
+               escalate する
        -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認
@@ -355,6 +359,10 @@ required review 数の valid discovery と Resolution の完了をもって、
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
 upstream task/design の不安定さを疑います。
+2nd discovery の accepted finding を fix した後も、その fix が behavior /
+blast radius をさらに materially 変えた場合は、3rd full discovery を起動
+せず、targeted closure だけで merge へ進まず、upstream task/design の
+不安定さを疑い、必要に応じて escalate します。
 
 Normative document review:
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -214,6 +214,9 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 - accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
 - fix 後は全 discovery をやり直さず、targeted closure を基本とする
 - review を新しい scope の探索に使わない
+- targeted closure / closure verification の finding も Resolution Contract
+  の対象であり、Resolution が完了するまで merge / review completion の
+  根拠にしない
 
 ### Review Adapter boundary
 
@@ -250,12 +253,17 @@ precondition の evidence は自動的に持ち越しません。target 変更�
 review / closure / merge の根拠とする前に、artifact classification が要求する
 precondition check（Executable の deterministic verify、Normative の mechanical
 check）を新しい target に対して再成立させます。
+review / closure / merge の根拠として使う precondition evidence は、review 対象
+として確定した（freeze / Selection された）target と一致していなければなりません。
+一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
+check を再実行します。
 
 Code review:
 
 ```text
 deterministic verify
   -> freeze candidate SHA
+  -> verify target と freeze target の consistency 確認
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
@@ -264,6 +272,7 @@ deterministic verify
        -> deterministic verify
        -> targeted closure
        -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
        -> merge
   -> accepted fix が無く candidate SHA が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
@@ -272,7 +281,9 @@ deterministic verify
 
 accepted finding の batch fix によって candidate SHA が変更された場合のみ
 targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認してから merge します。
+に従って completion / acquisition / validity を確認します。targeted closure
+の finding も Resolution Contract の対象とし、Resolution が完了するまで
+merge しません。
 accepted fix が無く candidate SHA が変更されていない場合は、
 required review 数の valid discovery と Resolution の完了をもって、
 新たな closure run を要求せずに merge できます。
@@ -285,12 +296,14 @@ Normative document review:
 
 ```text
 mechanical check
+  -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で target SHA / range が変更された場合:
        mechanical check
        -> closure verification
        -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
        -> 完了
   -> accepted fix が無く target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
@@ -300,7 +313,9 @@ mechanical check
 accepted finding の fix によって target SHA / range が変更された場合のみ、
 新しい target に対して mechanical check を再実行してから closure
 verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。
+に従って completion / acquisition / validity を確認します。closure
+verification の finding も Resolution Contract の対象とし、Resolution が
+完了するまで review を完了しません。
 accepted fix が無く target が変更されていない場合は、
 required review 数の valid semantic discovery と Resolution の完了をもって、
 新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -286,6 +286,14 @@ deterministic verify
   -> accepted finding の batch fix で candidate SHA が変更された場合:
        batch fix + root-cause sweep
        -> deterministic verify
+       -> fix が behavior / blast radius を materially 変えた場合のみ:
+            second discovery target の Selection / Execution
+            -> full discovery（2nd round、独立 reviewer）
+            -> completion / acquisition / validity 確認
+            -> required review 数の valid run 確認
+            -> aggregate / triage
+            -> accepted finding があれば batch fix
+            -> target が変われば deterministic verify
        -> closure target の Selection / Execution
        -> targeted closure
        -> closure completion / acquisition / validity 確認

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -182,12 +182,18 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
-Validity の判定は、Selection Contract の expected target と、
-record の `target_sha`（reviewed target）または acquired evidence 上の
-reviewed target を比較して行います。
+Validity の判定は、reviewed target を確定させた上で、Selection Contract の
+expected target と比較して行います。reviewed target は次のように確定します。
 
-reviewed SHA / range が target と一致しない場合、completion していても invalid です。
-この場合、record は `status: completed` かつ `validity: invalid` として表現します。
+- record の `target_sha` と acquired evidence 上の reviewed target が
+  両方存在する場合、両者は一致していなければなりません。
+  一致しない場合は invalid です。
+- reviewed target を Validity 判定に必要な精度で確認できない場合は unknown
+  です。
+
+確定した reviewed target が expected target と一致しない場合、
+completion していても invalid です。この場合、record は `status: completed`
+かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -76,6 +76,27 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     ),
   );
 
+  // Codex P2 (pass the selected commit range to Execution): Execution Contract's
+  // target field is bound to Selection's expected target (SHA or commit range),
+  // not reduced to a bare "target SHA" that Selection's range would silently
+  // narrow down to. Since Step 9 (2nd discovery) and Step 10 (targeted closure)
+  // both already say "Execution Contract に従って", fixing the Contract's own
+  // definition is enough to cover them without restating range semantics there.
+  assert.ok(
+    containsText(core, "Selection で確定した expected target SHA / commit range"),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "Selection Contract で commit range を expected target として選択した場合、Execution ではその selected range を reviewer の trigger へ渡し、実際に渡した target を記録します。head SHA だけへ黙って縮退させません。",
+    ),
+  );
+  assert.doesNotMatch(
+    core,
+    /#### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*target SHA\s*\n/,
+    "Execution Contract must not regress to a bare, Selection-unbound 'target SHA' field",
+  );
+
   // Principle B (review evidence is target-specific): discovery evidence, not just
   // precondition evidence, does not carry over to a new target unless the change
   // was the accepted-fix-driven closure path.
@@ -414,6 +435,22 @@ test("review skills document procedure without duplicating normative rules", asy
       reviewCode,
       "expected target SHA / applicable な commit range を決めます。",
     ),
+  );
+
+  // Codex P2 (pass the selected commit range to Execution): Step 4 must send the
+  // Selection-confirmed target to the reviewer trigger, not just record a bare
+  // target SHA after the fact — recording alone would still let the range
+  // silently narrow to head SHA.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Execution Contract に従い、Selection で確定した expected target SHA / applicable な commit range を各 reviewer の trigger へ渡して起動します。",
+    ),
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /trigger 方法と target SHA、渡した required context を記録します。/,
+    "Step 4 must pass the Selection-confirmed target to the trigger, not just record target SHA after invocation",
   );
 
   // A mixed change (accepted-fix-driven head move plus an independently moved

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -169,11 +169,12 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(containsText(core, "materially 変えた場合のみ 2 round 目を許容します。"));
   assert.ok(core.includes("semantic discovery（1 round）"));
   // Canonical policy: Normative closure is likewise conditioned on an accepted-fix
-  // target change, not unconditional (matches skills/review-doc.md's procedure).
+  // target change, not unconditional (matches skills/review-doc.md's procedure),
+  // and re-runs mechanical check against the post-fix target first (Finding 2).
   assert.ok(
     containsText(
       core,
-      "accepted finding の fix によって target SHA / range が変更された場合のみ closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+      "accepted finding の fix によって target SHA / range が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
     ),
   );
   assert.ok(
@@ -182,6 +183,24 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "accepted fix が無く target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
     ),
   );
+
+  // Canonical invariant (root cause fix): mechanical/deterministic precondition
+  // evidence is target-specific and does not carry over across a target change.
+  assert.ok(
+    containsText(
+      core,
+      "target が変更された場合、その新しい target に対する mechanical / deterministic precondition の evidence は自動的に持ち越しません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "precondition check（Executable の deterministic verify、Normative の mechanical check）を新しい target に対して再成立させます。",
+    ),
+  );
+  // The Normative accepted-fix branch re-runs mechanical check before closure
+  // verification, without adding a 2nd semantic discovery round.
+  assert.ok(containsText(core, "mechanical check -> closure verification"));
 
   // Observed evidence stays a general principle, not a permanent provider rule
   assert.ok(containsText(core, "expected trigger behavior は completion evidence と同義ではありません。"));
@@ -307,9 +326,27 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewCode, "手順 7 の batch fix によって candidate SHA が変更された場合のみ"),
   );
 
-  // 2x2 cell A (Executable x accepted fix): closure re-freezes the post-fix SHA as
-  // the closure target and applies Selection / Execution Contract to it, so closure
-  // validity is judged against the post-fix target, not Step 3's original Selection.
+  // Root cause fix (this round, cell B): a non-fix SHA change must re-run Step 1's
+  // deterministic verify against the new SHA before re-freezing, since mechanical/
+  // deterministic precondition evidence does not carry over across a target change.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら",
+    ),
+  );
+
+  // 2x2 cell A (Executable x accepted fix): deterministic verify runs against the
+  // post-fix SHA before targeted closure (pre-existing, unaffected by this round);
+  // closure re-freezes the post-fix SHA as the closure target and applies
+  // Selection / Execution Contract to it, so closure validity is judged against
+  // the post-fix target, not Step 3's original Selection.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "手順 7 の batch fix によって candidate SHA が変更された場合のみ、fix 後に手順 1 の verify を再実行します。",
+    ),
+  );
   assert.ok(
     containsText(
       reviewCode,
@@ -356,7 +393,17 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "新しい target を re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic discovery を新しい target に対して行います。",
+      "re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic discovery を新しい target に対して行います。",
+    ),
+  );
+
+  // Root cause fix (this round, cell D): a non-fix target change must also re-run
+  // Step 1's mechanical check against the new target before re-freezing, matching
+  // review-code.md's cell B fix.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "新しい target に対して手順 1 の mechanical check を再実行し、成功したら",
     ),
   );
   assert.ok(
@@ -385,7 +432,7 @@ test("review skills document procedure without duplicating normative rules", asy
   // review run, so closure validity is judged against the post-fix target instead
   // of the pre-fix expected target from Step 2's Selection.
   assert.ok(
-    containsText(reviewDoc, "修正後の SHA / range を closure target として re-freeze し、"),
+    containsText(reviewDoc, "成功したらその SHA / range を closure target として re-freeze し、"),
   );
   assert.ok(
     containsText(
@@ -395,6 +442,16 @@ test("review skills document procedure without duplicating normative rules", asy
   );
   assert.ok(
     containsText(reviewDoc, "この closure target を expected target として Acquisition & Validity"),
+  );
+
+  // Root cause fix (this round, cell C): closure re-runs Step 1's mechanical check
+  // against the post-fix target before re-freezing it, so mechanical precondition
+  // evidence is re-established for the new target rather than carried over.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "修正後の target に対して手順 1 の mechanical check を再実行し、成功したら",
+    ),
   );
 
   // Latent gap (push-before-check E): Closure only fires on an accepted-fix-driven

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function flatten(text) {
+  return text.replace(/\s+/g, " ");
+}
+
+test("core policy defines the provider-neutral Review Protocol", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const flat = flatten(core);
+
+  for (const heading of [
+    "## Review Protocol",
+    "### Artifact classification",
+    "### Review contracts",
+    "#### Selection Contract",
+    "#### Execution Contract",
+    "#### Acquisition & Validity Contract",
+    "#### Resolution Contract",
+    "### Review Adapter boundary",
+    "### Failure / retry",
+    "### Review stopping rules",
+  ]) {
+    assert.ok(core.includes(heading), `missing Review Protocol heading: ${heading}`);
+  }
+
+  // Artifact classification
+  for (const artifactClass of ["**Executable**", "**Normative**", "**Informational**"]) {
+    assert.ok(flat.includes(artifactClass), `missing artifact class: ${artifactClass}`);
+  }
+
+  // Acquisition & Validity invariants
+  assert.ok(flat.includes("CI status は review completion と同義ではありません"));
+  assert.ok(flat.includes("0 findings は positive evidence を必要とします"));
+  assert.ok(
+    flat.includes(
+      "reviewed SHA / range が target と一致しない場合、completion していても invalid です。",
+    ),
+  );
+  assert.ok(flat.includes("intended artifact set が review されていない場合も invalid です。"));
+  assert.ok(
+    flat.includes(
+      "positive completion evidence のない empty output は `unknown` として扱います。",
+    ),
+  );
+  assert.ok(
+    flat.includes("`none` / `unknown` / `failure` を区別し、混同してはいけません。"),
+  );
+
+  // Acquisition record schema fields
+  for (const field of [
+    '"reviewer"',
+    '"target_sha"',
+    '"status"',
+    '"finding_count"',
+    '"result_locator"',
+    '"started_at"',
+    '"completed_at"',
+    '"failure"',
+  ]) {
+    assert.ok(core.includes(field), `missing record schema field: ${field}`);
+  }
+
+  // Resolution Contract
+  assert.ok(
+    flat.includes(
+      "fix / false-positive / needs-verification / technical-dispute / intent-question へ triage する",
+    ),
+  );
+  assert.ok(flat.includes("human を raw finding の message bus にしない"));
+  assert.ok(flat.includes("pure technical dispute は technical adjudication で解決する"));
+  assert.ok(flat.includes("human escalation は product intent / authority に限る"));
+  assert.ok(
+    flat.includes("accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"),
+  );
+  assert.ok(flat.includes("fix 後は全 discovery をやり直さず、targeted closure を基本とする"));
+  assert.ok(flat.includes("review を新しい scope の探索に使わない"));
+
+  // Review Adapter boundary
+  for (const fn of ["trigger()", "pollCompletion()", "collectOutputs()", "normalizeFindings()"]) {
+    assert.ok(core.includes(fn), `missing adapter boundary function: ${fn}`);
+  }
+  assert.ok(flat.includes("という negative claim を恒久仕様にしてはいけません。"));
+
+  // Failure / retry
+  assert.ok(flat.includes("transient failure: bounded retry"));
+  assert.ok(
+    flat.includes("quota / rate limit: `unknown` または `failure` として明示し、success に潰さない"),
+  );
+  assert.ok(
+    flat.includes(
+      "structural capability mismatch: 同じ trigger を無限 retry せず、alternate reviewer / escalation",
+    ),
+  );
+  assert.ok(flat.includes("empty output: positive completion evidence がなければ `unknown`"));
+
+  // Stopping rules
+  assert.ok(flat.includes("full discovery は原則 1 round です。"));
+  assert.ok(flat.includes("materially 変えた場合のみ 2 round 目を許容します。"));
+  assert.ok(flat.includes("semantic discovery（1 round）"));
+
+  // Observed evidence stays a general principle, not a permanent provider rule
+  assert.ok(flat.includes("expected trigger behavior は completion evidence と同義ではありません。"));
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("review skills document procedure without duplicating normative rules", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  for (const skill of [reviewCode, reviewDoc]) {
+    assert.ok(skill.includes("policy/core.md"), "skill must reference policy/core.md");
+    assert.doesNotMatch(
+      skill,
+      /"target_sha": "\.\.\."/,
+      "skill must not duplicate the Acquisition & Validity record schema from policy",
+    );
+  }
+
+  // review-code.md covers the code review procedure and manual adapter boundary
+  for (const phrase of [
+    "Freeze candidate SHA",
+    "Deterministic verify",
+    "Targeted closure",
+    "Adapter boundary",
+    "Manual review pilot",
+  ]) {
+    assert.ok(reviewCode.includes(phrase), `review-code.md missing: ${phrase}`);
+  }
+  assert.match(reviewCode, /Claude.*Codex.*CodeRabbit/);
+
+  // review-doc.md covers the normative document review procedure
+  for (const phrase of ["Mechanical check", "Semantic discovery", "Triage", "Fix", "Closure"]) {
+    assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
+  }
+  assert.ok(flatten(reviewDoc).includes("drip fix"));
+
+  assert.ok(core.length > 0);
+});

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -6,13 +6,18 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-function flatten(text) {
-  return text.replace(/\s+/g, " ");
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+// Ignores all whitespace (not just line-wrap points) on both sides, so prose
+// assertions survive any content-preserving Markdown reflow.
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
 }
 
 test("core policy defines the provider-neutral Review Protocol", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
-  const flat = flatten(core);
 
   for (const heading of [
     "## Review Protocol",
@@ -31,26 +36,29 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
 
   // Artifact classification
   for (const artifactClass of ["**Executable**", "**Normative**", "**Informational**"]) {
-    assert.ok(flat.includes(artifactClass), `missing artifact class: ${artifactClass}`);
+    assert.ok(core.includes(artifactClass), `missing artifact class: ${artifactClass}`);
   }
 
   // Acquisition & Validity invariants
-  assert.ok(flat.includes("CI status は review completion と同義ではありません"));
-  assert.ok(flat.includes("0 findings は positive evidence を必要とします"));
+  assert.ok(containsText(core, "CI status は review completion と同義ではありません"));
+  assert.ok(containsText(core, "0 findings は positive evidence を必要とします"));
   assert.ok(
-    flat.includes(
-      "reviewed SHA / range が target と一致しない場合、completion していても invalid です。",
-    ),
+    containsText(core, "reviewed SHA / range が target と一致しない場合、completion していても invalid です。"),
   );
-  assert.ok(flat.includes("intended artifact set が review されていない場合も invalid です。"));
+  assert.ok(containsText(core, "intended artifact set が review されていない場合も invalid です。"));
   assert.ok(
-    flat.includes(
-      "positive completion evidence のない empty output は `unknown` として扱います。",
-    ),
+    containsText(core, "positive completion evidence のない empty output は `unknown` として扱います。"),
   );
+  assert.ok(containsText(core, "`none` / `unknown` / `failure` を区別し、混同してはいけません。"));
+
+  // Completion and Validity must not both claim ownership of target SHA/range matching:
+  // Completion covers run termination/acquisition only; Validity owns the SHA/range match.
   assert.ok(
-    flat.includes("`none` / `unknown` / `failure` を区別し、混同してはいけません。"),
+    !core.includes("intended SHA / range を対象にしている"),
+    "Completion must not require intended SHA/range match (that belongs to Validity, see Fix 5)",
   );
+  assert.ok(containsText(core, "reviewed SHA / range が intended target と一致している"));
+  assert.ok(containsText(core, "quota / timeout / structural な execution / acquisition failure がない"));
 
   // Acquisition record schema fields
   for (const field of [
@@ -68,54 +76,69 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
 
   // Resolution Contract
   assert.ok(
-    flat.includes(
+    containsText(
+      core,
       "fix / false-positive / needs-verification / technical-dispute / intent-question へ triage する",
     ),
   );
-  assert.ok(flat.includes("human を raw finding の message bus にしない"));
-  assert.ok(flat.includes("pure technical dispute は technical adjudication で解決する"));
-  assert.ok(flat.includes("human escalation は product intent / authority に限る"));
+  assert.ok(containsText(core, "human を raw finding の message bus にしない"));
+  assert.ok(containsText(core, "pure technical dispute は technical adjudication で解決する"));
+  assert.ok(containsText(core, "human escalation は product intent / authority に限る"));
   assert.ok(
-    flat.includes("accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"),
+    containsText(core, "P0/P1 相当の重大 finding を dismiss する場合は、必要に応じて独立 reviewer の確認を要求する"),
   );
-  assert.ok(flat.includes("fix 後は全 discovery をやり直さず、targeted closure を基本とする"));
-  assert.ok(flat.includes("review を新しい scope の探索に使わない"));
+  assert.ok(containsText(core, "accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"));
+  assert.ok(containsText(core, "fix 後は全 discovery をやり直さず、targeted closure を基本とする"));
+  assert.ok(containsText(core, "review を新しい scope の探索に使わない"));
 
   // Review Adapter boundary
   for (const fn of ["trigger()", "pollCompletion()", "collectOutputs()", "normalizeFindings()"]) {
     assert.ok(core.includes(fn), `missing adapter boundary function: ${fn}`);
   }
-  assert.ok(flat.includes("という negative claim を恒久仕様にしてはいけません。"));
+  assert.ok(containsText(core, "という negative claim を恒久仕様にしてはいけません。"));
+  assert.ok(
+    containsText(
+      core,
+      "収集した evidence は、comment ID / review ID / run ID / timestamp / target SHA または commit range を可能な範囲で保持します。",
+    ),
+  );
 
   // Failure / retry
-  assert.ok(flat.includes("transient failure: bounded retry"));
+  assert.ok(containsText(core, "transient failure: bounded retry"));
   assert.ok(
-    flat.includes("quota / rate limit: `unknown` または `failure` として明示し、success に潰さない"),
+    containsText(core, "quota / rate limit: `unknown` または `failure` として明示し、success に潰さない"),
   );
   assert.ok(
-    flat.includes(
+    containsText(
+      core,
       "structural capability mismatch: 同じ trigger を無限 retry せず、alternate reviewer / escalation",
     ),
   );
-  assert.ok(flat.includes("empty output: positive completion evidence がなければ `unknown`"));
+  assert.ok(containsText(core, "empty output: positive completion evidence がなければ `unknown`"));
 
-  // Stopping rules
-  assert.ok(flat.includes("full discovery は原則 1 round です。"));
-  assert.ok(flat.includes("materially 変えた場合のみ 2 round 目を許容します。"));
-  assert.ok(flat.includes("semantic discovery（1 round）"));
+  // Stopping rules, including the closure Acquisition & Validity gate before merge
+  assert.ok(core.includes("closure completion / acquisition / validity 確認"));
+  assert.ok(
+    containsText(
+      core,
+      "targeted closure の review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認してから merge します。",
+    ),
+  );
+  assert.ok(containsText(core, "full discovery は原則 1 round です。"));
+  assert.ok(containsText(core, "materially 変えた場合のみ 2 round 目を許容します。"));
+  assert.ok(core.includes("semantic discovery（1 round）"));
 
   // Observed evidence stays a general principle, not a permanent provider rule
-  assert.ok(flat.includes("expected trigger behavior は completion evidence と同義ではありません。"));
+  assert.ok(containsText(core, "expected trigger behavior は completion evidence と同義ではありません。"));
   assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
 
   // The generated consumer adapter must be self-contained: it must not reference
   // Foundation-repo-only skill paths that are never distributed to the consumer.
-  assert.ok(core.includes("実行手順（review skill）は Foundation リポジトリ側に別途保持し、"));
+  assert.ok(containsText(core, "実行手順（review skill）は Foundation リポジトリ側に別途保持し、"));
   assert.doesNotMatch(core, /skills\/review-code\.md|skills\/review-doc\.md/);
 });
 
 test("review skills document procedure without duplicating normative rules", async () => {
-  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
   const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
   const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
 
@@ -126,43 +149,61 @@ test("review skills document procedure without duplicating normative rules", asy
       /"target_sha": "\.\.\."/,
       "skill must not duplicate the Acquisition & Validity record schema from policy",
     );
+    // Neither skill restates the drip-fix prohibition; both defer to Resolution Contract.
+    assert.doesNotMatch(skill, /drip fix/, "skill must reference Resolution Contract instead of restating drip fix");
   }
 
-  // review-code.md covers the code review procedure and manual adapter boundary
+  // review-code.md covers the code review procedure, including the closure validity
+  // gate before merge and the manual adapter boundary
   for (const phrase of [
     "Freeze candidate SHA",
+    "Selection",
+    "Execution",
     "Deterministic verify",
     "Targeted closure",
+    "Closure Acquisition & Validity",
+    "Merge",
     "Adapter boundary",
     "Manual review pilot",
   ]) {
     assert.ok(reviewCode.includes(phrase), `review-code.md missing: ${phrase}`);
   }
-  assert.match(reviewCode, /Claude.*Codex.*CodeRabbit/);
+  assert.ok(containsText(reviewCode, "Claude / Codex / CodeRabbit"));
 
-  // A SHA change before discovery validity is established invalidates the run and
-  // requires a re-freeze + re-discovery; a SHA change from an already-accepted fix
-  // must NOT restart discovery from scratch (targeted closure, per the stopping rule).
+  // SHA-change handling during code review: pre-validity change invalidates the run
+  // and re-freezes; a post-discovery fix-driven change proceeds to targeted closure
+  // without restarting discovery from scratch.
   assert.ok(
-    reviewCode.includes(
-      "その review target / run を invalid として扱い、新しい SHA で re-freeze して",
-    ),
+    containsText(reviewCode, "その review target / run を invalid として扱い、新しい SHA で re-freeze して"),
   );
   assert.ok(
-    reviewCode.includes("valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),
+    containsText(reviewCode, "valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),
   );
-  assert.ok(reviewCode.includes("re-freeze はしますが手順を最初からやり直さず、"));
+  assert.ok(containsText(reviewCode, "re-freeze はしますが手順を最初からやり直さず、"));
 
-  // Run state (none/unknown/failure) must be distinguished from a completed run, not
-  // presented as an exhaustive 3-state enum that a successful completion also falls into.
+  // review-code.md must defer to policy Contracts rather than restating their
+  // normative conditions (Fix 2): the specific prohibitions below must not reappear
+  // verbatim in the skill, only a reference to the owning Contract.
   assert.ok(
-    reviewCode.includes("completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ"),
+    !reviewCode.includes("completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ"),
+    "review-code.md must not restate the none/unknown/failure distinction; it must reference the Acquisition & Validity Contract",
   );
+  assert.ok(
+    containsText(reviewCode, "run を completion / validity / `none` / `unknown` / `failure` のいずれかに判定します。"),
+  );
+  assert.ok(
+    !containsText(reviewCode, "behavior / blast radius を materially"),
+    "review-code.md must not restate the discovery round-limit condition; it must reference Review stopping rules",
+  );
+  assert.ok(containsText(reviewCode, "Review stopping rules（`policy/core.md`）に従い"));
+  assert.ok(containsText(reviewCode, "重大 finding を dismiss する際の確認要否は"));
 
-  // review-doc.md covers the normative document review procedure
+  // review-doc.md covers the normative document review procedure, including the new
+  // Selection / Execution steps (Fix 7) and the closure validity gate (Fix 6)
   for (const phrase of [
     "Mechanical check",
-    "Semantic discovery",
+    "Selection",
+    "Execution & Semantic discovery",
     "Acquisition & Validity 確認",
     "Triage",
     "Fix",
@@ -170,14 +211,26 @@ test("review skills document procedure without duplicating normative rules", asy
   ]) {
     assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
   }
-  assert.ok(flatten(reviewDoc).includes("drip fix"));
-
-  // review-doc.md must confirm completion/acquisition/validity before handing findings
-  // to triage, referencing the policy contract rather than restating it.
   assert.ok(
-    reviewDoc.includes("target SHA / range、target artifact set、completion、"),
+    containsText(reviewDoc, "target SHA / range、target artifact set、reviewer / capability を確定します。"),
   );
-  assert.ok(reviewDoc.includes("確認できない run の finding は triage へ進めず、"));
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "Execution Contract に従い reviewer を起動し、trigger 方法と required context を記録した上で、",
+    ),
+  );
+  assert.ok(containsText(reviewDoc, "target SHA / range、target artifact set、"));
+  assert.ok(containsText(reviewDoc, "確認できない run の finding は triage へ進めず、"));
+  assert.ok(
+    containsText(reviewDoc, "closure verification 自体の completion / acquisition / validity も"),
+  );
 
-  assert.ok(core.length > 0);
+  // review-doc.md must not restate the 2nd-discovery-round prohibition verbatim;
+  // it must reference Review stopping rules instead (Fix 2).
+  assert.ok(
+    !reviewDoc.includes("2 回目の full discovery を追加しません"),
+    "review-doc.md must not restate the discovery round-limit condition; it must reference Review stopping rules",
+  );
+  assert.ok(containsText(reviewDoc, "round 数の扱いは Review stopping rules（`policy/core.md`）に従います。"));
 });

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -264,9 +264,29 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
   assert.ok(containsText(reviewDoc, "target SHA / range、target artifact set、"));
-  assert.ok(containsText(reviewDoc, "確認できない run の finding は triage へ進めず、"));
+
+  // Only valid runs' findings may reach triage; invalid/unknown/failure runs must not,
+  // matching review-code.md's "valid な run から finding を集約し" gate (Fix, Codex P2).
+  assert.ok(
+    !containsText(reviewDoc, "確認できない run の finding は triage へ進めず、"),
+    "review-doc.md must gate on valid (not just 'confirmable'), since invalid is a determinate Validity outcome, not an inability to confirm",
+  );
+  assert.ok(containsText(reviewDoc, "valid な run の finding だけを triage へ進めます。"));
+  assert.ok(containsText(reviewDoc, "invalid / unknown / failure な run の finding は triage に使用しません。"));
+
   assert.ok(
     containsText(reviewDoc, "closure verification 自体の completion / acquisition / validity も"),
+  );
+
+  // Closure must not unconditionally forbid further discovery; the round-limit
+  // condition (material behavior/blast-radius change) belongs to Review stopping
+  // rules and must not be re-copied into the skill (Fix, Codex P2).
+  assert.ok(
+    !containsText(reviewDoc, "full な再 discovery はしません"),
+    "review-doc.md's Closure step must not unconditionally forbid further discovery; it must defer to Review stopping rules",
+  );
+  assert.ok(
+    containsText(reviewDoc, "追加 discovery の要否は Review stopping rules（`policy/core.md`）に従います。"),
   );
 
   // review-doc.md must not restate the 2nd-discovery-round prohibition verbatim;

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -273,6 +273,17 @@ test("review skills document procedure without duplicating normative rules", asy
   );
   assert.ok(containsText(reviewCode, "確認できなければ merge せず、その後の扱いは Failure / retry"));
 
+  // Finding 1 (Codex P1): only a Step 7 batch-fix-driven SHA change may take the
+  // targeted-closure-only path; any other SHA change (parallel work, scope
+  // addition, unrelated commits) routes back through Step 2's invalidate/re-freeze/
+  // re-discovery handling instead of a separate SHA-change rule.
+  assert.ok(
+    containsText(reviewCode, "手順 7 の batch fix 以外の理由で candidate SHA が変わった場合"),
+  );
+  assert.ok(
+    containsText(reviewCode, "手順 7 の batch fix によって candidate SHA が変更された場合のみ"),
+  );
+
   // review-doc.md covers the normative document review procedure, including the new
   // Selection / Execution steps (Fix 7) and the closure validity gate (Fix 6)
   for (const phrase of [
@@ -311,6 +322,23 @@ test("review skills document procedure without duplicating normative rules", asy
 
   assert.ok(
     containsText(reviewDoc, "closure verification 自体の completion / acquisition / validity も"),
+  );
+
+  // Finding 2 (Codex P1): a fix that changes target SHA / range re-freezes the
+  // closure target and applies Selection / Execution Contract to the closure
+  // review run, so closure validity is judged against the post-fix target instead
+  // of the pre-fix expected target from Step 2's Selection.
+  assert.ok(
+    containsText(reviewDoc, "修正後の SHA / range を closure target として re-freeze し、"),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "Selection / Execution Contract（`policy/core.md`）を closure review run に適用します。",
+    ),
+  );
+  assert.ok(
+    containsText(reviewDoc, "この closure target を expected target として Acquisition & Validity"),
   );
 
   // review-doc.md must not restate the 2nd-discovery-round prohibition verbatim;

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -392,11 +392,22 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // SHA-change handling during code review: pre-validity change invalidates the run
-  // and re-freezes; a post-discovery fix-driven change proceeds to targeted closure
-  // without restarting discovery from scratch.
+  // SHA-change handling during code review: a pre-validity or post-valid-discovery
+  // non-fix change does not retroactively invalidate the old run's own Validity —
+  // it only stops that run from being used as evidence for the new target,
+  // matching review-doc.md's wording. A post-discovery fix-driven change proceeds
+  // to targeted closure without restarting discovery from scratch.
   assert.ok(
-    containsText(reviewCode, "その review target / run を invalid として扱います。"),
+    countOccurrences(
+      reviewCode,
+      "旧 review target / run を現在 target の evidence として扱いません。",
+    ) === 2,
+    "review-code.md must not retroactively mark a run's own Validity invalid on a candidate SHA change; it must state the run is no longer usable as evidence for the new target",
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /review target \/ run を invalid として扱い/,
+    "review-code.md must not conflate a target change with retroactively invalidating the prior run's own Validity",
   );
   assert.ok(
     containsText(reviewCode, "valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -168,9 +168,44 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "accepted finding の batch fix によって candidate SHA が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認してから merge します。",
+      "accepted finding の batch fix によって candidate SHA が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
     ),
   );
+
+  // Root cause A (closure findings need Resolution too): completed + valid closure
+  // runs still gate on Resolution before merge/completion, in both artifacts, using
+  // the existing Resolution Contract rather than a new Closure Resolution Contract.
+  assert.ok(
+    containsText(
+      core,
+      "targeted closure / closure verification の finding も Resolution Contract の対象であり、Resolution が完了するまで merge / review completion の根拠にしない",
+    ),
+  );
+  assert.ok(core.includes("closure finding の Resolution"));
+  assert.ok(
+    containsText(
+      core,
+      "targeted closure の finding も Resolution Contract の対象とし、Resolution が完了するまで merge しません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "closure verification の finding も Resolution Contract の対象とし、Resolution が完了するまで review を完了しません。",
+    ),
+  );
+
+  // Root cause B (precondition target-binding): precondition evidence used as
+  // review/closure/merge grounds must match the confirmed (frozen/Selected)
+  // target, not just "not stale after a later mutation."
+  assert.ok(
+    containsText(
+      core,
+      "review / closure / merge の根拠として使う precondition evidence は、review 対象として確定した（freeze / Selection された）target と一致していなければなりません。",
+    ),
+  );
+  assert.ok(core.includes("verify target と freeze target の consistency 確認"));
+  assert.ok(core.includes("mechanical check target と Selection target の consistency 確認"));
   // Canonical policy: no accepted fix + no SHA change completes via the required
   // review count's valid discovery + Resolution, with no new closure run required
   // (matches skills/review-code.md's existing Executable procedure).
@@ -251,6 +286,7 @@ test("review skills document procedure without duplicating normative rules", asy
     "Deterministic verify",
     "Targeted closure",
     "Closure Acquisition & Validity",
+    "Closure Resolution",
     "Merge",
     "Adapter boundary",
     "Manual review pilot",
@@ -258,6 +294,35 @@ test("review skills document procedure without duplicating normative rules", asy
     assert.ok(reviewCode.includes(phrase), `review-code.md missing: ${phrase}`);
   }
   assert.ok(containsText(reviewCode, "Claude / Codex / CodeRabbit"));
+
+  // Root cause A, cell A (Code): a completed + valid closure run with findings
+  // still gates on Resolution before merge; an accepted closure finding loops back
+  // through the existing batch-fix/verify/closure procedure, not a new loop design.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "targeted closure の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は merge しません。",
+    ),
+  );
+  assert.ok(containsText(reviewCode, "accepted な closure finding があれば、手順 7〜10 と同じ procedure"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "変更されていれば、Closure Acquisition & Validity と Closure Resolution が完了した時点で merge します。",
+    ),
+  );
+
+  // Root cause B, cells E/F (Code): the deterministic verify target captured at
+  // Step 1 must match the frozen candidate SHA at Step 2; a mismatch (a race
+  // between verify start and freeze) re-runs verify against the frozen SHA rather
+  // than carrying over evidence for a different target.
+  assert.ok(containsText(reviewCode, "その時点の candidate SHA を記録した上で"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致することを確認します。一致しない場合は、freeze した SHA に対して手順 1 の deterministic verify を再実行し、成功してから先へ進みます。",
+    ),
+  );
 
   // SHA-change handling during code review: pre-validity change invalidates the run
   // and re-freezes; a post-discovery fix-driven change proceeds to targeted closure
@@ -387,6 +452,7 @@ test("review skills document procedure without duplicating normative rules", asy
     "Triage",
     "Fix",
     "Closure",
+    "Closure Resolution",
   ]) {
     assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
   }
@@ -394,6 +460,35 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(
       reviewDoc,
       "target SHA / range、target artifact set、reviewer / capability、required review 数を確定します。",
+    ),
+  );
+
+  // Root cause A, cell B (Normative): a completed + valid closure run with
+  // findings still gates on Resolution before completion; an accepted closure
+  // finding loops back through the existing fix/mechanical-check/closure
+  // procedure, and this step does not apply when Step 7's closure never fired.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "closure verification（手順 7）の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は review procedure を完了としません。",
+    ),
+  );
+  assert.ok(containsText(reviewDoc, "accepted な closure finding があれば、手順 6〜7 と同じ procedure"));
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "手順 7 の closure が行われなかった場合（accepted fix が無く target も変更されていない場合）、この手順は不要です。",
+    ),
+  );
+
+  // Root cause B, cells G/H (Normative): the mechanical check target captured at
+  // Step 1 must match the target confirmed at Step 2's Selection; a mismatch
+  // re-runs mechanical check against the confirmed target.
+  assert.ok(containsText(reviewDoc, "その時点の target SHA / range を記録した上で"));
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "手順 1 で記録した mechanical check 対象の target と、ここで確定する target が一致することを確認します。一致しない場合は、確定した target に対して手順 1 の mechanical check を再実行してから先へ進みます。",
     ),
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -384,12 +384,9 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
   assert.ok(
-    containsText(reviewCode, "accepted な closure finding があれば、手順 7・8・10・11 と同じ"),
-  );
-  assert.ok(
     containsText(
       reviewCode,
-      "second full discovery はこの経路には含みません",
+      "accepted な closure finding があれば、手順 7 と同じ batch fix semantics でまとめて fix し、手順 8 と同じ deterministic verify を行います。",
     ),
   );
   assert.ok(
@@ -398,6 +395,25 @@ test("review skills document procedure without duplicating normative rules", asy
       "Closure Acquisition & Validity と Closure Resolution が完了した時点で merge します。",
     ),
   );
+
+  // Follow-up (sibling gap B): a closure finding's fix may now re-enter the
+  // optional Step 9 (2nd full discovery) if it's the first material fix in this
+  // review flow, reusing the same materiality-only, not origin-stage-specific,
+  // exception. If Step 9 was already used and another round is still needed, the
+  // flow escalates instead of silently completing via targeted closure alone.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この review flow で手順 9 をまだ使っておらず、2nd full discovery が必要と判断される場合は、手順 9 へ進み、完了後に手順 10 へ進みます。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "手順 9 を既に使っており、なお追加の full discovery が必要と判断される場合は、3rd full discovery は起動せず merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.ok(containsText(reviewCode, "追加の full discovery が不要な場合は、手順 10 へ進みます。"));
 
   // Gap fix: a repeating closure-finding cycle connects to the existing Review
   // stopping rules (upstream instability / escalate) instead of looping
@@ -557,13 +573,29 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "最終的な post-fix SHA を closure target として re-freeze し、Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
+      "最終的な post-fix SHA を closure target として re-freeze し、直近の successful deterministic verify target との consistency を確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
     ),
   );
   assert.ok(
     containsText(
       reviewCode,
       "この closure target を expected target として、targeted closure の review run に手順 5 と同じ Acquisition & Validity Contract を適用し",
+    ),
+  );
+
+  // Sibling gap A (Step 10): a mismatch between the closure target and the latest
+  // successful deterministic verify target must not carry over stale verify
+  // evidence — it re-runs verify against the confirmed closure target instead.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "一致しない場合は、その verify evidence を使わず、確定した closure target に対して deterministic verify を行い、成功したら re-freeze します。",
     ),
   );
 
@@ -577,6 +609,16 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(
       reviewCode,
       "Review stopping rules（`policy/core.md`）に従って 2nd full discovery が必要と判断された場合のみ、targeted closure の前に行います。",
+    ),
+  );
+  // Sibling gap A (Step 9): re-freezing the second discovery target is bound to
+  // the latest successful deterministic verify target, not entry-point-specific
+  // (works whether Step 9 is reached from Step 8 or looped back into from Step
+  // 12); a mismatch discards the stale verify evidence and re-verifies.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "直近の successful deterministic verify target を second discovery target として re-freeze し、consistency を確認します。一致しない場合は、その verify evidence を使わず、確定した second discovery target に対して deterministic verify を行い、成功したら re-freeze して Selection / Execution へ進みます。",
     ),
   );
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -278,17 +278,6 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewDoc, "closure verification 自体の completion / acquisition / validity も"),
   );
 
-  // Closure must not unconditionally forbid further discovery; the round-limit
-  // condition (material behavior/blast-radius change) belongs to Review stopping
-  // rules and must not be re-copied into the skill (Fix, Codex P2).
-  assert.ok(
-    !containsText(reviewDoc, "full な再 discovery はしません"),
-    "review-doc.md's Closure step must not unconditionally forbid further discovery; it must defer to Review stopping rules",
-  );
-  assert.ok(
-    containsText(reviewDoc, "追加 discovery の要否は Review stopping rules（`policy/core.md`）に従います。"),
-  );
-
   // review-doc.md must not restate the 2nd-discovery-round prohibition verbatim;
   // it must reference Review stopping rules instead (Fix 2).
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -611,15 +611,23 @@ test("review skills document procedure without duplicating normative rules", asy
       "Review stopping rules（`policy/core.md`）に従って 2nd full discovery が必要と判断された場合のみ、targeted closure の前に行います。",
     ),
   );
-  // Sibling gap A (Step 9): re-freezing the second discovery target is bound to
-  // the latest successful deterministic verify target, not entry-point-specific
-  // (works whether Step 9 is reached from Step 8 or looped back into from Step
-  // 12); a mismatch discards the stale verify evidence and re-verifies.
+  // Sibling gap A (Step 9), direction fix: the *current* post-fix SHA is frozen
+  // as the second discovery target, then checked against the latest successful
+  // deterministic verify target (matching Step 10's direction) — not the other
+  // way around, which would freeze a stale verify target and miss a candidate
+  // that advanced further before Step 9 ran. Not entry-point-specific (works
+  // whether Step 9 is reached from Step 8 or looped back into from Step 12); a
+  // mismatch discards the stale verify evidence and re-verifies.
   assert.ok(
     containsText(
       reviewCode,
-      "直近の successful deterministic verify target を second discovery target として re-freeze し、consistency を確認します。一致しない場合は、その verify evidence を使わず、確定した second discovery target に対して deterministic verify を行い、成功したら re-freeze して Selection / Execution へ進みます。",
+      "現在の post-fix SHA を second discovery target として re-freeze し、直近の successful deterministic verify target との consistency を確認します。一致しない場合は、その verify evidence を使わず、確定した second discovery target に対して deterministic verify を行い、成功したら re-freeze して Selection / Execution へ進みます。",
     ),
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /直近の successful deterministic verify target を second discovery\s*target として re-freeze/,
+    "Step 9 item 1 must not freeze the latest verify target itself as the second discovery target; it must freeze the current post-fix SHA and check it against the latest verify target",
   );
   assert.ok(
     containsText(reviewCode, "Selection Contract をこの second discovery stage へ適用します。"),

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -277,6 +277,25 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "review / closure / merge の根拠として使う precondition evidence は、review 対象として確定した（freeze / Selection された）target と一致していなければなりません。",
     ),
   );
+
+  // Range-only target change (Codex P1, commit range for Executable): a commit
+  // range's endpoint moving counts as a target change even if head SHA is
+  // unchanged, so old evidence isn't carried over just because the SHA looks the
+  // same; and the merge-without-closure branch is keyed on the review target
+  // (SHA-and-range), not head SHA alone, so an independent base/range move
+  // cannot slip through as "unchanged."
+  assert.ok(
+    containsText(
+      core,
+      "Selection Contract で commit range を expected target として使う場合、head SHA が不変でも range の endpoint が変われば、それも target の変更です。",
+    ),
+  );
+  assert.ok(core.includes("-> accepted fix が無く review target が変更されていない場合:"));
+  assert.doesNotMatch(
+    core,
+    /accepted fix が無く candidate SHA が変更されていない場合/,
+    "the merge-without-closure branch must key on review target (SHA-and-range), not head SHA alone, or an independent range move could read as unchanged",
+  );
   assert.ok(core.includes("verify target と freeze target の consistency 確認"));
   assert.ok(core.includes("mechanical check target と Selection target の consistency 確認"));
   // Canonical policy: no accepted fix + no SHA change completes via the required
@@ -285,7 +304,7 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "accepted fix が無く candidate SHA が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
+      "accepted fix が無く review target が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
     ),
   );
   assert.ok(containsText(core, "full discovery は原則 1 round です。"));
@@ -373,6 +392,40 @@ test("review skills document procedure without duplicating normative rules", asy
     assert.ok(reviewCode.includes(phrase), `review-code.md missing: ${phrase}`);
   }
   assert.ok(containsText(reviewCode, "Claude / Codex / CodeRabbit"));
+
+  // Commit range as review target (Codex P1): review target is SHA and,
+  // applicable, commit range, per Selection Contract's own field name — not
+  // reduced to head SHA alone, so a range-only mutation (e.g. base moving) is
+  // covered by the same target mutation semantics as a SHA change.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "review target は Selection Contract に従い、candidate SHA と、applicable な場合は commit range を含みます。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "commit range を review target として使う場合は、対象となる range も同時に freeze し、以降 SHA について述べる target mutation semantics を range にも同じ意味で適用します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "expected target SHA / applicable な commit range を決めます。",
+    ),
+  );
+
+  // A mixed change (accepted-fix-driven head move plus an independently moved
+  // range endpoint) is not closure-eligible for the independent portion — it
+  // routes through Step 2's existing non-fix mutation semantics instead of a new
+  // change-origin taxonomy.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint が accepted fix と無関係に変わった場合）、その独立した変更分は手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。",
+    ),
+  );
 
   // Root cause A, cell A (Code): a completed + valid closure run with findings
   // still gates on Resolution before merge; an accepted closure finding loops back

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -211,11 +211,32 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(core.includes("closure completion / acquisition / validity 確認"));
   // Finding 1: the Code accepted-fix branch re-applies Selection/Execution to the
   // closure target before targeted closure runs.
+  assert.ok(core.includes("closure target の Selection / Execution"));
+  assert.ok(core.includes("-> targeted closure"));
+
+  // Codex P2 (route a material fix through a full 2nd discovery): an optional 2nd
+  // full discovery, gated by the same material-fix condition Review stopping
+  // rules already define, sits between the post-fix deterministic verify and
+  // closure target Selection/Execution — reusing the same discovery Contracts,
+  // not a new Second Discovery Contract or round-counter schema.
   assert.ok(
     containsText(
       core,
-      "deterministic verify -> closure target の Selection / Execution -> targeted closure",
+      "deterministic verify -> fix が behavior / blast radius を materially 変えた場合のみ:",
     ),
+  );
+  assert.ok(core.includes("second discovery target の Selection / Execution"));
+  assert.ok(core.includes("full discovery（2nd round、独立 reviewer）"));
+  assert.ok(
+    containsText(
+      core,
+      "required review 数の valid run 確認 -> aggregate / triage -> accepted finding があれば batch fix -> target が変われば deterministic verify",
+    ),
+  );
+  assert.doesNotMatch(
+    core,
+    /discovery_round|round counter|Second Discovery Contract/,
+    "policy/core.md must not introduce a new round-counter schema or a Second Discovery Contract",
   );
   assert.ok(
     containsText(
@@ -362,11 +383,19 @@ test("review skills document procedure without duplicating normative rules", asy
       "targeted closure の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は merge しません。",
     ),
   );
-  assert.ok(containsText(reviewCode, "accepted な closure finding があれば、手順 7〜10 と同じ procedure"));
+  assert.ok(
+    containsText(reviewCode, "accepted な closure finding があれば、手順 7・8・10・11 と同じ"),
+  );
   assert.ok(
     containsText(
       reviewCode,
-      "変更されていれば、Closure Acquisition & Validity と Closure Resolution が完了した時点で merge します。",
+      "second full discovery はこの経路には含みません",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Closure Acquisition & Validity と Closure Resolution が完了した時点で merge します。",
     ),
   );
 
@@ -471,10 +500,27 @@ test("review skills document procedure without duplicating normative rules", asy
   // Root cause 2: closure (targeted closure / Closure Acquisition & Validity) is
   // required only when the candidate SHA actually changed, not unconditionally.
   assert.ok(containsText(reviewCode, "candidate SHA が変更された場合のみ"));
+
+  // Sibling gap fix: the closure predicate is stabilized to "did this review flow
+  // ever have an accepted-fix-driven target change" (including via the optional
+  // 2nd discovery), not "did Step 7's SHA change specifically" — so a 2nd
+  // discovery with zero accepted findings still requires targeted closure for the
+  // first accepted fix, and merge without closure still requires no target change
+  // at all across the whole flow.
+  assert.ok(
+    countOccurrences(
+      reviewCode,
+      "この review flow で accepted finding の fix によって target が変更された場合のみ",
+    ) === 2,
+    "review-code.md's Targeted closure and Closure Acquisition & Validity steps must gate on whether this review flow ever had an accepted-fix-driven target change, not just Step 7's own SHA change",
+  );
+  assert.ok(
+    containsText(reviewCode, "手順 9 の second full discovery を挟んだ場合を含む"),
+  );
   assert.ok(
     containsText(
       reviewCode,
-      "candidate SHA が変更されていなければ、required review 数の valid discovery と Resolution が完了した時点で merge します。",
+      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution が完了した時点で merge します。",
     ),
   );
 
@@ -511,7 +557,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "修正後の SHA を closure target として re-freeze し、Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
+      "最終的な post-fix SHA を closure target として re-freeze し、Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
     ),
   );
   assert.ok(
@@ -519,6 +565,64 @@ test("review skills document procedure without duplicating normative rules", asy
       reviewCode,
       "この closure target を expected target として、targeted closure の review run に手順 5 と同じ Acquisition & Validity Contract を適用し",
     ),
+  );
+
+  // Codex P2 (route a material fix through a full 2nd discovery): Step 9 is an
+  // optional, policy-gated 2nd full discovery inserted before targeted closure,
+  // reusing the same Selection / Execution / Acquisition & Validity / Resolution
+  // Contracts and the required-review-count gate as the first discovery — not a
+  // new Second Discovery Contract or schema.
+  assert.ok(reviewCode.includes("Second full discovery"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Review stopping rules（`policy/core.md`）に従って 2nd full discovery が必要と判断された場合のみ、targeted closure の前に行います。",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "Selection Contract をこの second discovery stage へ適用します。"),
+  );
+  assert.ok(
+    containsText(reviewCode, "Execution Contract に従って full discovery（独立 reviewer）を"),
+  );
+  assert.ok(
+    containsText(reviewCode, "Acquisition & Validity Contract をこの discovery run に適用します。"),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Selection で required とした review 数ぶんの valid run が揃うまで triage へ進みません。揃わない run の扱いは Failure / retry",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "accepted finding があれば、手順 7 と同じ batch fix semantics で"),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "その fix によって target が変わった場合、手順 8 と同じ",
+    ),
+  );
+  // Non-fix target mutation inside the 2nd discovery reuses Step 2's semantics
+  // rather than a Second-Discovery-specific mutation rule.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "accepted fix 以外の理由で target が変わった場合は、手順 2 と同じ target-specific evidence の扱いに従います。",
+    ),
+  );
+  // A 3rd full discovery is never triggered; the flow escalates instead, per the
+  // existing Review stopping rules (no new retry counter or round-limit schema).
+  assert.ok(
+    containsText(
+      reviewCode,
+      "3rd full discovery は起動せず merge もせず、Review stopping rules（`policy/core.md`）に従って upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /discovery_round|round counter|Second Discovery Contract/,
+    "review-code.md must not introduce a new round-counter schema or a Second Discovery Contract",
   );
 
   // Finding 3 (Code): Selection Contract's required review count gates closure

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -153,12 +153,35 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "targeted closure の review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認してから merge します。",
+      "accepted finding の batch fix によって candidate SHA が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認してから merge します。",
+    ),
+  );
+  // Canonical policy: no accepted fix + no SHA change completes via the required
+  // review count's valid discovery + Resolution, with no new closure run required
+  // (matches skills/review-code.md's existing Executable procedure).
+  assert.ok(
+    containsText(
+      core,
+      "accepted fix が無く candidate SHA が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
     ),
   );
   assert.ok(containsText(core, "full discovery は原則 1 round です。"));
   assert.ok(containsText(core, "materially 変えた場合のみ 2 round 目を許容します。"));
   assert.ok(core.includes("semantic discovery（1 round）"));
+  // Canonical policy: Normative closure is likewise conditioned on an accepted-fix
+  // target change, not unconditional (matches skills/review-doc.md's procedure).
+  assert.ok(
+    containsText(
+      core,
+      "accepted finding の fix によって target SHA / range が変更された場合のみ closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "accepted fix が無く target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
+    ),
+  );
 
   // Observed evidence stays a general principle, not a permanent provider rule
   assert.ok(containsText(core, "expected trigger behavior は completion evidence と同義ではありません。"));

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -454,7 +454,36 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   );
   assert.ok(containsText(core, "full discovery は原則 1 round です。"));
   assert.ok(containsText(core, "materially 変えた場合のみ 2 round 目を許容します。"));
+
+  // Codex P1 (stop merge after a materially-changing 2nd discovery fix): the
+  // canonical Code review diagram now re-evaluates materiality after the 2nd
+  // discovery's own accepted-finding fix, not just before entering 2nd
+  // discovery — a further material change stops at escalation, not merge.
+  assert.ok(
+    containsText(
+      core,
+      "-> target が変われば deterministic verify -> この fix でさらに追加の full discovery が必要と判断される場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する -> closure target の Selection / Execution",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "2nd discovery の accepted finding を fix した後も、その fix が behavior / blast radius をさらに materially 変えた場合は、3rd full discovery を起動せず、targeted closure だけで merge へ進まず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.doesNotMatch(
+    core,
+    /4th full discovery|third full discovery|discovery_round|round counter|Materiality Contract/i,
+    "must not introduce a 3rd discovery phase, round counter, or a new Materiality Contract",
+  );
+
+  // Normative must stay unchanged by this fix: no 2nd semantic discovery round.
   assert.ok(core.includes("semantic discovery（1 round）"));
+  assert.doesNotMatch(
+    core,
+    /semantic discovery（2nd round）|2nd semantic discovery/,
+    "Normative document review must not gain a 2nd semantic discovery round",
+  );
   // Canonical policy: Normative closure is likewise conditioned on an accepted-fix
   // target change, not unconditional (matches skills/review-doc.md's procedure),
   // and re-runs mechanical check against the post-fix target first (Finding 2).

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -361,11 +361,63 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   // Codex P1 (resolve discovery findings before merge, Code flow): the
   // accepted-fix diagram branch now requires required discovery stage(s)'
   // Resolution to complete, not just closure Resolution, before merge.
+  assert.ok(core.includes("required discovery stage(s) の Resolution 完了"));
   assert.ok(
     containsText(
       core,
-      "-> closure finding の Resolution -> required discovery stage(s) の Resolution 完了 -> merge",
+      "closure finding の Resolution -> accepted closure finding があれば:",
     ),
+  );
+
+  // Codex P1 (re-evaluate materiality of closure fixes): an accepted closure
+  // finding's fix re-enters Review stopping rules — routing to an unused 2nd
+  // discovery if needed, to escalation (no 3rd discovery, no merge) if 2nd was
+  // already used and still insufficient, or back to targeted closure if the
+  // fix wasn't material — instead of falling straight through to merge.
+  assert.ok(
+    containsText(
+      core,
+      "accepted closure finding があれば: batch fix -> deterministic verify -> Review stopping rules の再評価",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "2nd full discovery 未使用かつ必要な場合: second discovery target の Selection / Execution から上記の full discovery route へ進み、完了後 targeted closure を再実行する",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "2nd full discovery 使用済みでなお必要な場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "追加の full discovery が不要な場合: targeted closure を再実行する",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "targeted closure の finding に accepted fix がある場合も、fix 後の deterministic verify を経て Review stopping rules を再評価します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "2nd full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後に targeted closure をやり直します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "2nd full discovery を使用済みでなお full discovery が必要なら、3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.ok(
+    containsText(core, "追加の full discovery が不要なら、targeted closure をやり直します。"),
   );
   assert.ok(
     containsText(
@@ -473,7 +525,7 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   );
   assert.doesNotMatch(
     core,
-    /4th full discovery|third full discovery|discovery_round|round counter|Materiality Contract/i,
+    /4th full discovery|third full discovery|discovery_round|round counter|Materiality Contract|Closure Materiality Contract/i,
     "must not introduce a 3rd discovery phase, round counter, or a new Materiality Contract",
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -76,6 +76,39 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     ),
   );
 
+  // Codex P1 (resolve discovery findings before merge): the discovery
+  // Resolution gate is stage-independent — accepted-fix paths don't drop it,
+  // multiple discovery stages (e.g. 2nd full discovery) each need their own
+  // Resolution complete, and completion order vs. closure isn't mandated.
+  assert.ok(
+    containsText(
+      core,
+      "Selection Contract で required とした review stage（discovery、2nd full discovery を含む）の finding は、その stage で accepted fix があったかどうかに関係なく、Resolution Contract に従って Resolution が完了するまで merge / review completion へ進みません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "同じ review flow で複数の discovery stage を行った場合は、実行した discovery stage すべての Resolution が完了している必要があります。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "discovery Resolution を closure より先に完了させる順序を強制するものではなく、merge / review completion の時点で揃っていれば十分です。",
+    ),
+  );
+  assert.doesNotMatch(
+    core,
+    /Discovery Resolution Contract|discovery_resolved|resolution_state/i,
+    "policy/core.md must not introduce a new Discovery Resolution Contract or Resolution state schema",
+  );
+  assert.doesNotMatch(
+    core,
+    /discovery.{0,20}Resolution.{0,30}(完了|終わ).{0,10}(から|前提).{0,10}closure|closure.{0,10}を開始できません/,
+    "this fix is a merge/completion gate, not a new precondition for starting closure",
+  );
+
   // Codex P2 (pass the selected commit range to Execution): Execution Contract's
   // target field is bound to Selection's expected target (SHA or commit range),
   // not reduced to a bare "target SHA" that Selection's range would silently
@@ -298,7 +331,17 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "targeted closure / closure verification の finding も Resolution Contract の対象であり、Resolution が完了するまで merge / review completion の根拠にしない",
+      "discovery（2nd full discovery を含む）と targeted closure / closure verification のいずれの finding も Resolution Contract の対象であり、triage category を付けただけでは Resolution 完了ではない。",
+    ),
+  );
+
+  // Codex P1 (resolve discovery findings before merge): triage alone is not
+  // Resolution completion — an unresolved needs-verification / technical-dispute
+  // / intent-question finding blocks that stage's Resolution, no new state enum.
+  assert.ok(
+    containsText(
+      core,
+      "unresolved の finding（未解決の needs-verification / technical-dispute / intent-question 等を含む）が残る間は、その review stage の Resolution は完了せず、merge / review completion の根拠にしない",
     ),
   );
   assert.ok(core.includes("closure finding の Resolution"));
@@ -312,6 +355,37 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     containsText(
       core,
       "closure verification の finding も Resolution Contract の対象とし、Resolution が完了するまで review を完了しません。",
+    ),
+  );
+
+  // Codex P1 (resolve discovery findings before merge, Code flow): the
+  // accepted-fix diagram branch now requires required discovery stage(s)'
+  // Resolution to complete, not just closure Resolution, before merge.
+  assert.ok(
+    containsText(
+      core,
+      "-> closure finding の Resolution -> required discovery stage(s) の Resolution 完了 -> merge",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "targeted closure の Resolution に加えて、この review flow で実行した discovery stage（2nd full discovery を含む）すべての Resolution が完了していることも merge の条件です。完了順序は問いません。",
+    ),
+  );
+
+  // Codex P1 (resolve discovery findings before merge, Normative flow): same
+  // gate for semantic discovery Resolution before review completion.
+  assert.ok(
+    containsText(
+      core,
+      "-> closure finding の Resolution -> semantic discovery の Resolution 完了 -> 完了",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "closure verification の Resolution に加えて、semantic discovery（手順 3）の Resolution が完了していることも review completion の条件です。完了順序は問いません。",
     ),
   );
 
@@ -574,8 +648,15 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "Closure Acquisition & Validity と Closure Resolution が完了した時点で merge します。",
+      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution が完了した時点で merge します。",
     ),
+  );
+
+  // Codex P1 (resolve discovery findings before merge): the discovery Resolution
+  // gate isn't dropped when the accepted-fix path is taken — merge requires both
+  // discovery and closure Resolution, in either order, not closure alone.
+  assert.ok(
+    containsText(reviewCode, "discovery Resolution と closure の完了順序は問いません。"),
   );
 
   // Follow-up (sibling gap B): a closure finding's fix may now re-enter the
@@ -718,7 +799,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution が完了した時点で merge します。",
+      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge します。",
     ),
   );
 
@@ -923,6 +1004,16 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
   assert.ok(containsText(reviewDoc, "accepted な closure finding があれば、手順 6〜7 と同じ procedure"));
+
+  // Codex P1 (resolve discovery findings before merge, Normative sibling):
+  // closure Resolution completing doesn't drop the semantic discovery (Step 5)
+  // Resolution gate — review procedure completion requires both, in either order.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "closure Resolution に加えて、手順 5 の semantic discovery Resolution も完了していることが review procedure 完了の条件です。完了順序は問いません。",
+    ),
+  );
   assert.ok(
     containsText(
       reviewDoc,

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -16,6 +16,21 @@ function containsText(haystack, needle) {
   return stripWhitespace(haystack).includes(stripWhitespace(needle));
 }
 
+// Counts non-overlapping occurrences, whitespace-agnostic. Used where the same
+// precondition-recheck clause must appear once per applicable branch.
+function countOccurrences(haystack, needle) {
+  const hay = stripWhitespace(haystack);
+  const need = stripWhitespace(needle);
+  if (!need) return 0;
+  let count = 0;
+  let index = 0;
+  while ((index = hay.indexOf(need, index)) !== -1) {
+    count += 1;
+    index += need.length;
+  }
+  return count;
+}
+
 test("core policy defines the provider-neutral Review Protocol", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
@@ -248,12 +263,24 @@ test("review skills document procedure without duplicating normative rules", asy
   // and re-freezes; a post-discovery fix-driven change proceeds to targeted closure
   // without restarting discovery from scratch.
   assert.ok(
-    containsText(reviewCode, "その review target / run を invalid として扱い、新しい SHA で re-freeze して"),
+    containsText(reviewCode, "その review target / run を invalid として扱います。"),
   );
   assert.ok(
     containsText(reviewCode, "valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),
   );
   assert.ok(containsText(reviewCode, "re-freeze はしますが手順を最初からやり直さず、"));
+
+  // Gap 1 (same root cause as the canonical invariant, completed): a SHA change
+  // before discovery completion/validity is confirmed must also re-run Step 1's
+  // deterministic verify against the new SHA before re-freezing — not just the
+  // post-valid-discovery non-fix change case.
+  assert.ok(
+    countOccurrences(
+      reviewCode,
+      "新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら",
+    ) === 2,
+    "review-code.md must re-run deterministic verify on SHA change both before and after discovery validity is confirmed",
+  );
 
   // review-code.md must defer to policy Contracts rather than restating their
   // normative conditions (Fix 2): the specific prohibitions below must not reappear
@@ -326,16 +353,6 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewCode, "手順 7 の batch fix によって candidate SHA が変更された場合のみ"),
   );
 
-  // Root cause fix (this round, cell B): a non-fix SHA change must re-run Step 1's
-  // deterministic verify against the new SHA before re-freezing, since mechanical/
-  // deterministic precondition evidence does not carry over across a target change.
-  assert.ok(
-    containsText(
-      reviewCode,
-      "新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら",
-    ),
-  );
-
   // 2x2 cell A (Executable x accepted fix): deterministic verify runs against the
   // post-fix SHA before targeted closure (pre-existing, unaffected by this round);
   // closure re-freezes the post-fix SHA as the closure target and applies
@@ -397,14 +414,16 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // Root cause fix (this round, cell D): a non-fix target change must also re-run
-  // Step 1's mechanical check against the new target before re-freezing, matching
-  // review-code.md's cell B fix.
+  // Gap 2 (same root cause as the canonical invariant, completed): a target change
+  // before semantic discovery completion/validity is confirmed must also re-run
+  // Step 1's mechanical check against the new target — not just the
+  // post-valid-discovery non-fix change case (cell D).
   assert.ok(
-    containsText(
+    countOccurrences(
       reviewDoc,
       "新しい target に対して手順 1 の mechanical check を再実行し、成功したら",
-    ),
+    ) === 2,
+    "review-doc.md must re-run mechanical check on target change both before and after semantic discovery validity is confirmed",
   );
   assert.ok(
     containsText(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -107,6 +107,11 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   // Observed evidence stays a general principle, not a permanent provider rule
   assert.ok(flat.includes("expected trigger behavior は completion evidence と同義ではありません。"));
   assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+
+  // The generated consumer adapter must be self-contained: it must not reference
+  // Foundation-repo-only skill paths that are never distributed to the consumer.
+  assert.ok(core.includes("実行手順（review skill）は Foundation リポジトリ側に別途保持し、"));
+  assert.doesNotMatch(core, /skills\/review-code\.md|skills\/review-doc\.md/);
 });
 
 test("review skills document procedure without duplicating normative rules", async () => {
@@ -135,11 +140,44 @@ test("review skills document procedure without duplicating normative rules", asy
   }
   assert.match(reviewCode, /Claude.*Codex.*CodeRabbit/);
 
+  // A SHA change before discovery validity is established invalidates the run and
+  // requires a re-freeze + re-discovery; a SHA change from an already-accepted fix
+  // must NOT restart discovery from scratch (targeted closure, per the stopping rule).
+  assert.ok(
+    reviewCode.includes(
+      "その review target / run を invalid として扱い、新しい SHA で re-freeze して",
+    ),
+  );
+  assert.ok(
+    reviewCode.includes("valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),
+  );
+  assert.ok(reviewCode.includes("re-freeze はしますが手順を最初からやり直さず、"));
+
+  // Run state (none/unknown/failure) must be distinguished from a completed run, not
+  // presented as an exhaustive 3-state enum that a successful completion also falls into.
+  assert.ok(
+    reviewCode.includes("completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ"),
+  );
+
   // review-doc.md covers the normative document review procedure
-  for (const phrase of ["Mechanical check", "Semantic discovery", "Triage", "Fix", "Closure"]) {
+  for (const phrase of [
+    "Mechanical check",
+    "Semantic discovery",
+    "Acquisition & Validity 確認",
+    "Triage",
+    "Fix",
+    "Closure",
+  ]) {
     assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
   }
   assert.ok(flatten(reviewDoc).includes("drip fix"));
+
+  // review-doc.md must confirm completion/acquisition/validity before handing findings
+  // to triage, referencing the policy contract rather than restating it.
+  assert.ok(
+    reviewDoc.includes("target SHA / range、target artifact set、completion、"),
+  );
+  assert.ok(reviewDoc.includes("確認できない run の finding は triage へ進めず、"));
 
   assert.ok(core.length > 0);
 });

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -374,6 +374,25 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewDoc, "この closure target を expected target として Acquisition & Validity"),
   );
 
+  // Latent gap (push-before-check E): Closure only fires on an accepted-fix-driven
+  // target change; no accepted fix + no target change completes at Resolution
+  // without requiring a new closure run.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "accepted finding の fix によって target SHA / range が変わった場合のみ行います。",
+    ),
+  );
+  assert.ok(
+    containsText(reviewDoc, "accepted finding の fix が無く target も変更されていない場合"),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "required review 数の valid semantic discovery と Resolution が完了した時点で review procedure を完了とし、新たな closure run を要求しません。",
+    ),
+  );
+
   // review-doc.md must not restate the 2nd-discovery-round prohibition verbatim;
   // it must reference Review stopping rules instead (Fix 2).
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -85,16 +85,42 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(core, "Selection で確定した expected target SHA / commit range"),
   );
-  assert.ok(
-    containsText(
-      core,
-      "Selection Contract で commit range を expected target として選択した場合、Execution ではその selected range を reviewer の trigger へ渡し、実際に渡した target を記録します。head SHA だけへ黙って縮退させません。",
-    ),
-  );
   assert.doesNotMatch(
     core,
     /#### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*target SHA\s*\n/,
     "Execution Contract must not regress to a bare, Selection-unbound 'target SHA' field",
+  );
+
+  // Codex P1 (invalidate discovery on artifact-set-only target changes): the
+  // review target is explicitly defined as the (SHA/range, artifact set)
+  // pair, and the Execution Contract propagates the confirmed artifact set
+  // to the trigger just like the confirmed SHA/range, instead of silently
+  // dropping it.
+  assert.ok(
+    containsText(
+      core,
+      "この節における review target は、Selection Contract で確定した expected target SHA / commit range と target artifact set の組を指します。どちらか一方でも変われば review target の変更です。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "expected target SHA / commit range が不変でも target artifact set が変わった場合も、review target の変更として同じ scope です。",
+    ),
+  );
+  assert.ok(
+    containsText(core, "Selection で確定した target artifact set"),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "Selection Contract で確定した expected target（SHA / commit range）と target artifact set は、Execution で reviewer の trigger へ渡し、実際に渡した target と artifact set を記録します。",
+    ),
+  );
+  assert.doesNotMatch(
+    core,
+    /#### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*Selection で確定した expected target SHA \/ commit range\s*\n\s*-\s*required context\s*\n/,
+    "Execution Contract must not regress to omitting the confirmed target artifact set field",
   );
 
   // Principle B (review evidence is target-specific): discovery evidence, not just
@@ -308,7 +334,7 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "Selection Contract で commit range を expected target として使う場合、head SHA が不変でも range の endpoint が変われば、それも target の変更です。",
+      "head SHA が不変でも commit range の endpoint が変わった場合、また expected target SHA / commit range が不変でも target artifact set が変わった場合も、review target の変更として同じ scope です。",
     ),
   );
   assert.ok(core.includes("-> accepted fix が無く review target が変更されていない場合:"));
@@ -421,7 +447,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "review target は Selection Contract に従い、candidate SHA と、applicable な場合は commit range を含みます。",
+      "review target は Selection Contract に従い、candidate SHA、applicable な場合は commit range、および target artifact set を含みます。",
     ),
   );
   assert.ok(
@@ -444,13 +470,27 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "Execution Contract に従い、Selection で確定した expected target SHA / applicable な commit range を各 reviewer の trigger へ渡して起動します。",
+      "Execution Contract に従い、Selection で確定した expected target SHA / applicable な commit range と target artifact set を各 reviewer の trigger へ渡して起動します。",
     ),
   );
   assert.doesNotMatch(
     reviewCode,
     /trigger 方法と target SHA、渡した required context を記録します。/,
     "Step 4 must pass the Selection-confirmed target to the trigger, not just record target SHA after invocation",
+  );
+
+  // Codex P1 (invalidate discovery on artifact-set-only target changes): Step 3
+  // freezes the artifact set as part of the review target from the moment
+  // Selection confirms it, and Step 4 records what artifact set was actually
+  // sent to the trigger, not just the SHA/range.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "target artifact set を確定した時点から、その artifact set も review target の一部として扱い、手順 2 の target mutation semantics を artifact set にも同じ意味で適用します。",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "実際に渡した target と artifact set、required context を記録します。"),
   );
 
   // A mixed change (accepted-fix-driven head move plus an independently moved
@@ -460,7 +500,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint が accepted fix と無関係に変わった場合）、その独立した変更分は手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。",
+      "fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint や target artifact set が accepted fix と無関係に変わった場合）、その独立した変更分は手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。",
     ),
   );
 
@@ -841,13 +881,24 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "手順 6 の accepted finding batch fix 以外の理由で target SHA / range が変わった場合",
+      "手順 6 の accepted finding batch fix 以外の理由で target SHA / range または target artifact set が変わった場合",
     ),
   );
   assert.ok(
     containsText(
       reviewDoc,
       "re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic discovery を新しい target に対して行います。",
+    ),
+  );
+
+  // Codex P1 (invalidate discovery on artifact-set-only target changes,
+  // Normative sibling): the pre-validity mutation clause must cover an
+  // artifact-set-only change the same way it covers a SHA/range change, not
+  // just the post-validity non-fix clause above.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "手順 3 の semantic discovery の completion / validity が確定する前に target SHA / range または target artifact set が変わった場合、その review target / run を現在 target の evidence として扱いません。",
     ),
   );
 
@@ -862,13 +913,18 @@ test("review skills document procedure without duplicating normative rules", asy
     ) === 2,
     "review-doc.md must re-run mechanical check on target change both before and after semantic discovery validity is confirmed",
   );
+  assert.ok(containsText(reviewDoc, "target SHA / range、target artifact set、"));
+
+  // Codex P1 (invalidate discovery on artifact-set-only target changes,
+  // Normative sibling): Step 3 must pass the Selection-confirmed target SHA
+  // / range AND target artifact set to the reviewer trigger, not just record
+  // required context after the fact.
   assert.ok(
     containsText(
       reviewDoc,
-      "Execution Contract に従い reviewer を起動し、trigger 方法と required context を記録した上で、",
+      "Execution Contract に従い、Selection で確定した target SHA / range と target artifact set を reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した target と artifact set、required context を記録した上で、",
     ),
   );
-  assert.ok(containsText(reviewDoc, "target SHA / range、target artifact set、"));
 
   // Only valid runs' findings may reach triage; invalid/unknown/failure runs must not,
   // matching review-code.md's "valid な run から finding を集約し" gate (Fix, Codex P2).

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -188,9 +188,20 @@ test("review skills document procedure without duplicating normative rules", asy
     !reviewCode.includes("completed（success を含む）と混同せず未開始・判定不能・失敗をそれぞれ"),
     "review-code.md must not restate the none/unknown/failure distinction; it must reference the Acquisition & Validity Contract",
   );
+  // Completion and validity are independent judgments (not a single enum), and a
+  // completed-but-invalid run (e.g. stale/wrong SHA) must remain expressible.
   assert.ok(
-    containsText(reviewCode, "run を completion / validity / `none` / `unknown` / `failure` のいずれかに判定します。"),
+    !containsText(
+      reviewCode,
+      "run を completion / validity / `none` / `unknown` / `failure` のいずれかに判定します。",
+    ),
+    "review-code.md must not collapse completion/validity/none/unknown/failure into a single enum",
   );
+  assert.ok(containsText(reviewCode, "completion と validity は独立した判定とし"));
+  assert.ok(
+    containsText(reviewCode, "target SHA / artifact set 等が一致しない completed run は invalid として表現できます"),
+  );
+  assert.ok(containsText(reviewCode, "`none` / `unknown` / `failure` は completion / validity と混同せず"));
   assert.ok(
     !containsText(reviewCode, "behavior / blast radius を materially"),
     "review-code.md must not restate the discovery round-limit condition; it must reference Review stopping rules",

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -241,6 +241,38 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(containsText(reviewCode, "Review stopping rules（`policy/core.md`）に従い"));
   assert.ok(containsText(reviewCode, "重大 finding を dismiss する際の確認要否は"));
 
+  // Root cause 1: required review count is a gate on triage, in both skills — a
+  // shortfall (invalid/unknown/failure) defers to Failure / retry, not a separate
+  // "at least one valid run" rule.
+  const requiredReviewGate =
+    "Selection Contract で required とした review 数ぶんの `validity: valid` な run が揃うまで triage へ進みません。";
+  assert.ok(containsText(reviewCode, requiredReviewGate));
+  assert.ok(containsText(reviewDoc, requiredReviewGate));
+  assert.ok(
+    containsText(reviewCode, "揃わない run（invalid / unknown / failure）の扱いは Failure / retry"),
+  );
+  assert.ok(
+    containsText(reviewDoc, "揃わない run（invalid / unknown / failure）の扱いは Failure / retry"),
+  );
+
+  // Root cause 2: closure (targeted closure / Closure Acquisition & Validity) is
+  // required only when the candidate SHA actually changed, not unconditionally.
+  assert.ok(containsText(reviewCode, "candidate SHA が変更された場合のみ"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "candidate SHA が変更されていなければ、required review 数の valid discovery と Resolution が完了した時点で merge します。",
+    ),
+  );
+
+  // Root cause 3: an unconfirmed closure defers to Failure / retry instead of
+  // unconditionally retrying the same closure trigger.
+  assert.ok(
+    !containsText(reviewCode, "targeted closure をやり直します"),
+    "review-code.md must not unconditionally retry the same closure trigger; it must defer to Failure / retry",
+  );
+  assert.ok(containsText(reviewCode, "確認できなければ merge せず、その後の扱いは Failure / retry"));
+
   // review-doc.md covers the normative document review procedure, including the new
   // Selection / Execution steps (Fix 7) and the closure validity gate (Fix 6)
   for (const phrase of [
@@ -255,7 +287,10 @@ test("review skills document procedure without duplicating normative rules", asy
     assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
   }
   assert.ok(
-    containsText(reviewDoc, "target SHA / range、target artifact set、reviewer / capability を確定します。"),
+    containsText(
+      reviewDoc,
+      "target SHA / range、target artifact set、reviewer / capability、required review 数を確定します。",
+    ),
   );
   assert.ok(
     containsText(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -325,6 +325,30 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     ),
   );
 
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range): a SHA-only match is not enough — the selected target artifact
+  // set must also be within the precondition check's covered scope, checked
+  // after Selection when the check ran before it, with a rerun required
+  // whenever coverage can't be positively confirmed.
+  assert.ok(
+    containsText(
+      core,
+      "この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "precondition check を Selection より前に実行した場合は、Selection 後にこの binding を確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "selected artifact set を precondition evidence がカバーしていると確認できない場合は、確定した target に対して precondition check を再実行してから先へ進みます。",
+    ),
+  );
+
   // Range-only target change (Codex P1, commit range for Executable): a commit
   // range's endpoint moving counts as a target change even if head SHA is
   // unchanged, so old evidence isn't carried over just because the SHA looks the
@@ -493,6 +517,34 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewCode, "実際に渡した target と artifact set、required context を記録します。"),
   );
 
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range): Step 1 records what scope the deterministic verify actually
+  // covered, and Step 3 checks that scope against the confirmed target
+  // artifact set once Selection has run, re-verifying when coverage can't be
+  // confirmed. Artifact set ownership stays with Selection — Step 1/2 only
+  // record evidence metadata, they don't freeze a competing artifact set.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "その verify が対象とした artifact / package / repository scope を必要な精度で記録した上で",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "repository 全体を対象とする verify であれば repo-wide として記録すれば十分です。"),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "target artifact set を確定したら、直近の successful deterministic verify evidence が、確定した SHA / range と target artifact set の両方をカバーしているかを確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "selected artifact set をその verify evidence がカバーしていると確認できない場合は、確定した target に対して手順 1 の deterministic verify を再実行し、成功してから手順 4（Execution）へ進みます。",
+    ),
+  );
+
   // A mixed change (accepted-fix-driven head move plus an independently moved
   // range endpoint) is not closure-eligible for the independent portion — it
   // routes through Step 2's existing non-fix mutation semantics instead of a new
@@ -559,7 +611,7 @@ test("review skills document procedure without duplicating normative rules", asy
   // Step 1 must match the frozen candidate SHA at Step 2; a mismatch (a race
   // between verify start and freeze) re-runs verify against the frozen SHA rather
   // than carrying over evidence for a different target.
-  assert.ok(containsText(reviewCode, "その時点の candidate SHA を記録した上で"));
+  assert.ok(containsText(reviewCode, "その時点の candidate SHA"));
   assert.ok(
     containsText(
       reviewCode,
@@ -709,7 +761,18 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
+      "Selection Contract に従ってこの closure target を expected target として確定し、確定した closure artifact set まで直近の successful deterministic verify evidence がカバーしているかを確認します。",
+    ),
+  );
+
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range): targeted closure's artifact-set coverage check re-runs
+  // deterministic verify against the confirmed closure target when coverage
+  // can't be confirmed, before Execution starts the closure run.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "カバーしていると確認できない場合は、確定した closure target に対して deterministic verify を再実行し、成功してから Execution Contract に従って closure run を起動します。",
     ),
   );
   assert.ok(
@@ -760,7 +823,21 @@ test("review skills document procedure without duplicating normative rules", asy
     "Step 9 item 1 must not freeze the latest verify target itself as the second discovery target; it must freeze the current post-fix SHA and check it against the latest verify target",
   );
   assert.ok(
-    containsText(reviewCode, "Selection Contract をこの second discovery stage へ適用します。"),
+    containsText(
+      reviewCode,
+      "Selection Contract をこの second discovery stage へ適用し、確定した target artifact set まで直近の successful deterministic verify evidence がカバーしているかを確認します。",
+    ),
+  );
+
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range): second discovery's artifact-set coverage check re-runs
+  // deterministic verify against the confirmed second discovery target when
+  // coverage can't be confirmed, before Execution starts full discovery.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "カバーしていると確認できない場合は、確定した second discovery target に対して deterministic verify を再実行し、成功してから Execution へ進みます。",
+    ),
   );
   assert.ok(
     containsText(reviewCode, "Execution Contract に従って full discovery（独立 reviewer）を"),
@@ -866,11 +943,35 @@ test("review skills document procedure without duplicating normative rules", asy
   // Root cause B, cells G/H (Normative): the mechanical check target captured at
   // Step 1 must match the target confirmed at Step 2's Selection; a mismatch
   // re-runs mechanical check against the confirmed target.
-  assert.ok(containsText(reviewDoc, "その時点の target SHA / range を記録した上で"));
+  assert.ok(containsText(reviewDoc, "その時点の target SHA / range"));
   assert.ok(
     containsText(
       reviewDoc,
       "手順 1 で記録した mechanical check 対象の target と、ここで確定する target が一致することを確認します。一致しない場合は、確定した target に対して手順 1 の mechanical check を再実行してから先へ進みます。",
+    ),
+  );
+
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range, Normative sibling): Step 1 records what scope the mechanical
+  // check covered, and Step 2 checks that scope against the confirmed target
+  // artifact set, re-checking when coverage can't be confirmed. Artifact set
+  // ownership stays with Selection — Step 1 only records evidence metadata.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "その mechanical check が対象とした document / artifact scope を必要な精度で記録した上で",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "target artifact set を確定したら、直近の successful mechanical-check evidence が、確定した target SHA / range と target artifact set の両方をカバーしているかを確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "selected artifact set をその mechanical check evidence がカバーしていると確認できない場合は、確定した target に対して手順 1 の mechanical check を再実行してから手順 3（semantic discovery）へ進みます。",
     ),
   );
 
@@ -949,11 +1050,22 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "Selection / Execution Contract（`policy/core.md`）を closure review run に適用します。",
+      "Selection Contract（`policy/core.md`）をこの closure review run に適用します。",
     ),
   );
   assert.ok(
     containsText(reviewDoc, "この closure target を expected target として Acquisition & Validity"),
+  );
+
+  // Codex P2 (bind precondition evidence to selected artifact set, not just
+  // SHA/range): Normative closure's artifact-set coverage check re-runs
+  // mechanical check against the confirmed closure target when coverage
+  // can't be confirmed, before Execution starts the closure run.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "確定した closure artifact set を、直近の mechanical-check evidence がカバーしていることを確認します。確認できない場合は、確定した closure target に対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を closure review run に適用します。",
+    ),
   );
 
   // Finding 3 (Normative): Selection Contract's required review count gates

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -284,6 +284,22 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(reviewCode, "手順 7 の batch fix によって candidate SHA が変更された場合のみ"),
   );
 
+  // 2x2 cell A (Executable x accepted fix): closure re-freezes the post-fix SHA as
+  // the closure target and applies Selection / Execution Contract to it, so closure
+  // validity is judged against the post-fix target, not Step 3's original Selection.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "修正後の SHA を closure target として re-freeze し、Selection Contract に従ってこの closure target を expected target として確定し、Execution Contract に従って closure run を起動します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この closure target を expected target として、targeted closure の review run に手順 5 と同じ Acquisition & Validity Contract を適用し",
+    ),
+  );
+
   // review-doc.md covers the normative document review procedure, including the new
   // Selection / Execution steps (Fix 7) and the closure validity gate (Fix 6)
   for (const phrase of [
@@ -301,6 +317,23 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(
       reviewDoc,
       "target SHA / range、target artifact set、reviewer / capability、required review 数を確定します。",
+    ),
+  );
+
+  // 2x2 cell D (Normative x non-fix change): a target change after valid discovery
+  // that isn't Step 6's accepted-finding fix invalidates the old discovery as
+  // evidence for the new target and restarts from Selection through a fresh
+  // semantic discovery on the new target — not a 2nd round on the same target.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "手順 6 の accepted finding batch fix 以外の理由で target SHA / range が変わった場合",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "新しい target を re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic discovery を新しい target に対して行います。",
     ),
   );
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -43,7 +43,10 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(containsText(core, "CI status は review completion と同義ではありません"));
   assert.ok(containsText(core, "0 findings は positive evidence を必要とします"));
   assert.ok(
-    containsText(core, "reviewed SHA / range が target と一致しない場合、completion していても invalid です。"),
+    containsText(
+      core,
+      "確定した reviewed target が expected target と一致しない場合、completion していても invalid です。",
+    ),
   );
   assert.ok(containsText(core, "intended artifact set が review されていない場合も invalid です。"));
   assert.ok(
@@ -87,6 +90,20 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(containsText(core, "`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。"));
   assert.ok(
     containsText(core, "この場合、record は `status: completed` かつ `validity: invalid` として表現します。"),
+  );
+
+  // Reviewed-target evidence consistency: when record.target_sha and the acquired
+  // evidence's reviewed target both exist, they must agree; disagreement is invalid,
+  // and an unconfirmable reviewed target is unknown (not silently valid).
+  assert.ok(
+    containsText(
+      core,
+      "record の `target_sha` と acquired evidence 上の reviewed target が両方存在する場合、両者は一致していなければなりません。",
+    ),
+  );
+  assert.ok(containsText(core, "一致しない場合は invalid です。"));
+  assert.ok(
+    containsText(core, "reviewed target を Validity 判定に必要な精度で確認できない場合は unknown です。"),
   );
 
   // Resolution Contract

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -65,6 +65,7 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     '"reviewer"',
     '"target_sha"',
     '"status"',
+    '"validity"',
     '"finding_count"',
     '"result_locator"',
     '"started_at"',
@@ -73,6 +74,20 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   ]) {
     assert.ok(core.includes(field), `missing record schema field: ${field}`);
   }
+
+  // The record's target_sha is the reviewed/observed target, not the Selection
+  // Contract's expected target, and completed-but-invalid must be expressible via
+  // status/validity together, without expanding the schema beyond this one field.
+  assert.ok(
+    containsText(
+      core,
+      "record の `target_sha` は、Selection Contract の expected target（SHA / commit range）ではなく、実際に reviewed された SHA / range（observed target）を表します。",
+    ),
+  );
+  assert.ok(containsText(core, "`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。"));
+  assert.ok(
+    containsText(core, "この場合、record は `status: completed` かつ `validity: invalid` として表現します。"),
+  );
 
   // Resolution Contract
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -312,6 +312,16 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
+  // Gap fix: a repeating closure-finding cycle connects to the existing Review
+  // stopping rules (upstream instability / escalate) instead of looping
+  // unbounded; no new closure-specific retry counter or policy was introduced.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この cycle が繰り返し発生する場合は無制限に続けず、Review stopping rules（`policy/core.md`）に従って upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+
   // Root cause B, cells E/F (Code): the deterministic verify target captured at
   // Step 1 must match the frozen candidate SHA at Step 2; a mismatch (a race
   // between verify start and freeze) re-runs verify against the frozen SHA rather
@@ -478,6 +488,16 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(
       reviewDoc,
       "手順 7 の closure が行われなかった場合（accepted fix が無く target も変更されていない場合）、この手順は不要です。",
+    ),
+  );
+
+  // Gap fix: a repeating closure-finding cycle connects to this skill's existing
+  // stopping condition and Review stopping rules instead of looping unbounded,
+  // without restating the "## 停止条件" section verbatim.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "この cycle が繰り返し発生する場合は、本 skill の停止条件および Review stopping rules（`policy/core.md`）に従います。",
     ),
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -321,8 +321,21 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "accepted finding の batch fix によって candidate SHA が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+      "accepted finding の batch fix によって review target が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
     ),
+  );
+
+  // Codex P2 (unify closure-entry predicates with the canonical review target
+  // definition): the Code review diagram's accepted-fix branch condition is
+  // "review target changed", not a stage-local "candidate SHA changed" that
+  // drifts from the review target definition established just above.
+  assert.ok(
+    containsText(core, "-> accepted finding の batch fix で review target が変更された場合:"),
+  );
+  assert.doesNotMatch(
+    core,
+    /accepted finding の batch fix で candidate SHA が変更された場合/,
+    "the Code review diagram's closure-entry condition must not regress to a bare candidate-SHA predicate",
   );
 
   // Root cause A (closure findings need Resolution too): completed + valid closure
@@ -542,13 +555,48 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "accepted finding の fix によって target SHA / range が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+      "accepted finding の fix によって review target が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
     ),
   );
   assert.ok(
     containsText(
       core,
-      "accepted fix が無く target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
+      "accepted fix が無く review target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
+    ),
+  );
+
+  // Codex P2 (unify closure-entry predicates with the canonical review target
+  // definition, Normative sibling): both diagram branches (accepted-fix and
+  // no-change) key on "review target", matching the Code review diagram and
+  // the review target definition established just above, not a stage-local
+  // "target SHA / range" partial predicate.
+  assert.ok(
+    containsText(core, "-> accepted finding の fix で review target が変更された場合:"),
+  );
+  assert.ok(
+    containsText(core, "-> accepted fix が無く review target が変更されていない場合:"),
+  );
+  assert.doesNotMatch(
+    core,
+    /accepted finding の fix で target SHA \/ range が変更された場合/,
+    "the Normative diagram's closure-entry condition must not regress to a bare SHA/range predicate",
+  );
+
+  // Codex P2 (stage-independent closure-cycle stopping semantics): a repeating
+  // closure Resolution -> accepted fix -> closure review cycle (either
+  // artifact) is escalated as upstream/policy instability, distinct from
+  // Failure/retry's retry count — stated once in canonical policy rather than
+  // only referenced from the skills.
+  assert.ok(
+    containsText(
+      core,
+      "closure Resolution で accepted fix が生じ、その fix を closure review で確認する cycle（Executable の targeted closure、Normative の closure verification のいずれも）が繰り返し発生する場合、無制限に継続せず、upstream task/design または policy/document 自体の instability を疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "これは Failure / retry の retry count とは別の stopping semantics です。",
     ),
   );
 
@@ -1098,7 +1146,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "手順 7 の closure が行われなかった場合（accepted fix が無く target も変更されていない場合）、この手順は不要です。",
+      "手順 7 の closure が行われなかった場合（accepted fix が無く target SHA / range も target artifact set も変更されていない場合）、この手順は不要です。",
     ),
   );
 
@@ -1265,11 +1313,24 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "accepted finding の fix によって target SHA / range が変わった場合のみ行います。",
+      "accepted finding の fix によって target SHA / range または target artifact set が変わった場合のみ行います。",
     ),
   );
   assert.ok(
-    containsText(reviewDoc, "accepted finding の fix が無く target も変更されていない場合"),
+    containsText(
+      reviewDoc,
+      "accepted finding の fix が無く target SHA / range も target artifact set も変更されていない場合",
+    ),
+  );
+
+  // Codex P2 (unify closure-entry predicates with the canonical review target
+  // definition, skills/review-doc.md sibling): the closure predicate covers an
+  // artifact-set-only change too, matching Step 2's mutation semantics and
+  // policy/core.md's "review target" definition, not just target SHA / range.
+  assert.doesNotMatch(
+    reviewDoc,
+    /accepted finding の fix によって target SHA \/ range が変わった場合のみ行います。/,
+    "the Closure step's entry condition must not regress to a bare SHA/range predicate",
   );
   assert.ok(
     containsText(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -54,6 +54,50 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     assert.ok(core.includes(artifactClass), `missing artifact class: ${artifactClass}`);
   }
 
+  // Principle A (Contract applicability is stage-independent): the 4 Contracts
+  // apply to closure review runs too, not just discovery, and a Selection
+  // Contract's required review count gates closure the same as discovery.
+  assert.ok(
+    containsText(
+      core,
+      "各 Contract は discovery だけでなく、同じ Contract を使って起動する closure review run にも適用されます。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "closure target も Selection Contract で expected target として確定し、Execution Contract に従って起動します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "Selection Contract が required review 数を定めた review stage では、discovery か closure かを問わず、その required 数の completed かつ valid な run が揃うまで triage / Resolution / merge / review completion へ進みません。",
+    ),
+  );
+
+  // Principle B (review evidence is target-specific): discovery evidence, not just
+  // precondition evidence, does not carry over to a new target unless the change
+  // was the accepted-fix-driven closure path.
+  assert.ok(
+    containsText(
+      core,
+      "precondition evidence だけでなく、discovery / closure evidence も target-specific です。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "accepted-fix による closure target の変更以外の理由で review target が変わった場合、その discovery を新しい target の merge / completion evidence として使いません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "accepted fix による target 変更は、既存の targeted closure（Executable）/ closure verification（Normative）の扱いに従います。",
+    ),
+  );
+
   // Acquisition & Validity invariants
   assert.ok(containsText(core, "CI status は review completion と同義ではありません"));
   assert.ok(containsText(core, "0 findings は positive evidence を必要とします"));
@@ -165,6 +209,14 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
 
   // Stopping rules, including the closure Acquisition & Validity gate before merge
   assert.ok(core.includes("closure completion / acquisition / validity 確認"));
+  // Finding 1: the Code accepted-fix branch re-applies Selection/Execution to the
+  // closure target before targeted closure runs.
+  assert.ok(
+    containsText(
+      core,
+      "deterministic verify -> closure target の Selection / Execution -> targeted closure",
+    ),
+  );
   assert.ok(
     containsText(
       core,
@@ -248,9 +300,15 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "precondition check（Executable の deterministic verify、Normative の mechanical check）を新しい target に対して再成立させます。",
     ),
   );
-  // The Normative accepted-fix branch re-runs mechanical check before closure
-  // verification, without adding a 2nd semantic discovery round.
-  assert.ok(containsText(core, "mechanical check -> closure verification"));
+  // The Normative accepted-fix branch re-runs mechanical check and re-applies
+  // Selection/Execution to the closure target before closure verification,
+  // without adding a 2nd semantic discovery round.
+  assert.ok(
+    containsText(
+      core,
+      "mechanical check -> closure target の Selection / Execution -> closure verification",
+    ),
+  );
 
   // Observed evidence stays a general principle, not a permanent provider rule
   assert.ok(containsText(core, "expected trigger behavior は completion evidence と同義ではありません。"));
@@ -452,6 +510,15 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
+  // Finding 3 (Code): Selection Contract's required review count gates closure
+  // the same as discovery; a shortfall defers to Failure / retry.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "closure 用 Selection Contract で required とした review 数ぶんの valid な closure run が揃うまで Closure Resolution へ進みません。",
+    ),
+  );
+
   // review-doc.md covers the normative document review procedure, including the new
   // Selection / Execution steps (Fix 7) and the closure validity gate (Fix 6)
   for (const phrase of [
@@ -576,6 +643,15 @@ test("review skills document procedure without duplicating normative rules", asy
   );
   assert.ok(
     containsText(reviewDoc, "この closure target を expected target として Acquisition & Validity"),
+  );
+
+  // Finding 3 (Normative): Selection Contract's required review count gates
+  // closure the same as discovery; a shortfall defers to Failure / retry.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "closure 用 Selection Contract で required とした review 数ぶんの valid な closure run が揃うまで Closure Resolution へ進みません。",
+    ),
   );
 
   // Root cause fix (this round, cell C): closure re-runs Step 1's mechanical check


### PR DESCRIPTION
Closes #9

## Summary

- provider-neutral な Review Protocol（Artifact classification / Selection・Execution・Acquisition & Validity・Resolution Contract / Review Adapter boundary / Failure・retry / Resolution・triage / Review stopping rules）を `policy/core.md` の canonical source に追加しました。
- 実行手順を `skills/review-code.md`（Executable artifact向け）と `skills/review-doc.md`（Normative artifact向け）に分離し、policy側の規範的ルールを複製していません。
- `CI status != Review completion`、`0 findings != acquisition succeeded`、`none/unknown/failure` の区別、target SHA / artifact set 不一致時の invalid 判定を normative に明記しました。
- Review Adapter boundary（`trigger()` / `pollCompletion()` / `collectOutputs()` / `normalizeFindings()`）は概念的な形のみを定義し、provider 固有 adapter の実装は行っていません。
- 既存 composition で consumer fixture の `AGENTS.md` を再生成しました。

## Canonical source

`policy/core.md`（Review Protocol）

## Review procedures

- `skills/review-code.md`
- `skills/review-doc.md`

## Verification

- `npm test` — pass（7 tests、guardrail fixture 8件）
- `npm run check:fixture` — pass
- `npm run --prefix test/fixtures/consumer verify` — pass
- `git diff --check` — pass

## Manual review pilot

PR #11 自身を manual review pilot として使用しました。

- discovery target: `2ed918db94953addfcec2d6636b7b2e9c38448c0`
- base: `6486956a7f4108cd59b11596ec59e1649665e176`
- Claude: fresh independent review で指定6ファイルすべてを確認し、Completion / Acquisition / Validity を満たした上で4 findingsを取得
- CodeRabbit: Run ID `50427d63-2dbe-4b12-a5c6-4a291acc6154`、base→targetのrangeと6ファイル選択を確認し、3 actionable commentsを取得
- Codex: reviewed commit `2ed918db94` とreview completion / inline outputは確認できた一方、GitHub上のsurfaceでは指定6ファイルすべてをreview対象としたpositive evidenceまでは得られず、artifact-set validityはunknownとして扱いました

findingsはaggregate / triageし、accepted findingsをbatch fixしました。CodeRabbitのschema複製検出強化はscope expansionとしてrejectし、その後のincremental reviewで出たP0/P1 dismissalの無条件mandatory化もIssue #9の固定decisionを超えるためrejectしました。

full discoveryは再実行せず、修正箇所のみtargeted closureを行いました。run record上のcompleted-but-invalid表現、reviewed target evidenceの整合性、valid runだけをtriageへ進めるgateをminimalな既存contractの範囲で修正しました。さらにreviewの4 commentsは3 root cause（required review数のvalid-run gate、candidate未変更時のclosure不要、closure failureのFailure / retry委譲）へ統合してbatch fixしました。その後のCodex P1 2件についても、targeted closure経路をStep 7のbatch fixによるSHA変更に限定し、それ以外のSHA変更はre-freeze + discoveryへ戻すこと、Normative closureでは修正後targetをre-freezeして既存Selection / Execution / Acquisition & Validity Contractをclosure runへ適用すること、の2点をprocedure層だけでbatch fixしました。続くCodex P1 2件はpost-discovery target mutationの左右非対称という1 root causeとして統合し、Executableのaccepted fix後に修正後targetをclosure用expected targetとしてSelection / Executionすること、Normativeの非fix target変更ではold discoveryを現在targetのevidenceとして使わずSelection + semantic discoveryへ戻すことを `35fcb3aa0c283a6c86f319d9eb59e43b87202818` で修正しました。さらにpush前semantic checkで露出したNormativeのaccepted fixなし + target不変時にclosure runが不要である停止条件を `7d5dff544c5c0f0ec3cf309d0bc37ecf2637228f` で明確化し、0 findings専用flowや新しいreview phaseは追加していません。続くCodex P2で、skills側の停止条件に対してcanonical `policy/core.md` のCode/Normative stopping rulesが無条件closureのまま残っている不整合を確認し、`fb02cbbc3f243c63f4a02d1ba231004568d5f109` でaccepted-fix-driven target change時のみclosureを要求し、accepted fixなし + target不変時はrequired valid discovery + Resolution完了で追加closureを要求しない条件へcanonical側を同期しました。consumer fixtureは既存compositionで再生成し、Code/Normative双方の分岐をregression testで固定しています。

続くCodex closure reviewでは、target変更後のmechanical / deterministic precondition evidence再成立が一部経路で抜けるP1/P2を確認しました。これらを「precondition evidenceはtarget-specificであり、新targetへ自動的に持ち越さない」という1 root causeとして扱い、`7cc526f1c2b7590f7f556578666a3828e5fc66e1` でcanonical invariantを追加するとともに、Executableのvalid discovery後の非fix SHA変更、Normativeのaccepted-fix target変更、Normativeのvalid discovery後の非fix target変更に新targetでのprecondition再実行を追加しました。さらにpush後のsemantic sweepで同じroot causeのpre-validity branchが残っていることを確認し、`9beb0266cd8a5b9351250e201717960d1bec5b0f` でExecutable / Normative双方についてdiscovery completion / validity確定前のtarget変更でも新targetのdeterministic verify / mechanical checkを再成立させてからre-freeze / Selection / discoveryへ進むよう補完しました。新review phase、state machine、provider rule、Normativeの同一targetへの2nd semantic discoveryは追加していません。

最新Codex closure reviewでは、closure runがcompleted + validでもclosure findingのResolution完了前にmerge / review completionへ進めるP1と、initial precondition checkとfreeze / Selectionの間でtargetが変わるraceのP2を確認しました。`f47e8175c038e11a9c72a4b889e13fd407195c3d` で、targeted closure / closure verificationのfindingにも既存Resolution Contractを適用し、Resolution完了をmerge / review completionのgateに追加しました。またIssue #9の `verify -> freeze` / `mechanical check -> Selection` 順序は維持しつつ、Step 1でcheck対象targetを記録し、Step 2でfreeze / Selectionされたtargetとの一致を要求し、不一致時は確定targetでprecondition checkを再実行するtarget-binding gateをCode / Normative双方へ追加しました。さらに `9fea850d00d363924f5d3b3c4ea818dbde4302ea` で、accepted closure findingのResolution / fix / closure cycleが反復する場合は無制限に続けず、既存Review stopping rules / skill停止条件へ接続してupstream task/designまたはpolicy/documentの不安定さを疑い、必要に応じてescalateすることを明記しました。新しいClosure Resolution Contract、retry counter、state、phase、Normative full semantic rediscoveryは追加していません。

その後のCodex final closureでは、closure targetのSelection / Execution、valid discovery後のnon-fix target変更のcanonical invalidation、closureでのrequired review数gateというP1 3件を確認しました。3件は「skill側procedureは成立しているが、consumerへ配布されるself-contained canonical policyがReview Contractの適用範囲とreview evidenceのtarget-specificityを十分に表現していない」という1 root causeへ統合し、`64034c3f994effbcba0a5e71a2a1a216fed0e9be` で修正しました。各Review Contractはdiscoveryだけでなくclosure review runにも適用されること、Selectionのrequired review数はdiscovery / closure共通のstage gateであること、discovery / closure evidence自体もtarget-specificでnon-fix target変更後はold discoveryをnew targetへ持ち越さないことをcanonical principleとして追加し、Code / Normative両stopping flowとskillsのclosure required-count gateを同期しました。新しいContract、phase/state、固定reviewer数、Normativeのsame-target 2nd discoveryは追加していません。

続くCodex closure reviewでは、Code skillのtarget mutation文言が、旧runを現在targetのevidenceとして使えなくなることと旧run自身のValidityをretroactively invalidへ変更することを混同しているP2を確認しました。`7412b053c2c12671d946ce0109d2941567296a63` で、pre-validity target変更とvalid discovery後のnon-fix target変更の2箇所を、Normative skillと同じ「旧 review target / run を現在 target の evidence として扱いません」という表現へ統一しました。旧runのValidityは元targetについて保持しつつ、新targetでは既存どおりdeterministic verify → re-freeze → 必要なdiscoveryを行います。canonical policy、Normative skill、consumer fixtureは変更していません。この時点のclosure targetは `7412b053c2c12671d946ce0109d2941567296a63` です。

続くCodex closure reviewでは、material fixで2nd full discoveryを許容するcanonical stopping ruleに対して、Executable skillにSelection / Execution / Acquisition & Validity / required-valid-review gate / Resolutionを通る実行routeが無いP2を確認しました。このfindingと関連sibling gapを「2nd full discoveryが許可条件としては存在するが、review flow全体のoptional routeとして接続されていない」という1 root causeとして扱いました。`f110ef1fefcf602a09e5c5a31d286aaff57c6365` で、material fixの場合のみtargeted closure前へ2nd full discoveryを接続し、finding有無にかかわらず最初のaccepted fixに必要なclosureを維持、2nd discoveryのaccepted fix後はverifyしてtargeted closureへ進み、さらにfull discoveryが必要なら3rdを起動せずupstream instabilityとしてescalateするようにしました。`55b64ea6f12880f08ea2be316bb0a6c52872a74b` では、closure findingのfixが初めてmaterialになった場合にも未使用の2nd full discoveryを利用でき、既に2ndを使用済みなら追加full discoveryを起動せずmergeもしない3分岐へClosure Resolutionを接続するとともに、Step 9 / Step 10のpost-fix verify evidenceをdownstream targetへbindするguardを追加しました。`fa0a7bcd0df52c1a990a2a446d7891e5f051d793` でStep 9 item 1のtarget-binding方向を、current post-fix SHAをfreezeしてlatest successful verify targetと比較する形へ修正しました。新しいContract / state / schema / round counterは追加せず、Normativeの1 semantic discovery + closure verification方針も変更していません。この時点のclosure targetは `fa0a7bcd0df52c1a990a2a446d7891e5f051d793` です。上記deterministic verificationはこのtargetでもすべてpassしています。

続くCodex final closureでは、Executable procedureがcanonical Selection Contractの `expected target SHA / commit range` をcandidate SHAだけへ縮退させていたため、head SHAが不変でもrange endpoint変更でreview target / artifact setが変わるケースを検出できないP1を確認しました。`d43cb6b87da2fc27d7da80009a8963a87abf633d` で、Selectionでcommit rangeをexpected targetとして使う場合のrange-only changeもtarget changeとしてcanonicalに明示し、old discovery / closure evidenceをcurrent targetへ持ち越さないこと、no-fix direct-merge条件を`review target unchanged`へ一般化しました。Executable skillではreview targetをcandidate SHA + applicable commit rangeとして扱い、Step 2でrangeもfreezeして既存target-mutation semanticsを適用し、Step 3を`expected target SHA / applicable commit range`へ同期しました。accepted fixによるhead変更と独立したrange endpoint変更が同時に起きた場合はtargeted closureだけでは扱わずStep 2のnon-fix mutation semanticsへ戻します。新しいContract / schema / state / provider-specific ruleは追加せず、Normative skillは変更していません。最終closure targetは `d43cb6b87da2fc27d7da80009a8963a87abf633d` です。上記deterministic verificationは実装報告上すべてpassしています。

このpilotで、expected trigger behavior != completion evidence、CompletionとValidityの分離、provider surfaceから取得できるpositive evidenceの差を実測しました。これらは恒久的なprovider ruleにはせず、observed evidenceとして扱います。

## Non-goals（今回実装しないもの）

review dashboard / reviewer scoring / 全provider surfaceの完全自動collector / generalized review orchestrator / retrospectiveからの自動Issue生成 / review bot triggerの自動修復 / provider capabilityの巨大な恒久台帳 / provider固有adapterの実装

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コードおよび規範文書を対象とした、統一的なレビュー手順を追加しました。
  * レビュー結果の妥当性確認、指摘事項の整理、修正後の再検証、完了判定を明確化しました。
  * レビュー対象の分類、取得記録、失敗時の再試行、停止条件を定義しました。

* **ドキュメント**
  * 作業手順が共通ポリシーを参照し、規範ルールを重複して定義しない構成を追記しました。

* **テスト**
  * レビュープロトコルの契約、完了条件、参照関係を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->