### PR TITLE
Bootstrap audit: resolve v0.1 freeze blockers (#18)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,9 +21,10 @@ jobs:
   claude-review:
     if: >
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '@claude')
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -38,6 +39,6 @@ jobs:
           additional_permissions: |
             contents: read
           claude_args: |
-            --max-turns 10
+            --max-turns 30
             --allowedTools Read,Grep,Glob
             --disallowedTools Edit,Write,MultiEdit,NotebookEdit,Bash

--- a/policy/core.md
+++ b/policy/core.md
@@ -236,6 +236,26 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
   intent-question 等を含む）が残る間は、その review stage の Resolution
   は完了せず、merge / review completion の根拠にしない
 
+### Merge readiness and merge authority
+
+本節における review completion（Resolution Contract の完了を含む）が
+成立した状態を **merge-ready** と呼びます。Review contracts および
+Review stopping rules で `merge` と記述する到達点は、merge-ready の
+成立を指し、merge を実行してよいという判断そのものとは同義ではありません。
+
+merge execution authority は、Review Protocol とは別の contract /
+context として扱います。current Task、Execution Envelope、または
+explicit な authority が merge の実行を許可している場合に限り、agent は
+merge を実行してよいです。
+
+merge authority が明示されていない場合、または別 authority の承認が
+必要な場合、agent は merge を実行せず、merge-ready の状態を報告した
+上で停止し、authority escalation / handoff します。
+
+この分離は、すべての PR で Human diff approval を mandatory にする
+ことを意味しません。GitHub の required approval 数を増やす rule でも
+ありません。provider や model 固有の rule にもしません。
+
 ### Review Adapter boundary
 
 provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
@@ -426,3 +446,31 @@ completion evidence が得られない場合は、trigger 前提を疑い、Acqu
 Contract に従って `unknown` として扱います。特定 provider が常に特定の trigger 方法を
 要求するという恒久仕様は Kernel に置かず、observed evidence として capability/profile
 側で再検証可能な形にします。
+
+## Foundation Change Protocol
+
+Foundation 自身の canonical rule を変更する場合の、provider-neutral な
+最小 contract です。この protocol は Skill / Profile へ複製せず、変更を
+検討する際は本節を参照します。
+
+Observation は、そのままでは Issue や mandatory rule へ自動的に昇格しません。
+
+mandatory な Foundation change は、原則として次のいずれかで正当化します。
+
+1. 既存の mandatory / manual step を置き換える
+2. material defect を deterministically 防止する
+3. demonstrated recurring / escaped failure へ対処する
+
+Change Proposal は、少なくとも次を表現できるものとします。
+
+- Problem
+- Evidence
+- Proposed Change
+- Expected Effect
+- Trade-off
+- Scope
+- Success Criterion
+
+change class や review 強度は、固定の provider 名へ結びつけません。単発の
+friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
+化しません。

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -49,7 +49,21 @@ export default [
   ...nextSupabaseQualityProfile(),
   architectureImportBoundary({
     files: ['src/domain/**/*.ts'],
-    restrictedPatterns: ['../ui/**', '../infrastructure/**'],
+    // Depth-independent, anchored patterns: "../**/ui" (and "/**") matches
+    // "../ui", "../../ui", "../ui/x", "../../ui/x", ... regardless of how
+    // deep the importing domain file is nested, without also matching an
+    // unrelated external package such as "@vendor/ui/button" the way a bare
+    // "**/ui/**" pattern would.
+    restrictedPatterns: [
+      '../**/ui',
+      '../**/ui/**',
+      '../**/infrastructure',
+      '../**/infrastructure/**',
+      '@/ui',
+      '@/ui/**',
+      '@/infrastructure',
+      '@/infrastructure/**',
+    ],
     message: 'Domain code must not import UI or infrastructure.',
   }),
 ];

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -172,11 +172,13 @@ review でも同じ意味で適用します。
     停止し、authority escalation / handoff します。
     この review flow で accepted finding の fix による
     target 変更が一度も発生していなければ、required review 数の valid
