### PR TITLE
Bootstrap: Claude reviewのmanual trigger workflowをmainへ登録する

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,37 @@
+name: Claude Code Review (manual)
+
+# Issue #12 capability smoke test: this workflow only prepares a manual,
+# explicit-mention trigger for Claude Code review. It intentionally does
+# NOT run automatically on every push (see policy/core.md Review Protocol
+# and skills/review-briefs.md). Selection Contract decides per-Task
+# whether this trigger is used.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  claude-review:
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Read,Grep,Glob

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,4 +38,3 @@ jobs:
           claude_args: |
             --max-turns 10
             --allowedTools Read,Grep,Glob
-            --disallowedTools Edit,Write,Bash,NotebookEdit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,7 @@ on:
     types: [created]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
   id-token: write
@@ -23,15 +23,19 @@ jobs:
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e2a4b761cd77a1138a5b41410eda9b28581f9bcd # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
+            --max-turns 10
             --allowedTools Read,Grep,Glob
+            --disallowedTools Edit,Write,Bash,NotebookEdit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,6 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@e2a4b761cd77a1138a5b41410eda9b28581f9bcd # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            contents: read
           claude_args: |
             --max-turns 10
             --allowedTools Read,Grep,Glob

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,9 +2,9 @@ name: Claude Code Review (manual)
 
 # Issue #12 capability smoke test: this workflow only prepares a manual,
 # explicit-mention trigger for Claude Code review. It intentionally does
-# NOT run automatically on every push (see policy/core.md Review Protocol
-# and skills/review-briefs.md). Selection Contract decides per-Task
-# whether this trigger is used.
+# NOT run automatically on every push (see policy/core.md Review Protocol,
+# Review Adapter boundary). Selection Contract decides per-Task whether
+# this trigger is used.
 
 on:
   issue_comment:
@@ -38,3 +38,4 @@ jobs:
           claude_args: |
             --max-turns 10
             --allowedTools Read,Grep,Glob
+            --disallowedTools Edit,Write,MultiEdit,NotebookEdit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,4 +40,4 @@ jobs:
           claude_args: |
             --max-turns 10
             --allowedTools Read,Grep,Glob
-            --disallowedTools Edit,Write,MultiEdit,NotebookEdit
+            --disallowedTools Edit,Write,MultiEdit,NotebookEdit,Bash


### PR DESCRIPTION
Issue #12 のcontrolled smoke PR（#14）を先に進めるための小さなinfra前提PRです。

GitHub は `issue_comment` トリガーのworkflow定義を、そのworkflowを追加したPRの
branchではなく、repositoryのdefault branch（`main`）から評価します。#14 で
`.github/workflows/claude-review.yml` を追加しましたが、この workflow が
`main` 上に存在しない限り、#14 上の `@claude` mentionではtriggerが起動しません。

このPRは、その1ファイルだけを`main`へ乗せ、trigger を有効化することが目的です。
`main`へ入れた後、#14で改めて`@claude`をmentionしてsmokeを再実行します。

内容は#14でレビュー中のものと同一です（他の差分はありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プルリクエストに関連するコメントから、手動でコードレビューを実行できるようになりました。
  * レビューは読み取り専用で実行され、コードや設定は変更されません。
  * 実行時間と処理回数に上限を設け、安全に利用できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->