### PR TITLE
Review runtime: durable evidence recoverability契約とCodeRabbit手動化 (#22)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 reviews:
   auto_review:
     enabled: false
+  review_status: false

--- a/policy/core.md
+++ b/policy/core.md
@@ -220,12 +220,14 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 残さない場合（例: 実装 session 内で動く subagent review）は、その run の
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
-扱いません。reviewer mechanism が残す surface に、reviewed target・
-reviewed artifact set・finding 内容・completion 状態を後続 session が
-独立に判定できる形で含んでいる場合は、その surface 自体をこの record の
-recoverable な representation として扱ってよく、別途 record を post し
-直す必要はありません。intended artifact set が review 対象になっている
-かを surface から判定できない場合は、この十分条件を満たしません。
+扱いません。reviewer mechanism が残す surface から、本 Contract が定義する
+Completion と Validity の要求事項（reviewed target の一致、target
+artifact set の coverage、required context へのアクセス可否、finding
+内容、completion 状態を含む）を後続 session が独立に判定できる場合は、
+その surface 自体をこの record の recoverable な representation として
+扱ってよく、別途 record を post し直す必要はありません。これらの要求
+事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、
+その run を recoverable な evidence として扱いません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/policy/core.md
+++ b/policy/core.md
@@ -221,10 +221,11 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
 扱いません。reviewer mechanism が残す surface に、reviewed target・
-finding 内容・completion 状態を後続 session が独立に判定できる形で
-含んでいる場合は、その surface 自体をこの record の recoverable な
-representation として扱ってよく、別途 record を post し直す必要は
-ありません。
+reviewed artifact set・finding 内容・completion 状態を後続 session が
+独立に判定できる形で含んでいる場合は、その surface 自体をこの record の
+recoverable な representation として扱ってよく、別途 record を post し
+直す必要はありません。intended artifact set が review 対象になっている
+かを surface から判定できない場合は、この十分条件を満たしません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/policy/core.md
+++ b/policy/core.md
@@ -220,7 +220,11 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 残さない場合（例: 実装 session 内で動く subagent review）は、その run の
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
-扱いません。
+扱いません。reviewer mechanism が残す surface に、reviewed target・
+finding 内容・completion 状態を後続 session が独立に判定できる形で
+含んでいる場合は、その surface 自体をこの record の recoverable な
+representation として扱ってよく、別途 record を post し直す必要は
+ありません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/policy/core.md
+++ b/policy/core.md
@@ -211,6 +211,17 @@ completion していても invalid です。この場合、record は `status: c
 かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
+**acquisition の record は、後続 session から独立に recoverable な場所へ
+persist されて初めて durable evidence です。** review を行った
+agent/session が終了した後、別の後続 session がその session の記憶に
+頼らず参照できる場所（PR/Issue 上の comment 等）に record が存在しない
+限り、その run を merge / review completion の根拠として扱いません。
+reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
+残さない場合（例: 実装 session 内で動く subagent review）は、その run の
+record を上記の record schema に沿った内容で、そのような場所へ明示的に
+persist しない限り、session 終了後には recoverable な evidence として
+扱いません。
+
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。

--- a/policy/core.md
+++ b/policy/core.md
@@ -213,21 +213,23 @@ intended artifact set が review されていない場合も invalid です。
 
 **acquisition の record は、後続 session から独立に recoverable な場所へ
 persist されて初めて durable evidence です。** review を行った
-agent/session が終了した後、別の後続 session がその session の記憶に
-頼らず参照できる場所（PR/Issue 上の comment 等）に record が存在しない
-限り、その run を merge / review completion の根拠として扱いません。
-reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
-残さない場合（例: 実装 session 内で動く subagent review）は、その run の
-record を上記の record schema に沿った内容で、そのような場所へ明示的に
-persist しない限り、session 終了後には recoverable な evidence として
-扱いません。reviewer mechanism が残す surface から、本 Contract が定義する
-Completion と Validity の要求事項（reviewed target の一致、target
-artifact set の coverage、required context へのアクセス可否、finding
-内容、completion 状態を含む）を後続 session が独立に判定できる場合は、
-その surface 自体をこの record の recoverable な representation として
-扱ってよく、別途 record を post し直す必要はありません。これらの要求
-事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、
-その run を recoverable な evidence として扱いません。
+agent/session が終了した後、別の後続 session が session の記憶に頼らず、
+本 Contract が定義する Completion と Validity の要求事項を独立に判定
+できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
+上の comment 等）に存在しない限り、その run を merge / review completion
+の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
+へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
+自体をこの record の recoverable な representation として扱ってよく、
+別途 record を post し直す必要はありません。含まれていない場合
+（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
+例えば実装 session 内で動く subagent review を含む）は、上記の record
+schema の各 field に加え、Completion と Validity の要求事項（reviewed
+target の一致、target artifact set の coverage、required context への
+アクセス可否、finding 内容、completion 状態を含む）を独立に判定できる
+情報を、そのような場所へ明示的に persist しない限り、session 終了後には
+recoverable な evidence として扱いません。record schema 自体（特に
+`validity` field）は判定結果の要約であり、その根拠情報の代わりには
+なりません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -193,7 +193,12 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
   inline/thread comment、review submission/summary、status/check、必要なら
   workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。
+  確認したか」を記録します。reviewer mechanism 自身がそのような外部から確認可能な
+  surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、
+  `collectOutputs()` に相当する手段として、その run の record を
+  `policy/core.md` の Acquisition & Validity Contract の record schema に
+  沿った内容で PR/Issue 上の comment 等へ明示的に persist し、それを
+  result locator とします。
 - `normalizeFindings()`: 集めた出力を record schema と triage category へ変換し、
   finding ごとに出典 surface と locator を残します。
 
@@ -205,6 +210,17 @@ manual trigger command を送って初めて review completion の evidence が�
 という一般原則の実測例として扱い、特定 provider が常に manual trigger を要求すると
 いう恒久仕様には昇格させません。同種の provider を扱う際は、automatic trigger を
 仮定せず、completion evidence が得られるまで `unknown` として扱ってください。
+
+別の観測として、ある reviewer は PR 上の明示的な mention コメントを trigger と
+する GitHub-native workflow を経由した場合、result（target 参照・finding・
+completion 状態）が PR の comment として繰り返し durable に残ることを確認して
+います。この観測は、in-session/subagent 実行のみに依存するより、reviewer が
+そのような GitHub-native trigger 経路を持つならそれを優先する方が
+Acquisition & Validity Contract の recoverability 要件を満たしやすい、という
+運用上の判断材料になります。ただしこれも特定 provider の恒久仕様ではなく、
+capability record 側で再検証可能な observed evidence として扱ってください。
+GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は、上記の
+`collectOutputs()` の persist 手順を必ず行います。
 
 ## Manual review pilot
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -193,11 +193,14 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
   inline/thread comment、review submission/summary、status/check、必要なら
   workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。この surface が、reviewed target・finding 内容・
-  completion 状態を後続 session が独立に判定できる形で含んでいれば、
-  `policy/core.md` の Acquisition & Validity Contract が要求する record の
-  recoverable な representation として、その surface 自体を result locator に
-  使えます（別途 record を post し直す必要はありません）。reviewer mechanism
+  確認したか」を記録します。この surface が、reviewed target・reviewed
+  artifact set・finding 内容・completion 状態を後続 session が独立に
+  判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity
+  Contract が要求する record の recoverable な representation として、
+  その surface 自体を result locator に使えます（別途 record を post し
+  直す必要はありません）。intended artifact set が review 対象になって
+  いるかを surface から判定できない場合は、この十分条件を満たしません。
+  reviewer mechanism
   自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装
   session 内で動く subagent review）は、`collectOutputs()` に相当する手段
   として、その run の record を上記の record schema に沿った内容で PR/Issue

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -193,12 +193,15 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
   inline/thread comment、review submission/summary、status/check、必要なら
   workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。reviewer mechanism 自身がそのような外部から確認可能な
-  surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、
-  `collectOutputs()` に相当する手段として、その run の record を
-  `policy/core.md` の Acquisition & Validity Contract の record schema に
-  沿った内容で PR/Issue 上の comment 等へ明示的に persist し、それを
-  result locator とします。
+  確認したか」を記録します。この surface が、reviewed target・finding 内容・
+  completion 状態を後続 session が独立に判定できる形で含んでいれば、
+  `policy/core.md` の Acquisition & Validity Contract が要求する record の
+  recoverable な representation として、その surface 自体を result locator に
+  使えます（別途 record を post し直す必要はありません）。reviewer mechanism
+  自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装
+  session 内で動く subagent review）は、`collectOutputs()` に相当する手段
+  として、その run の record を上記の record schema に沿った内容で PR/Issue
+  上の comment 等へ明示的に persist し、それを result locator とします。
 - `normalizeFindings()`: 集めた出力を record schema と triage category へ変換し、
   finding ごとに出典 surface と locator を残します。
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -193,18 +193,17 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
   inline/thread comment、review submission/summary、status/check、必要なら
   workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。この surface が、reviewed target・reviewed
-  artifact set・finding 内容・completion 状態を後続 session が独立に
-  判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity
-  Contract が要求する record の recoverable な representation として、
-  その surface 自体を result locator に使えます（別途 record を post し
-  直す必要はありません）。intended artifact set が review 対象になって
-  いるかを surface から判定できない場合は、この十分条件を満たしません。
-  reviewer mechanism
-  自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装
-  session 内で動く subagent review）は、`collectOutputs()` に相当する手段
-  として、その run の record を上記の record schema に沿った内容で PR/Issue
-  上の comment 等へ明示的に persist し、それを result locator とします。
+  確認したか」を記録します。この surface から `policy/core.md` の
+  Acquisition & Validity Contract が定義する Completion と Validity の
+  要求事項を後続 session が独立に判定できれば、その surface 自体を同
+  Contract の record の recoverable な representation として result
+  locator に使えます（別途 record を post し直す必要はありません）。
+  それらの要求事項のいずれかを surface から判定できない場合は、
+  reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
+  残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、
+  `collectOutputs()` に相当する手段として、その run の record を
+  `policy/core.md` の record schema に沿った内容で PR/Issue 上の comment
+  等へ明示的に persist し、それを result locator とします。
 - `normalizeFindings()`: 集めた出力を record schema と triage category へ変換し、
   finding ごとに出典 surface と locator を残します。
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -201,9 +201,11 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   それらの要求事項のいずれかを surface から判定できない場合は、
   reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
   残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、
-  `collectOutputs()` に相当する手段として、その run の record を
-  `policy/core.md` の record schema に沿った内容で PR/Issue 上の comment
-  等へ明示的に persist し、それを result locator とします。
+  `collectOutputs()` に相当する手段として、`policy/core.md` の record
+  schema の各 field に加え、上記の Completion / Validity 要求事項を独立に
+  判定できる情報（`validity` 等の判定結果の要約だけでなく、その根拠と
+  なる情報）を PR/Issue 上の comment 等へ明示的に persist し、それを
+  result locator とします。
 - `normalizeFindings()`: 集めた出力を record schema と triage category へ変換し、
   finding ごとに出典 surface と locator を残します。
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -228,12 +228,14 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 残さない場合（例: 実装 session 内で動く subagent review）は、その run の
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
-扱いません。reviewer mechanism が残す surface に、reviewed target・
-reviewed artifact set・finding 内容・completion 状態を後続 session が
-独立に判定できる形で含んでいる場合は、その surface 自体をこの record の
-recoverable な representation として扱ってよく、別途 record を post し
-直す必要はありません。intended artifact set が review 対象になっている
-かを surface から判定できない場合は、この十分条件を満たしません。
+扱いません。reviewer mechanism が残す surface から、本 Contract が定義する
+Completion と Validity の要求事項（reviewed target の一致、target
+artifact set の coverage、required context へのアクセス可否、finding
+内容、completion 状態を含む）を後続 session が独立に判定できる場合は、
+その surface 自体をこの record の recoverable な representation として
+扱ってよく、別途 record を post し直す必要はありません。これらの要求
+事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、
+その run を recoverable な evidence として扱いません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -221,21 +221,23 @@ intended artifact set が review されていない場合も invalid です。
 
 **acquisition の record は、後続 session から独立に recoverable な場所へ
 persist されて初めて durable evidence です。** review を行った
-agent/session が終了した後、別の後続 session がその session の記憶に
-頼らず参照できる場所（PR/Issue 上の comment 等）に record が存在しない
-限り、その run を merge / review completion の根拠として扱いません。
-reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
-残さない場合（例: 実装 session 内で動く subagent review）は、その run の
-record を上記の record schema に沿った内容で、そのような場所へ明示的に
-persist しない限り、session 終了後には recoverable な evidence として
-扱いません。reviewer mechanism が残す surface から、本 Contract が定義する
-Completion と Validity の要求事項（reviewed target の一致、target
-artifact set の coverage、required context へのアクセス可否、finding
-内容、completion 状態を含む）を後続 session が独立に判定できる場合は、
-その surface 自体をこの record の recoverable な representation として
-扱ってよく、別途 record を post し直す必要はありません。これらの要求
-事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、
-その run を recoverable な evidence として扱いません。
+agent/session が終了した後、別の後続 session が session の記憶に頼らず、
+本 Contract が定義する Completion と Validity の要求事項を独立に判定
+できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
+上の comment 等）に存在しない限り、その run を merge / review completion
+の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
+へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
+自体をこの record の recoverable な representation として扱ってよく、
+別途 record を post し直す必要はありません。含まれていない場合
+（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
+例えば実装 session 内で動く subagent review を含む）は、上記の record
+schema の各 field に加え、Completion と Validity の要求事項（reviewed
+target の一致、target artifact set の coverage、required context への
+アクセス可否、finding 内容、completion 状態を含む）を独立に判定できる
+情報を、そのような場所へ明示的に persist しない限り、session 終了後には
+recoverable な evidence として扱いません。record schema 自体（特に
+`validity` field）は判定結果の要約であり、その根拠情報の代わりには
+なりません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -229,10 +229,11 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
 扱いません。reviewer mechanism が残す surface に、reviewed target・
-finding 内容・completion 状態を後続 session が独立に判定できる形で
-含んでいる場合は、その surface 自体をこの record の recoverable な
-representation として扱ってよく、別途 record を post し直す必要は
-ありません。
+reviewed artifact set・finding 内容・completion 状態を後続 session が
+独立に判定できる形で含んでいる場合は、その surface 自体をこの record の
+recoverable な representation として扱ってよく、別途 record を post し
+直す必要はありません。intended artifact set が review 対象になっている
+かを surface から判定できない場合は、この十分条件を満たしません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -228,7 +228,11 @@ reviewer mechanism 自身がそのような外部から確認可能な surface �
 残さない場合（例: 実装 session 内で動く subagent review）は、その run の
 record を上記の record schema に沿った内容で、そのような場所へ明示的に
 persist しない限り、session 終了後には recoverable な evidence として
-扱いません。
+扱いません。reviewer mechanism が残す surface に、reviewed target・
+finding 内容・completion 状態を後続 session が独立に判定できる形で
+含んでいる場合は、その surface 自体をこの record の recoverable な
+representation として扱ってよく、別途 record を post し直す必要は
+ありません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -219,6 +219,17 @@ completion していても invalid です。この場合、record は `status: c
 かつ `validity: invalid` として表現します。
 intended artifact set が review されていない場合も invalid です。
 
+**acquisition の record は、後続 session から独立に recoverable な場所へ
+persist されて初めて durable evidence です。** review を行った
+agent/session が終了した後、別の後続 session がその session の記憶に
+頼らず参照できる場所（PR/Issue 上の comment 等）に record が存在しない
+限り、その run を merge / review completion の根拠として扱いません。
+reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を
+残さない場合（例: 実装 session 内で動く subagent review）は、その run の
+record を上記の record schema に沿った内容で、そのような場所へ明示的に
+persist しない限り、session 終了後には recoverable な evidence として
+扱いません。
+
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -204,6 +204,17 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、その run の record を上記の record schema に沿った内容で、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
     ),
   );