-    discovery と Resolution（手順 6）が完了した時点で merge します。
+    discovery と Resolution（手順 6）が完了した時点で merge-ready と
+    判定します。
     target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
     discovery Resolution（手順 9 を使った場合はその Resolution も含む）
     と、Closure Acquisition & Validity・Closure Resolution が完了した
-    時点で merge します。discovery Resolution と closure の完了順序は
+    時点で merge-ready と判定します。discovery Resolution と closure の
+    完了順序は
     問いません。
 
 ## Adapter boundary（manual pilot）

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -163,14 +163,21 @@ review でも同じ意味で適用します。
     この cycle が繰り返し発生する場合は無制限に続けず、Review stopping
     rules（`policy/core.md`）に従って upstream task/design の不安定さを
     疑い、必要に応じて escalate します。
-13. **Merge** — この review flow で accepted finding の fix による target
-    変更が一度も発生していなければ、required review 数の valid discovery
-    と Resolution（手順 6）が完了した時点で merge します。
+13. **Merge-ready** — この review flow で accepted finding の fix による
+    target 変更が一度も発生していなければ、required review 数の valid
+    discovery と Resolution（手順 6）が完了した時点で merge します。
     target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
     discovery Resolution（手順 9 を使った場合はその Resolution も含む）
     と、Closure Acquisition & Validity・Closure Resolution が完了した
     時点で merge します。discovery Resolution と closure の完了順序は
     問いません。
+    この時点で成立するのは merge-ready です。merge の実行は
+    `policy/core.md` の Merge readiness and merge authority に従い、
+    current Task / Execution Envelope / explicit authority が merge
+    execution を許可している場合のみ行います。authority が明示されて
+    いない、または別 authority の承認が必要な場合は merge を実行せず、
+    merge-ready の状態を報告して停止し、authority escalation /
+    handoff します。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -163,7 +163,14 @@ review でも同じ意味で適用します。
     この cycle が繰り返し発生する場合は無制限に続けず、Review stopping
     rules（`policy/core.md`）に従って upstream task/design の不安定さを
     疑い、必要に応じて escalate します。
-13. **Merge-ready** — この review flow で accepted finding の fix による
+13. **Merge-ready** — 以下の条件が成立するのは merge-ready であり、merge
+    の実行そのものではありません。merge の実行は `policy/core.md` の
+    Merge readiness and merge authority に従い、current Task / Execution
+    Envelope / explicit authority が merge execution を許可している場合
+    のみ行います。authority が明示されていない、または別 authority の
+    承認が必要な場合は merge を実行せず、merge-ready の状態を報告して
+    停止し、authority escalation / handoff します。
+    この review flow で accepted finding の fix による
     target 変更が一度も発生していなければ、required review 数の valid
     discovery と Resolution（手順 6）が完了した時点で merge します。
     target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
@@ -171,13 +178,6 @@ review でも同じ意味で適用します。
     と、Closure Acquisition & Validity・Closure Resolution が完了した
     時点で merge します。discovery Resolution と closure の完了順序は
     問いません。
-    この時点で成立するのは merge-ready です。merge の実行は
-    `policy/core.md` の Merge readiness and merge authority に従い、
-    current Task / Execution Envelope / explicit authority が merge
-    execution を許可している場合のみ行います。authority が明示されて
-    いない、または別 authority の承認が必要な場合は merge を実行せず、
-    merge-ready の状態を報告して停止し、authority escalation /
-    handoff します。
 
 ## Adapter boundary（manual pilot）
 

