### PR TITLE
Bootstrap: root AGENTS.mdへReview Protocolのthin routingを追加（Issue #12）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,10 @@
 このファイルはFoundation自身を編集するためのrepo-local instructionです。
 `templates/AGENTS.md`およびconsumerへ生成する`AGENTS.md`とは別物であり、
 consumer向けcanonical policyへ混在させません。
+
+## Review
+
+このrepositoryでcode / documentのreviewを行う場合は、`policy/core.md` の
+Review Protocolに従います。Executable artifactのreviewは
+`skills/review-code.md`、Normative artifactのreviewは
+`skills/review-doc.md` を参照してください。


### PR DESCRIPTION
Refs #12 — AC「minimum review lensを4候補へ渡せる」のevidence gap対応。

## 背景

Issue #12のcontrolled smoke（PR #14）では、Claudeにのみper-run briefを
明示的に渡していました。Codex / CodeRabbit / Copilotについては、probe.md
本文が「policy/core.mdを読んでください」と明記していたため従っただけで、
standing repository instructionとして自動参照した証拠にはなっていません
でした。

調査の結果、2026年時点でCodex / CodeRabbit / Copilotの3providerすべてが
root `AGENTS.md` をネイティブに自動参照する機能を持つことを確認しました
（追加設定不要）。Claudeは`CLAUDE.md`（`@AGENTS.md`のimport）経由で同じ
fileを読みます。

## 変更内容

root `AGENTS.md` へ、`policy/core.md`のReview Protocol・
`skills/review-code.md`・`skills/review-doc.md`へのthin pointerを
1箇所追加しました。Common blockers等のsemanticsは複製していません。
`skills/review-code.md`・`review-doc.md`が既に実践している
「policy/core.mdへのthin pointer」パターンをAGENTS.mdレベルへもう一段
適用したものです。

## 追加しないもの

- `.github/copilot-instructions.md` / `.coderabbit.yaml`（provider別複製）
- provider profile / generation pipeline変更
- durable review-brief skill
- Review Protocol自体の変更

## このPRの検証方法について

このPR自体がCodex / CodeRabbit / Copilotの review 対象になります。
これら3 providerが実際にroot AGENTS.md（このPRのhead branch版）を
参照し、追加したpointerの正しさ（`policy/core.md`に実際にReview Protocol
節があるか、`skills/review-code.md`・`review-doc.md`が実在し記述通りの
役割か）についてfindingやcommentを残すかどうかを観測します。
「findingが出たから読んだはず」という推定は避け、review output内の
具体的な引用の有無で判断します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * リポジトリ内のコードおよびドキュメントレビュー時に従うべきレビュープロトコルを追記しました。
  * 実行可能な成果物と規範的な成果物の参照先を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->