+
+  // Closure round (Codex P2 on PR #24): an existing provider surface that
+  // already carries reviewed target / findings / completion in a later-session-
+  // recoverable form counts as the record itself — this must not be read as
+  // requiring every already-durable run to additionally post a normalized record.
+  assert.ok(
+    containsText(
+      core,
+      "reviewer mechanism が残す surface に、reviewed target・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいる場合は、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+    ),
+  );
   assert.ok(
     containsText(core, "positive completion evidence のない empty output は `unknown` として扱います。"),
   );
@@ -701,6 +712,16 @@ test("review skills document procedure without duplicating normative rules", asy
     reviewCode,
     /GitHub-native trigger[^\n]*(Claude|Codex|CodeRabbit)/,
     "the GitHub-native-trigger preference must stay an anonymized observed example, not a provider-specific permanent rule",
+  );
+
+  // Closure round (Codex P2 on PR #24): collectOutputs() must state that a
+  // sufficiently informative existing surface counts as the recoverable
+  // record itself, not just describe the no-surface persistence fallback.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この surface が、reviewed target・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity Contract が要求する record の recoverable な representation として、その surface 自体を result locator に使えます",
+    ),
   );
 
   // Commit range as review target (Codex P1): review target is SHA and,

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -206,26 +206,46 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   );
 
   // Closure round (Codex P2 on PR #24): an existing provider surface that