--- a/test/claude-review-workflow.test.mjs
+++ b/test/claude-review-workflow.test.mjs
@@ -25,7 +25,15 @@ test("Claude review workflow restricts its trigger to trusted commenters", async
   const condition = ifMatch[1];
 
   assert.match(condition, /contains\(github\.event\.comment\.body, '@claude'\)/);
-  assert.match(condition, /author_association/);
+
+  // The allowlist must actually gate github.event.comment.author_association
+  // itself (not merely appear somewhere in the condition alongside it), or a
+  // future edit could decouple the two while this assertion stays green.
+  assert.match(
+    condition,
+    /contains\(fromJSON\('\["OWNER",\s*"MEMBER",\s*"COLLABORATOR"\]'\),\s*github\.event\.comment\.author_association\)/,
+    "trusted association allowlist must be applied to github.event.comment.author_association",
+  );
 
   for (const trustedAssociation of ["OWNER", "MEMBER", "COLLABORATOR"]) {
     assert.ok(

--- a/test/claude-review-workflow.test.mjs
+++ b/test/claude-review-workflow.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = path.join(root, ".github", "workflows", "claude-review.yml");
+
+test("Claude review workflow restricts its trigger to trusted commenters", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  // Regression proof for Issue #18 Blocker 4: a PR comment containing "@claude"
+  // must no longer be sufficient on its own to run a job holding
+  // CLAUDE_CODE_OAUTH_TOKEN. The job condition must also gate on the
+  // commenter's author_association.
+  assert.match(
+    workflow,
+    /github\.event\.comment\.author_association/,
+    "job condition must gate on the commenter's author_association",
+  );
+
+  const ifMatch = workflow.match(/if:\s*>([\s\S]*?)\n {4}runs-on:/);
+  assert.ok(ifMatch, "could not locate the claude-review job's `if` condition");
+  const condition = ifMatch[1];
+
+  assert.match(condition, /contains\(github\.event\.comment\.body, '@claude'\)/);
+  assert.match(condition, /author_association/);
+
+  for (const trustedAssociation of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    assert.ok(
+      condition.includes(trustedAssociation),
+      `trusted-actor allowlist must include ${trustedAssociation}`,
+    );
+  }
+
+  // The allowlist must not admit an untrusted/public association such as a
+  // fork PR's default "NONE"/"CONTRIBUTOR"/"FIRST_TIME_CONTRIBUTOR" commenter.
+  for (const untrustedAssociation of ["NONE", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]) {
+    assert.ok(
+      !condition.includes(untrustedAssociation),
+      `trusted-actor allowlist must not include ${untrustedAssociation}`,
+    );
+  }
+});
+
+test("Claude review workflow uses bounded runtime tuning from first-consumer evidence", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  // Regression proof for Issue #18 Blocker 4: first-consumer Discovery hit
+  // `error_max_turns` at the previous `--max-turns 10` / `timeout-minutes: 15`
+  // defaults on a realistically sized review. `--max-turns 30` /
+  // `timeout-minutes: 25` is the first-consumer-validated baseline; this must
+  // not regress below it.
+  const maxTurnsMatch = workflow.match(/--max-turns (\d+)/);
+  assert.ok(maxTurnsMatch, "workflow must configure --max-turns");
+  assert.ok(
+    Number(maxTurnsMatch[1]) >= 30,
+    `--max-turns must be at least 30 (first-consumer baseline), got ${maxTurnsMatch[1]}`,
+  );
+
+  const timeoutMatch = workflow.match(/timeout-minutes:\s*(\d+)/);
+  assert.ok(timeoutMatch, "job must configure timeout-minutes");
+  assert.ok(
+    Number(timeoutMatch[1]) >= 25,
+    `timeout-minutes must be at least 25 (first-consumer baseline), got ${timeoutMatch[1]}`,
+  );
+});

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -244,6 +244,26 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
   intent-question 等を含む）が残る間は、その review stage の Resolution
   は完了せず、merge / review completion の根拠にしない
 
+### Merge readiness and merge authority
+
+本節における review completion（Resolution Contract の完了を含む）が
+成立した状態を **merge-ready** と呼びます。Review contracts および
+Review stopping rules で `merge` と記述する到達点は、merge-ready の
+成立を指し、merge を実行してよいという判断そのものとは同義ではありません。
+
+merge execution authority は、Review Protocol とは別の contract /
+context として扱います。current Task、Execution Envelope、または
+explicit な authority が merge の実行を許可している場合に限り、agent は
+merge を実行してよいです。
+
+merge authority が明示されていない場合、または別 authority の承認が
+必要な場合、agent は merge を実行せず、merge-ready の状態を報告した
+上で停止し、authority escalation / handoff します。
+
+この分離は、すべての PR で Human diff approval を mandatory にする
+ことを意味しません。GitHub の required approval 数を増やす rule でも
+ありません。provider や model 固有の rule にもしません。
+
 ### Review Adapter boundary
 
 provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
@@ -434,6 +454,34 @@ completion evidence が得られない場合は、trigger 前提を疑い、Acqu
 Contract に従って `unknown` として扱います。特定 provider が常に特定の trigger 方法を
 要求するという恒久仕様は Kernel に置かず、observed evidence として capability/profile
 側で再検証可能な形にします。
+
+## Foundation Change Protocol
+
+Foundation 自身の canonical rule を変更する場合の、provider-neutral な
+最小 contract です。この protocol は Skill / Profile へ複製せず、変更を
+検討する際は本節を参照します。
+
+Observation は、そのままでは Issue や mandatory rule へ自動的に昇格しません。
+
+mandatory な Foundation change は、原則として次のいずれかで正当化します。
+
+1. 既存の mandatory / manual step を置き換える
+2. material defect を deterministically 防止する
+3. demonstrated recurring / escaped failure へ対処する
+
+Change Proposal は、少なくとも次を表現できるものとします。
+
+- Problem
+- Evidence
+- Proposed Change
+- Expected Effect
+- Trade-off
+- Scope
+- Success Criterion
+
+change class や review 強度は、固定の provider 名へ結びつけません。単発の
+friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
+化しません。
 
 ## Technology profile: Next.js + Supabase
 

--- a/test/fixtures/guardrails/architecture-reverse-import/src/app/entry.ts
+++ b/test/fixtures/guardrails/architecture-reverse-import/src/app/entry.ts
@@ -1,0 +1,1 @@
+export const entry = 'entry';

--- a/test/fixtures/guardrails/architecture-reverse-import/src/shared/aliased-app.ts
+++ b/test/fixtures/guardrails/architecture-reverse-import/src/shared/aliased-app.ts
@@ -1,0 +1,3 @@
+import { entry } from '@/app/entry';
+
+export const aliasedAppEntry = entry;

--- a/test/fixtures/guardrails/architecture-reverse-import/src/shared/aliased-features.ts
+++ b/test/fixtures/guardrails/architecture-reverse-import/src/shared/aliased-features.ts
@@ -1,0 +1,3 @@
+import { feature } from '@/features/feature';
+
+export const aliasedFeatureModel = feature;

--- a/test/fixtures/guardrails/architecture-reverse-import/src/shared/nested/deep.ts
+++ b/test/fixtures/guardrails/architecture-reverse-import/src/shared/nested/deep.ts
@@ -1,0 +1,3 @@
+import { feature } from '../../features/feature';
+
+export const deepModel = feature;

--- a/test/fixtures/guardrails/architecture-reverse-import/tsconfig.json
+++ b/test/fixtures/guardrails/architecture-reverse-import/tsconfig.json
@@ -1,1 +1,5 @@
-{ "extends": "../../../../profiles/next-supabase/quality/tsconfig.quality.json", "include": ["src"] }
+{
+  "extends": "../../../../profiles/next-supabase/quality/tsconfig.quality.json",
+  "compilerOptions": { "baseUrl": ".", "paths": { "@/*": ["src/*"] } },
+  "include": ["src"]
+}

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -107,4 +107,18 @@ test("core policy separates merge-readiness from merge execution authority", asy
       "authority が明示されていない、または別 authority の承認が必要な場合は merge を実行せず、merge-ready の状態を報告して停止し、authority escalation / handoff します。",
     ),
   );