-  // already carries reviewed target / findings / completion in a later-session-
-  // recoverable form counts as the record itself — this must not be read as
-  // requiring every already-durable run to additionally post a normalized record.
+  // already carries enough information in a later-session-recoverable form
+  // counts as the record itself — this must not be read as requiring every
+  // already-durable run to additionally post a normalized record.
+  //
+  // 3rd closure round (root-cause fix, Codex P2 x2 + Claude): the first two
+  // closure attempts hand-enumerated which elements the surface must carry
+  // (target, then +artifact set), and each round a reviewer found one more
+  // Validity/Completion element missing from the hand-kept list (required
+  // context accessibility was still absent after round 2). Rather than
+  // enumerate a 3rd time, this defers to "Completion と Validity の要求事項"
+  // as a whole, so no future element can be missing from this sufficiency
+  // bar without also being missing from the Contract's own definition above.
   assert.ok(
     containsText(
       core,
-      "reviewer mechanism が残す surface に、reviewed target・reviewed artifact set・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいる場合は、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+      "reviewer mechanism が残す surface から、本 Contract が定義する Completion と Validity の要求事項",
     ),
   );
-  // 2nd closure round (Claude on PR #24): the surface-sufficiency bar must
-  // also require artifact-set coverage to be judgable, mirroring Validity's
-  // separate "intended artifact set が review 対象になっている" requirement —
-  // otherwise a target-matching, 0-finding comment that silently skipped part
-  // of the intended artifact set could be misread as durable valid evidence.
   assert.ok(
     containsText(
       core,
-      "intended artifact set が review 対象になっているかを surface から判定できない場合は、この十分条件を満たしません。",
+      "その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
     ),
   );
+  assert.ok(
+    containsText(
+      core,
+      "これらの要求事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、その run を recoverable な evidence として扱いません。",
+    ),
+  );
+  // The sufficiency bar must not silently re-narrow to only a hand-picked
+  // subset — it must cover Validity's own 4 listed requirements by reference.
+  for (const requirement of [
+    "reviewed SHA / range が intended target と一致している",
+    "intended artifact set が review 対象になっている",
+    "required context へアクセスできた",
+    "execution / acquisition が途中で欠落していない",
+  ]) {
+    assert.ok(core.includes(requirement), `Validity requirement must still be listed: ${requirement}`);
+  }
   assert.ok(
     containsText(core, "positive completion evidence のない empty output は `unknown` として扱います。"),
   );
@@ -712,7 +732,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、`collectOutputs()` に相当する手段として、その run の record を",
+      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、その run の record を",
     ),
   );
   assert.ok(
@@ -728,18 +748,22 @@ test("review skills document procedure without duplicating normative rules", asy
   // Closure round (Codex P2 on PR #24): collectOutputs() must state that a
   // sufficiently informative existing surface counts as the recoverable
   // record itself, not just describe the no-surface persistence fallback.
+  //
+  // 3rd closure round (root-cause fix): defer to policy's own Completion /
+  // Validity requirements by reference instead of re-enumerating them here
+  // too — the skill already says "skill は policy を使った作業方法を説明し、
+  // 規範的なルールを複製しません", and a second hand-kept list here would
+  // reintroduce the same drift risk the policy.md fix just eliminated.
   assert.ok(
     containsText(
       reviewCode,
-      "この surface が、reviewed target・reviewed artifact set・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity Contract が要求する record の recoverable な representation として、その surface 自体を result locator に使えます",
+      "この surface から `policy/core.md` の Acquisition & Validity Contract が定義する Completion と Validity の要求事項を後続 session が独立に判定できれば、その surface 自体を同 Contract の record の recoverable な representation として result locator に使えます",
     ),
   );
-  // 2nd closure round (Claude on PR #24): artifact-set coverage must be part
-  // of the surface-sufficiency bar here too, not just in policy/core.md.
   assert.ok(
     containsText(
       reviewCode,
-      "intended artifact set が review 対象になっているかを surface から判定できない場合は、この十分条件を満たしません。",
+      "それらの要求事項のいずれかを surface から判定できない場合は",
     ),
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -212,7 +212,18 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "reviewer mechanism が残す surface に、reviewed target・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいる場合は、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+      "reviewer mechanism が残す surface に、reviewed target・reviewed artifact set・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいる場合は、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+    ),
+  );
+  // 2nd closure round (Claude on PR #24): the surface-sufficiency bar must
+  // also require artifact-set coverage to be judgable, mirroring Validity's
+  // separate "intended artifact set が review 対象になっている" requirement —
+  // otherwise a target-matching, 0-finding comment that silently skipped part
+  // of the intended artifact set could be misread as durable valid evidence.
+  assert.ok(
+    containsText(
+      core,
+      "intended artifact set が review 対象になっているかを surface から判定できない場合は、この十分条件を満たしません。",
     ),
   );
   assert.ok(
@@ -720,7 +731,15 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "この surface が、reviewed target・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity Contract が要求する record の recoverable な representation として、その surface 自体を result locator に使えます",
+      "この surface が、reviewed target・reviewed artifact set・finding 内容・completion 状態を後続 session が独立に判定できる形で含んでいれば、`policy/core.md` の Acquisition & Validity Contract が要求する record の recoverable な representation として、その surface 自体を result locator に使えます",
+    ),
+  );
+  // 2nd closure round (Claude on PR #24): artifact-set coverage must be part
+  // of the surface-sufficiency bar here too, not just in policy/core.md.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "intended artifact set が review 対象になっているかを surface から判定できない場合は、この十分条件を満たしません。",
     ),
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -188,6 +188,22 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     ),
   );
   assert.ok(containsText(core, "intended artifact set が review されていない場合も invalid です。"));