+
+  // Regression proof (converged CodeRabbit + independent Claude Discovery finding
+  // on this PR): Step 13 must not contain an unqualified "...時点で merge します"
+  // completion sentence a skimming reader/agent could act on as an unconditional
+  // merge instruction. Both completion branches must read as a merge-ready
+  // determination instead.
+  assert.doesNotMatch(
+    reviewCode,
+    /時点で merge します/,
+    "review-code.md Step 13 must not phrase review completion as an unqualified merge instruction",
+  );
+  assert.ok(
+    containsText(reviewCode, "が完了した時点で merge-ready と判定します。"),
+  );
 });

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+test("core policy defines the Foundation Change Protocol", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("## Foundation Change Protocol"));
+  assert.ok(
+    containsText(core, "Observation は、そのままでは Issue や mandatory rule へ自動的に昇格しません。"),
+  );
+
+  for (const reason of [
+    "既存の mandatory / manual step を置き換える",
+    "material defect を deterministically 防止する",
+    "demonstrated recurring / escaped failure へ対処する",
+  ]) {
+    assert.ok(core.includes(reason), `missing Foundation Change justification: ${reason}`);
+  }
+
+  for (const field of [
+    "Problem",
+    "Evidence",
+    "Proposed Change",
+    "Expected Effect",
+    "Trade-off",
+    "Scope",
+    "Success Criterion",
+  ]) {
+    assert.ok(core.includes(field), `Change Proposal must express: ${field}`);
+  }
+
+  assert.ok(
+    containsText(
+      core,
+      "単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory 化しません。",
+    ),
+  );
+
+  // Foundation Change Protocol stays provider-neutral, like the rest of the Kernel.
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("core policy separates merge-readiness from merge execution authority", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  assert.ok(core.includes("### Merge readiness and merge authority"));
+  assert.ok(
+    containsText(
+      core,
+      "review completion（Resolution Contract の完了を含む）が成立した状態を **merge-ready** と呼びます。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "merge execution authority は、Review Protocol とは別の contract / context として扱います。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "current Task、Execution Envelope、または explicit な authority が merge の実行を許可している場合に限り、agent は merge を実行してよいです。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "merge authority が明示されていない場合、または別 authority の承認が必要な場合、agent は merge を実行せず、merge-ready の状態を報告した上で停止し、authority escalation / handoff します。",
+    ),
+  );
+
+  // This is a stop/report gate, not a new mandatory Human diff-approval or
+  // GitHub-required-approval-count rule, and it stays provider-neutral.
+  assert.ok(
+    containsText(
+      core,
+      "この分離は、すべての PR で Human diff approval を mandatory にすることを意味しません。GitHub の required approval 数を増やす rule でもありません。provider や model 固有の rule にもしません。",
+    ),
+  );
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+
+  // review-code.md's own merge step must defer execution to the canonical
+  // authority contract instead of treating review completion as license to merge.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "merge の実行は `policy/core.md` の Merge readiness and merge authority に従い、current Task / Execution Envelope / explicit authority が merge execution を許可している場合のみ行います。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "authority が明示されていない、または別 authority の承認が必要な場合は merge を実行せず、merge-ready の状態を報告して停止し、authority escalation / handoff します。",
+    ),
+  );
+});

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -114,11 +114,20 @@ test("core policy separates merge-readiness from merge execution authority", asy
   // merge instruction. Both completion branches must read as a merge-ready
   // determination instead.
   assert.doesNotMatch(
-    reviewCode,
-    /時点で merge します/,
+    stripWhitespace(reviewCode),
+    /時点でmergeします/,
     "review-code.md Step 13 must not phrase review completion as an unqualified merge instruction",
   );
   assert.ok(
-    containsText(reviewCode, "が完了した時点で merge-ready と判定します。"),
+    containsText(
+      reviewCode,
+      "required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge-ready と判定します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Closure Acquisition & Validity・Closure Resolution が完了した時点で merge-ready と判定します。",
+    ),
   );
 });

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -777,7 +777,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution が完了した時点で merge します。",
+      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution が完了した時点で merge-ready と判定します。",
     ),
   );
 