+
+  // Issue #22: acquisition records are only durable evidence once persisted
+  // somewhere a later session can recover independent of the reviewing
+  // agent/session (e.g. a PR/Issue comment), not merely "recordable".
+  assert.ok(
+    containsText(
+      core,
+      "acquisition の record は、後続 session から独立に recoverable な場所へpersist されて初めて durable evidence です。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、その run の record を上記の record schema に沿った内容で、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
+    ),
+  );
   assert.ok(
     containsText(core, "positive completion evidence のない empty output は `unknown` として扱います。"),
   );
@@ -666,6 +682,26 @@ test("review skills document procedure without duplicating normative rules", asy
     assert.ok(reviewCode.includes(phrase), `review-code.md missing: ${phrase}`);
   }
   assert.ok(containsText(reviewCode, "Claude / Codex / CodeRabbit"));
+
+  // Issue #22: collectOutputs() must cover mechanisms with no external
+  // surface of their own (e.g. in-session/subagent review) by persisting the
+  // run's record somewhere recoverable, deferring to policy's record schema
+  // rather than restating it.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、`collectOutputs()` に相当する手段として、その run の record を",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "GitHub-native trigger 経路を持つならそれを優先する方が"),
+    "review-code.md must document the observed GitHub-native-trigger preference without hardcoding a permanent provider rule",
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /GitHub-native trigger[^\n]*(Claude|Codex|CodeRabbit)/,
+    "the GitHub-native-trigger preference must stay an anonymized observed example, not a provider-specific permanent rule",
+  );
 
   // Commit range as review target (Codex P1): review target is SHA and,
   // applicable, commit range, per Selection Contract's own field name — not

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -198,13 +198,6 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "acquisition の record は、後続 session から独立に recoverable な場所へpersist されて初めて durable evidence です。",
     ),
   );