@@ -928,7 +928,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge します。",
+      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge-ready と判定します。",
     ),
   );
 

--- a/tooling/verify-guardrails.mjs
+++ b/tooling/verify-guardrails.mjs
@@ -11,7 +11,7 @@ const fixturesRoot = path.join(root, "test", "fixtures", "guardrails");
 const profileConfig = path.join(root, "profiles", "next-supabase", "quality", "eslint.config.mjs");
 const prettierConfig = path.join(root, "profiles", "next-supabase", "quality", "prettier.config.mjs");
 const expectedLintFailures = new Map([
-  ["architecture-reverse-import", { ruleId: "no-restricted-imports", minimumCount: 2 }],
+  ["architecture-reverse-import", { ruleId: "no-restricted-imports", minimumCount: 4 }],
   ["no-any", { ruleId: "@typescript-eslint/no-explicit-any", minimumCount: 1 }],
   ["no-assertion", { ruleId: "no-restricted-syntax", minimumCount: 2 }],
   ["no-non-null", { ruleId: "@typescript-eslint/no-non-null-assertion", minimumCount: 1 }],

--- a/tooling/verify-guardrails.mjs
+++ b/tooling/verify-guardrails.mjs
@@ -11,7 +11,7 @@ const fixturesRoot = path.join(root, "test", "fixtures", "guardrails");
 const profileConfig = path.join(root, "profiles", "next-supabase", "quality", "eslint.config.mjs");
 const prettierConfig = path.join(root, "profiles", "next-supabase", "quality", "prettier.config.mjs");
 const expectedLintFailures = new Map([
-  ["architecture-reverse-import", { ruleId: "no-restricted-imports", minimumCount: 1 }],
+  ["architecture-reverse-import", { ruleId: "no-restricted-imports", minimumCount: 2 }],
   ["no-any", { ruleId: "@typescript-eslint/no-explicit-any", minimumCount: 1 }],
   ["no-assertion", { ruleId: "no-restricted-syntax", minimumCount: 2 }],
   ["no-non-null", { ruleId: "@typescript-eslint/no-non-null-assertion", minimumCount: 1 }],
@@ -46,7 +46,20 @@ for (const name of fixtureNames) {
   const boundaryConfig = name === "architecture-reverse-import"
     ? [profile.architectureImportBoundary({
       files: ["src/shared/**/*.{ts,tsx}"],
-      restrictedPatterns: ["../features/**", "../app/**", "@/features/**", "@/app/**"],
+      // Depth-independent, anchored patterns (see profiles/next-supabase/quality/README.md):
+      // "../**/features" (and "/**") matches a restricted import regardless of how deep the
+      // importing shared-layer file is nested, unlike a bare "../features/**" pattern which
+      // only matches a direct sibling import.
+      restrictedPatterns: [
+        "../**/features",
+        "../**/features/**",
+        "../**/app",
+        "../**/app/**",
+        "@/features",
+        "@/features/**",
+        "@/app",
+        "@/app/**",
+      ],
       message: "Fixture shared layer must not import higher layers.",
     })]
     : [];


### PR DESCRIPTION
#18 に関連（bounded pre-freeze fix）。**このPRは #18 をcloseしません** — merge / Issue close の authority は #18 の Task Contract により PO に留保されています。

## Scope

Bootstrap audit（親 #1）で確認された、v0.1 freeze を妨げる4つのdemonstrated Foundation-owned defectのみを対象とします。それ以外のfirst-consumer Observation（例: `service_role` documentation、stage-tracker側の repin）は対象外です。

1. **Foundation Change Protocol** を `policy/core.md` にcanonical化（新設 `## Foundation Change Protocol`）: Observationは自動的にmandatory ruleへ昇格しない。mandatory changeは「既存step置換 / material defectのdeterministic防止 / demonstrated recurring・escaped failureへの対処」のいずれかで正当化する。Change Proposalは Problem/Evidence/Proposed Change/Expected Effect/Trade-off/Scope/Success Criterion を表現できる。provider-neutral。
2. **merge-readiness と merge authority の分離** を `policy/core.md`（新設 `### Merge readiness and merge authority`、Review Protocol配下）に定義し、`skills/review-code.md` のMergeステップへ整合させました。review完了は `merge-ready` であり、merge実行そのものの許可ではありません。merge execution authorityはTask / Execution Envelopeの別contractとして扱い、authorityが不明な場合はmerge-readyを報告して停止・escalationします。全PRでのHuman diff approval mandatory化やGitHub required approval数の増加は行っていません。
3. **`profiles/next-supabase/quality/README.md`** のimport-boundary exampleを、depth-independent / anchoredなpattern（`../**/ui`, `../**/ui/**`, `@/ui`, `@/ui/**` 等）へ置き換えました。これはfirst real consumer（`reitojike/stage-tracker`）で実証済みの修正スタイルです。旧例の `../ui/**` はdepth-dependentで、nested importを取りこぼしていました。`architectureImportBoundary()` mechanism自体は変更しておらず、引き続きconsumerがpatternを渡します。
4. **`.github/workflows/claude-review.yml`**: `@claude` PR commentトリガーに、`github.event.comment.author_association` が `OWNER`/`MEMBER`/`COLLABORATOR` であることを追加条件としました（従来はcomment本文に`@claude`が含まれるだけで、forkからのuntrusted commenterでも `CLAUDE_CODE_OAUTH_TOKEN` を保持するjobを起動できました）。`--max-turns` / `timeout-minutes` は、first consumerで実測されたbaselineである `10`/`15` から `30`/`25` へ引き上げました。

## Deterministic Verification

- `npm test` — 11/11 green（新規テストファイル2本: `foundation-change-and-merge-authority.test.mjs`, `claude-review-workflow.test.mjs`）
- `npm run test:guardrails` — 8/8 fixture検証green。`architecture-reverse-import` にnested importのケースを追加し、旧（depth-dependent）patternではredになり、修正後のpatternでgreenになることをcommit前に実測済み
- `test/fixtures/consumer/AGENTS.md` は `policy/core.md` 更新に伴いdriftしていたため `npm run sync:fixture` で再生成。`check:fixture` / drift検知はgreen
- 既存の `test/review-protocol.test.mjs`（1349行、厳密なtext assertion）への regression なし — すべての変更は既存のassertion対象文字列を書き換えず、追記のみで行いました

## Review Selection（#18準拠）

canonical normative policy/skill、technology profile guidance、executable GitHub Actions workflow、deterministic tests/fixturesを同時に含むmixed change。required valid independent Discovery perspectives = 2、うち少なくとも1つはClaude workflow自身以外（このPRがClaude workflowを変更するため）。Discovery / Resolution / Closure evidenceは完了ししだいこのPRへコメントで記録します。

## Merge authority

#18 の Task Contract により、このPRにmerge / Issue close authorityはありません。PO の明示的な指示なしにmergeせず、#18 もcloseしません（上記に意図的に `Closes #18` を含めていません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - レビュー完了とマージ実行権限を分離し、権限不明時は安全に停止・報告する運用を追加しました。
  - 基盤ルールの変更手順と、変更提案に必要な要件を明文化しました。
  - UI・インフラ間の不適切な相対パス／エイリアス参照を、階層に関係なく検出できるよう強化しました。
  - レビュー自動実行の対象投稿者を制限し、処理時間と試行回数の上限を見直しました。

- **テスト**
  - レビュー運用、権限管理、インポート境界チェックの検証を追加・拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->