-  assert.ok(
-    containsText(
-      core,
-      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、その run の record を上記の record schema に沿った内容で、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
-    ),
-  );
-
   // Closure round (Codex P2 on PR #24): an existing provider surface that
   // already carries enough information in a later-session-recoverable form
   // counts as the record itself — this must not be read as requiring every
@@ -221,20 +214,41 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "reviewer mechanism が残す surface から、本 Contract が定義する Completion と Validity の要求事項",
+      "本 Contract が定義する Completion と Validity の要求事項を独立に判定できるだけの情報が",
     ),
   );
   assert.ok(
     containsText(
       core,
-      "その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+      "reviewer mechanism が外部から確認可能な surface へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
+    ),
+  );
+  // 4th closure round (root-cause fix #2, Codex P2): the first root-cause fix
+  // still let the no-surface fallback path point at the bare record schema,
+  // whose `validity` field is only a self-asserted conclusion — so a later
+  // session had no way to independently re-derive it, unlike the surface
+  // branch which requires independently-judgable raw information. Unify both
+  // branches under one bar (enough info to independently judge Completion/
+  // Validity) so the schema's summary fields can never again be mistaken for
+  // a substitute for the evidence behind them.
+  assert.ok(
+    containsText(
+      core,
+      "含まれていない場合（reviewer mechanism 自身がそのような surface へ結果を残さない場合、例えば実装 session 内で動く subagent review を含む）は、上記の record schema の各 field に加え、Completion と Validity の要求事項",
     ),
   );
   assert.ok(
     containsText(
       core,
-      "これらの要求事項のいずれかを surface から判定できない場合は、この十分条件を満たさず、その run を recoverable な evidence として扱いません。",
+      "を独立に判定できる情報を、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
     ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "record schema 自体（特に `validity` field）は判定結果の要約であり、その根拠情報の代わりにはなりません。",
+    ),
+    "the record schema's validity field must not be treated as sufficient evidence on its own",
   );
   // The sufficiency bar must not silently re-narrow to only a hand-picked
   // subset — it must cover Validity's own 4 listed requirements by reference.
@@ -732,7 +746,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、その run の record を",
+      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、`policy/core.md` の record schema の各 field に加え",
     ),
   );
   assert.ok(
@@ -764,6 +778,16 @@ test("review skills document procedure without duplicating normative rules", asy
     containsText(
       reviewCode,
       "それらの要求事項のいずれかを surface から判定できない場合は",
+    ),
+  );
+  // 4th closure round (root-cause fix #2, Codex P2): the no-surface fallback
+  // here must also require evidence for Completion/Validity, not just
+  // conformance to the bare record schema (whose `validity` field is only a
+  // self-asserted conclusion a later session can't independently re-derive).
+  assert.ok(
+    containsText(
+      reviewCode,
+      "`policy/core.md` の record schema の各 field に加え、上記の Completion / Validity 要求事項を独立に判定できる情報",
     ),
   );
 


### PR DESCRIPTION
Closes evaluation work for #22 (does not close the Issue itself — Issue #22 remains open per Review Protocol merge-ready stop point).

## Review Selection / Execution Contract record

### Selection Contract
- **artifact classification**: Normative（`policy/core.md` Kernel change を含む）
- **target artifact set**: `policy/core.md` / `skills/review-code.md` / `.coderabbit.yaml` / `test/fixtures/consumer/AGENTS.md`（生成物）/ `test/review-protocol.test.mjs`
- **expected target SHA**: `59dac83f2cb72e7610d70702ac8b872330a12323`
- **required review数**: 2（独立reviewer 2系統。Kernel policyを変更するNormative contractのため）
- **reviewer / capability**: Codex Cloud（automatic trigger）および Claude（GitHub-native `@claude review` mention trigger）

### Execution Contract
- **trigger**: Codexはこのpull request作成によるautomatic trigger。Claudeは `@claude review` の明示的mention。
- **渡すtarget**: 上記expected target SHA / target artifact set
- **timeout / retry**: transient failureはbounded retry。quota / rate limitは `unknown` として扱いsuccessに潰さない。

## 背景（Issue #22の実測）

stage-tracker PR #19では、in-session subagent reviewがdefectを見つけたが、session終了後にPR上からその証拠を再構成できなかった（durable evidence gap）。今回の調査で以下を実測した。

- Codex GitHub Review: 自動trigger + `Reviewed commit`明示、durable。現状維持。
- Claude GitHub-native review（既存 `.github/workflows/claude-review.yml` の `@claude` mention trigger）: ai-dev-foundation PR #21で複数round実際に使われ、durable evidenceを問題なく残せることを確認済み。新しいpaid契約は不要（既存subscription token）。
- CodeRabbit: 自動reviewは全PRで一貫してskip（実際の理由は「fewer than 10 stars」であり、Issue #12記録の「manual review required」ではなかった）。にもかかわらずstatus checkは常にgreen success — misleadingなノイズ。手動trigger（`@coderabbitai review`）はPR #14で実際に有効なevidenceを取得できたが、Pro Plusプランでも約1件/時間のquota制約を確認（PR #16で "Review rate limited"）。

POと協議の上、CodeRabbitのautomatic reviewは無効化し（`.coderabbit.yaml`）、manual trigger限定のoptional third perspectiveとして維持する方針とした。Claude GitHub-native reviewは、durable evidenceが必要なreview perspectiveの優先取得経路として推奨する方針とした。

## 変更内容

- `policy/core.md`: Acquisition & Validity Contractに、acquisitionのrecordは後続sessionから独立にrecoverableな場所へpersistされて初めてdurable evidenceである、という要件を追加。reviewer mechanism自身が外部surfaceへ出力を残さない場合（in-session/subagent review等）の扱いを明記。provider名は固定しない。
- `skills/review-code.md`: Adapter boundaryの `collectOutputs()` に、上記のnon-surface mechanism向けpersist手順を追加。GitHub-native trigger経路がdurable evidenceを残しやすいというobserved example（anonymized、恒久provider ruleではない）を追記。
- `.coderabbit.yaml`: `reviews.auto_review.enabled: false`。manual `@coderabbitai review` / `full review` は引き続き有効。
- `test/review-protocol.test.mjs`: 上記の回帰保護アサーションを追加。
- `test/fixtures/consumer/AGENTS.md`: `npm run sync:fixture` で再生成。

Out of scope（Issue #22のScope外を維持）: 全PR mandatory化、3 reviewer mandatory化、generalized orchestrator、provider ranking、Kernelへのprovider-specific固定。

## Mechanical check（Normative precondition）

上記SHA/artifact setに対して実行済み。

| check | result |
| --- | --- |
| `npm test`（13 tests + guardrails） | pass |
| `npm run check:fixture`（drift check） | pass（generated adapters are current） |
| `git diff --check` | pass |

merge-readyで停止する予定です。merge / Issue #22 close authorityはこのスレッドにもありません。