### PR TITLE
Next.js + Supabase profile: shared local stackのworktree isolation guidanceを追加する (#23)

### DIFF
--- a/profiles/next-supabase/project-rules.md
+++ b/profiles/next-supabase/project-rules.md
@@ -8,5 +8,7 @@ domain terminology、product-specific security decision は consumer product rul
 - generated Supabase types を database type の source of truth として扱います。
 - stack-specific deterministic quality check は Foundation core policy ではなく、
   この profile または関連 tooling に置きます。
-- quality profile の適用方法とblocking/advisoryの区別は `quality/README.md` を
-  正本とします。product-domain rule はそこへ追加しません。
+- quality profile の適用方法とblocking/advisoryの区別は consumer の
+  `.ai-dev-foundation/quality/README.md`（Foundation リポジトリでは
+  `profiles/next-supabase/quality/README.md`）を正本とします。product-domain
+  rule はそこへ追加しません。

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -143,7 +143,11 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 shared local stackに対して上記を実行するagentは、少なくとも次を満たします。
 
 1. destructive / statefulなDB operationの前に、そのstackに対するexclusive
-   ownershipを合理的な方法で確認する。
+   ownershipを確認し、そのownershipをoperation完了まで排他的に維持する。
+   一時点のcheck（time-of-check）だけでoperationの実行（time-of-use）中の
+   排他性を保証しない方法は、この要件を満たしません。ほぼ同時に開始した
+   複数checkoutが互いを「利用中でない」と判定してしまうgapを許容しない
+   方法を用います。
 2. 他checkoutが同じstackをactiveに利用中であれば、並行して実行しない。
 3. verification対象のcheckout自身のmigration / configから、その
    verification用のclean target stateを作る。
@@ -162,7 +166,11 @@ checkout由来でなければ、その結果はverification evidenceとしてinv
 exclusive ownershipの確認方法（lockfile、mutex、scheduler、
 `pg_stat_activity`の確認、process inspection、runtime固有のlocking等）は
 Foundationが特定の実装を指定しません。consumer / runtimeに合った合理的な
-mechanismを選びます。
+mechanismを選びますが、選んだmechanismはitem 1のtime-of-check/time-of-use
+gapを許容しないことを満たす必要があります（例えば`pg_stat_activity`や
+process inspectionのみを単発の時点確認として使う場合、それ単独では
+operation完了までの排他性を保証しないため、lockfile/mutex等の排他制御と
+組み合わせるか、そのgapを埋める他の方法を併用します）。
 
 ### Isolated local stack
 

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -142,12 +142,14 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 
 shared local stackに対して上記を実行するagentは、少なくとも次を満たします。
 
-1. destructive / statefulなDB operationの前に、そのstackに対するexclusive
-   ownershipを確認し、そのownershipをoperation完了まで排他的に維持する。
-   一時点のcheck（time-of-check）だけでoperationの実行（time-of-use）中の
-   排他性を保証しない方法は、この要件を満たしません。ほぼ同時に開始した
-   複数checkoutが互いを「利用中でない」と判定してしまうgapを許容しない
-   方法を用います。
+1. 上記でexclusive resourceとして列挙したoperation（destructive /
+   statefulなDB operationだけでなく、read-only寄りのDB / RLS / auth
+   integration testやgenerated types drift verificationを含む）の前に、
+   そのstackに対するexclusive ownershipを確認し、そのownershipを
+   operation完了まで排他的に維持する。一時点のcheck（time-of-check）
+   だけでoperationの実行（time-of-use）中の排他性を保証しない方法は、
+   この要件を満たしません。ほぼ同時に開始した複数checkoutが互いを
+   「利用中でない」と判定してしまうgapを許容しない方法を用います。
 2. 他checkoutが同じstackをactiveに利用中であれば、並行して実行しない。
 3. verification対象のcheckout自身のmigration / configから、その
    verification用のclean target stateを作る。

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -118,3 +118,58 @@ commandにします。DB/RLS testがあるconsumerは同じ`verify:profile`か�
 
 `jscpd`や`knip`などのノイズを含み得るcheckはadvisoryです。blocking quality floorには
 含めません。
+
+## Worktree/checkoutをまたぐlocal Supabase stack
+
+複数のcheckout（worktreeを含む）が同一のlocal Supabase runtime / DB stateを
+共有する構成と、checkoutごとに完全に分離された構成のどちらもあり得ます。
+Foundationは特定のisolation implementationを強制しません。この節は、DB stateに
+依存するverificationが何をevidenceとして扱ってよいかを規定します。
+
+### Shared local stack
+
+複数checkoutが同一のlocal Supabase project（同じproject identifier / ports /
+containers / volumes等）を共有する場合、そのstackはshared local stackです。
+次を**exclusive resource**として扱います。
+
+- `supabase start` / `supabase stop`
+- `supabase db reset`
+- migration apply / rollback相当のoperation
+- DB / RLS / auth integration test
+- schema由来のgenerated types生成、およびdrift verification
+- 上記のいずれかを内包する`verify:profile`
+- 上記のいずれかを内包するfull `verify`
+
+shared local stackに対して上記を実行するagentは、少なくとも次を満たします。
+
+1. destructive / statefulなDB operationの前に、そのstackに対するexclusive
+   ownershipを合理的な方法で確認する。
+2. 他checkoutが同じstackをactiveに利用中であれば、並行して実行しない。
+3. verification対象のcheckout自身のmigration / configから、その
+   verification用のclean target stateを作る。
+4. 既に起動しているshared stackの現在stateを、それだけを根拠に自checkoutの
+   verification evidenceとして扱わない。DB stateがどのcheckoutのmigrationに
+   由来するか確認できない場合、そこから得た結果は当該checkoutのverification
+   evidenceとして使わない。
+5. operationの完了後はownershipをreleaseし、他checkoutがそのstackを利用
+   できる状態に戻す。
+
+**exit code 0やCI greenであっても、参照したDB stateがverification対象の
+checkout由来でなければ、その結果はverification evidenceとしてinvalidです。**
+これはcommandが同時に実行されたかどうかとは独立したfailure modeであり、
+逐次実行しただけでは防げません。
+
+exclusive ownershipの確認方法（lockfile、mutex、scheduler、
+`pg_stat_activity`の確認、process inspection、runtime固有のlocking等）は
+Foundationが特定の実装を指定しません。consumer / runtimeに合った合理的な
+mechanismを選びます。
+
+### Isolated local stack
+
+checkoutごとにproject identifier / ports / containers / volume等が十分に
+分離され、互いのDB stateを変更できないことが確認できる場合、そのcheckoutは
+isolated local stackです。isolated local stackでは上記のexclusive
+serializationを要求しません。
+
+local Supabaseを使うconsumerが常にshared local stackである、という前提は
+置きません。

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -142,12 +142,14 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 
 shared local stackに対して上記を実行するagentは、少なくとも次を満たします。
 
-1. destructive / statefulなDB operationの前に、そのstackに対するexclusive
-   ownershipを確認し、そのownershipをoperation完了まで排他的に維持する。
-   一時点のcheck（time-of-check）だけでoperationの実行（time-of-use）中の
-   排他性を保証しない方法は、この要件を満たしません。ほぼ同時に開始した
-   複数checkoutが互いを「利用中でない」と判定してしまうgapを許容しない
-   方法を用います。
+1. 上記でexclusive resourceとして列挙したoperation（destructive /
+   statefulなDB operationだけでなく、read-only寄りのDB / RLS / auth
+   integration testやgenerated types drift verificationを含む）の前に、
+   そのstackに対するexclusive ownershipを確認し、そのownershipを
+   operation完了まで排他的に維持する。一時点のcheck（time-of-check）
+   だけでoperationの実行（time-of-use）中の排他性を保証しない方法は、
+   この要件を満たしません。ほぼ同時に開始した複数checkoutが互いを
+   「利用中でない」と判定してしまうgapを許容しない方法を用います。
 2. 他checkoutが同じstackをactiveに利用中であれば、並行して実行しない。
 3. verification対象のcheckout自身のmigration / configから、その
    verification用のclean target stateを作る。

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -49,7 +49,21 @@ export default [
   ...nextSupabaseQualityProfile(),
   architectureImportBoundary({
     files: ['src/domain/**/*.ts'],
-    restrictedPatterns: ['../ui/**', '../infrastructure/**'],
+    // Depth-independent, anchored patterns: "../**/ui" (and "/**") matches
+    // "../ui", "../../ui", "../ui/x", "../../ui/x", ... regardless of how
+    // deep the importing domain file is nested, without also matching an
+    // unrelated external package such as "@vendor/ui/button" the way a bare
+    // "**/ui/**" pattern would.
+    restrictedPatterns: [
+      '../**/ui',
+      '../**/ui/**',
+      '../**/infrastructure',
+      '../**/infrastructure/**',
+      '@/ui',
+      '@/ui/**',
+      '@/infrastructure',
+      '@/infrastructure/**',
+    ],
     message: 'Domain code must not import UI or infrastructure.',
   }),
 ];
@@ -104,3 +118,66 @@ commandにします。DB/RLS testがあるconsumerは同じ`verify:profile`か�
 
 `jscpd`や`knip`などのノイズを含み得るcheckはadvisoryです。blocking quality floorには
 含めません。
+
+## Worktree/checkoutをまたぐlocal Supabase stack
+
+複数のcheckout（worktreeを含む）が同一のlocal Supabase runtime / DB stateを
+共有する構成と、checkoutごとに完全に分離された構成のどちらもあり得ます。
+Foundationは特定のisolation implementationを強制しません。この節は、DB stateに
+依存するverificationが何をevidenceとして扱ってよいかを規定します。
+
+### Shared local stack
+
+複数checkoutが同一のlocal Supabase project（同じproject identifier / ports /
+containers / volumes等）を共有する場合、そのstackはshared local stackです。
+次を**exclusive resource**として扱います。
+
+- `supabase start` / `supabase stop`
+- `supabase db reset`
+- migration apply / rollback相当のoperation
+- DB / RLS / auth integration test
+- schema由来のgenerated types生成、およびdrift verification
+- 上記のいずれかを内包する`verify:profile`
+- 上記のいずれかを内包するfull `verify`
+
+shared local stackに対して上記を実行するagentは、少なくとも次を満たします。
+
+1. destructive / statefulなDB operationの前に、そのstackに対するexclusive
+   ownershipを確認し、そのownershipをoperation完了まで排他的に維持する。
+   一時点のcheck（time-of-check）だけでoperationの実行（time-of-use）中の
+   排他性を保証しない方法は、この要件を満たしません。ほぼ同時に開始した
+   複数checkoutが互いを「利用中でない」と判定してしまうgapを許容しない
+   方法を用います。
+2. 他checkoutが同じstackをactiveに利用中であれば、並行して実行しない。
+3. verification対象のcheckout自身のmigration / configから、その
+   verification用のclean target stateを作る。
+4. 既に起動しているshared stackの現在stateを、それだけを根拠に自checkoutの
+   verification evidenceとして扱わない。DB stateがどのcheckoutのmigrationに
+   由来するか確認できない場合、そこから得た結果は当該checkoutのverification
+   evidenceとして使わない。
+5. operationの完了後はownershipをreleaseし、他checkoutがそのstackを利用
+   できる状態に戻す。
+
+**exit code 0やCI greenであっても、参照したDB stateがverification対象の
+checkout由来でなければ、その結果はverification evidenceとしてinvalidです。**
+これはcommandが同時に実行されたかどうかとは独立したfailure modeであり、
+逐次実行しただけでは防げません。
+
+exclusive ownershipの確認方法（lockfile、mutex、scheduler、
+`pg_stat_activity`の確認、process inspection、runtime固有のlocking等）は
+Foundationが特定の実装を指定しません。consumer / runtimeに合った合理的な
+mechanismを選びますが、選んだmechanismはitem 1のtime-of-check/time-of-use
+gapを許容しないことを満たす必要があります（例えば`pg_stat_activity`や
+process inspectionのみを単発の時点確認として使う場合、それ単独では
+operation完了までの排他性を保証しないため、lockfile/mutex等の排他制御と
+組み合わせるか、そのgapを埋める他の方法を併用します）。
+
+### Isolated local stack
+
+checkoutごとにproject identifier / ports / containers / volume等が十分に
+分離され、互いのDB stateを変更できないことが確認できる場合、そのcheckoutは
+isolated local stackです。isolated local stackでは上記のexclusive
+serializationを要求しません。
+
+local Supabaseを使うconsumerが常にshared local stackである、という前提は
+置きません。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -595,8 +595,10 @@ domain terminology、product-specific security decision は consumer product rul
 - generated Supabase types を database type の source of truth として扱います。
 - stack-specific deterministic quality check は Foundation core policy ではなく、
   この profile または関連 tooling に置きます。
-- quality profile の適用方法とblocking/advisoryの区別は `quality/README.md` を
-  正本とします。product-domain rule はそこへ追加しません。
+- quality profile の適用方法とblocking/advisoryの区別は consumer の
+  `.ai-dev-foundation/quality/README.md`（Foundation リポジトリでは
+  `profiles/next-supabase/quality/README.md`）を正本とします。product-domain
+  rule はそこへ追加しません。
 
 ## Consumer product rules
 

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+test("Next.js + Supabase quality profile defines shared local stack exclusive-resource guidance", async () => {
+  const readme = await readFile(
+    path.join(root, "profiles", "next-supabase", "quality", "README.md"),
+    "utf8",
+  );
+
+  assert.ok(readme.includes("## Worktree/checkoutをまたぐlocal Supabase stack"));
+  assert.ok(readme.includes("### Shared local stack"));
+  assert.ok(readme.includes("### Isolated local stack"));
+
+  for (const operation of [
+    "`supabase start` / `supabase stop`",
+    "`supabase db reset`",
+    "migration apply / rollback相当のoperation",
+    "DB / RLS / auth integration test",
+    "schema由来のgenerated types生成、およびdrift verification",
+    "`verify:profile`",
+    "full `verify`",
+  ]) {
+    assert.ok(readme.includes(operation), `missing exclusive-resource operation: ${operation}`);
+  }
+
+  assert.ok(
+    containsText(readme, "そのstackはshared local stackです。次を**exclusive resource**として扱います。"),
+  );
+
+  // The core failure mode: exit 0 / CI green does not imply valid evidence
+  // when the observed DB state came from a different checkout.
+  assert.ok(
+    containsText(
+      readme,
+      "exit code 0やCI greenであっても、参照したDB stateがverification対象の" +
+        "checkout由来でなければ、その結果はverification evidenceとしてinvalidです。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      readme,
+      "既に起動しているshared stackの現在stateを、それだけを根拠に自checkoutの" +
+        "verification evidenceとして扱わない。",
+    ),
+  );
+
+  // Isolated stacks must not be forced into unnecessary serialization.
+  assert.ok(
+    containsText(
+      readme,
+      "isolated local stackでは上記のexclusive serializationを要求しません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      readme,
+      "local Supabaseを使うconsumerが常にshared local stackである、という前提は置きません。",
+    ),
+  );
+
+  // Foundation must not pin a specific ownership-confirmation mechanism.
+  assert.ok(
+    containsText(
+      readme,
+      "Foundationが特定の実装を指定しません。consumer / runtimeに合った合理的な" +
+        "mechanismを選びます。",
+    ),
+  );
+});
+
+test("Foundation Kernel keeps Supabase-specific semantics out of policy/core.md", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  assert.doesNotMatch(core, /Supabase/i);
+});

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -90,6 +90,20 @@ test("Next.js + Supabase quality profile defines shared local stack exclusive-re
         "排他性を保証しない方法は、この要件を満たしません。",
     ),
   );
+
+  // The ownership-hold requirement must cover every operation on the
+  // exclusive-resource list, not only destructive/stateful ones — a
+  // read-only DB/RLS test or drift check can still observe wrong-checkout
+  // state if it runs without holding ownership.
+  assert.ok(
+    containsText(
+      readme,
+      "上記でexclusive resourceとして列挙したoperation（destructive /" +
+        "statefulなDB operationだけでなく、read-only寄りのDB / RLS / auth" +
+        "integration testやgenerated types drift verificationを含む）の前に、" +
+        "そのstackに対するexclusive ownershipを確認し",
+    ),
+  );
 });
 
 test("Foundation Kernel keeps Supabase-specific semantics out of policy/core.md", async () => {

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -96,3 +96,27 @@ test("Foundation Kernel keeps Supabase-specific semantics out of policy/core.md"
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
   assert.doesNotMatch(core, /Supabase/i);
 });
+
+test("project-rules.md points consumers at the actual bootstrapped quality profile path", async () => {
+  const projectRules = await readFile(
+    path.join(root, "profiles", "next-supabase", "project-rules.md"),
+    "utf8",
+  );
+  const bootstrapTooling = await readFile(
+    path.join(root, "tooling", "bootstrap-next-supabase.mjs"),
+    "utf8",
+  );
+
+  // The pointer must name the consumer-relative path that bootstrap actually
+  // writes to, not a bare "quality/README.md" a consumer agent cannot resolve
+  // from AGENTS.md alone.
+  assert.ok(projectRules.includes("`.ai-dev-foundation/quality/README.md`"));
+  assert.match(bootstrapTooling, /"\.ai-dev-foundation",\s*"quality"/);
+  assert.ok(
+    containsText(
+      projectRules,
+      "consumer の `.ai-dev-foundation/quality/README.md`（Foundation リポジトリでは" +
+        "`profiles/next-supabase/quality/README.md`）を正本とします。",
+    ),
+  );
+});

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -76,7 +76,18 @@ test("Next.js + Supabase quality profile defines shared local stack exclusive-re
     containsText(
       readme,
       "Foundationが特定の実装を指定しません。consumer / runtimeに合った合理的な" +
-        "mechanismを選びます。",
+        "mechanismを選びますが、選んだmechanismはitem 1のtime-of-check/time-of-use" +
+        "gapを許容しないことを満たす必要があります",
+    ),
+  );
+
+  // Ownership confirmation must not be a point-in-time check alone (TOCTOU).
+  assert.ok(
+    containsText(
+      readme,
+      "そのownershipをoperation完了まで排他的に維持する。" +
+        "一時点のcheck（time-of-check）だけでoperationの実行（time-of-use）中の" +
+        "排他性を保証しない方法は、この要件を満たしません。",
     ),
   );
 });

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -119,4 +119,31 @@ test("project-rules.md points consumers at the actual bootstrapped quality profi
         "`profiles/next-supabase/quality/README.md`）を正本とします。",
     ),
   );
+});
+
+test("the documented reference consumer's bootstrapped quality profile is not stale", async () => {
+  // README.md:13 documents test/fixtures/consumer/ as "最小の reference consumer".
+  // project-rules.md now names its .ai-dev-foundation/quality/README.md as the
+  // canonical path a consumer agent resolves to, so that checked-in copy must
+  // not silently drift from the live profile source (otherwise the pointer
+  // resolves to stale guidance instead of the current normative content).
+  const sourceDirectory = path.join(root, "profiles", "next-supabase", "quality");
+  const fixtureDirectory = path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "quality");
+
+  const sourceFiles = (await readdir(sourceDirectory)).sort();
+  const fixtureFiles = (await readdir(fixtureDirectory)).sort();
+  assert.deepEqual(fixtureFiles, sourceFiles);
+
+  for (const file of sourceFiles) {
+    const [sourceContent, fixtureContent] = await Promise.all([
+      readFile(path.join(sourceDirectory, file), "utf8"),
+      readFile(path.join(fixtureDirectory, file), "utf8"),
+    ]);
+    assert.equal(
+      fixtureContent,
+      sourceContent,
+      `test/fixtures/consumer/.ai-dev-foundation/quality/${file} is stale; ` +
+        "run: node tooling/bootstrap-next-supabase.mjs --consumer test/fixtures/consumer",
+    );
+  }
 });


### PR DESCRIPTION
Issue #23 の実装（Issueは自動closeしません。merge / Issue close authorityはこのPRにありません）。

## Review Selection / Execution Contract record

### Selection Contract
- **artifact classification**: Normative（profile README + 回帰保護のための小さな deterministic test）
- **target artifact set**: `profiles/next-supabase/quality/README.md` / `test/quality-profile-worktree-isolation.test.mjs`
- **expected target SHA**: `0dbb42ab36d70e8d7f81e07cea3b524da99af4b2`
- **required review数**: 2（独立reviewer 2系統。verification evidenceのvalidityを規定するprofile-level normative contractのため）
- **reviewer / capability**: Codex（`chatgpt-codex-connector[bot]`、PR作成によるautomatic trigger）および Claude（GitHub-native `@claude review` mention trigger、`.github/workflows/claude-review.yml`）

### Execution Contract
- **trigger**: Codexはこのpull request作成によるautomatic trigger。Claudeはこの後postする `@claude review` の明示的mention。
- **渡すtarget**: 上記expected target SHA / target artifact set
- **timeout / retry**: transient failureはbounded retry。quota / rate limitは `unknown` として扱いsuccessに潰さない。

## Discoverability checkpoint（Issueで指定された確認事項）

「profile READMEだけではconsumer agentがTask-local追加説明なしにこのruleを発見できない可能性」を実際のconsumer導線で確認した。

- `tooling/lib.mjs` の `composeAgents()` は `profiles/next-supabase/project-rules.md` を consumer `AGENTS.md` の "Technology profile" section へ合成する。この `project-rules.md` は既に次のcanonical pointerを含む：「quality profile の適用方法とblocking/advisoryの区別は `quality/README.md` を正本とします。」
- このpointerは stage-tracker consumer の生成済み `AGENTS.md`（このタスクを実行しているagent自身のsystem context）に実際に現れており、agentは追加のTask-local説明なしにこのpointerを経由して `quality/README.md` へ到達できることを一次evidenceとして確認した。
- `tooling/bootstrap-next-supabase.mjs` は `profiles/next-supabase/quality/` ディレクトリ全体（README.md含む）を consumer `.ai-dev-foundation/quality/` へcopyする。README自身がこの展開先pathを明記している。

結論: README単独で consumer-visible canonical guidanceとして十分であり、`policy/core.md` / `project-rules.md` / bootstrap tooling への追加materializationは不要と判断した。change surfaceを拡張していない。

## 変更内容

- `profiles/next-supabase/quality/README.md`: 「Worktree/checkoutをまたぐlocal Supabase stack」節を追加。
  - Shared local stack: `supabase start/stop`、`db reset`、migration apply/rollback、DB/RLS/auth test、generated types生成・drift verification、これらを内包する`verify:profile`/`verify`をexclusive resourceとして扱う。exclusive ownership確認、他checkoutの並行利用回避、checkout自身のmigrationからのclean target state構築、already-running stackを無条件にevidence化しないこと、release、を明示。**exit 0/CI greenでもwrong checkout由来のDB stateはverification evidenceとしてinvalid**というfailure modeを明示。
  - Isolated local stack: project identifier/ports/containers/volumeが十分に分離されている場合はexclusive serializationを要求しない条件付きrule。
  - lock実装（lockfile/mutex/scheduler/`pg_stat_activity`/process inspection等）はいずれもmandatoryとして固定していない。
- `test/quality-profile-worktree-isolation.test.mjs`: 上記normative contentの回帰保護、および `policy/core.md` にSupabase固有semanticsが漏れていないことの確認。

`policy/core.md` は変更していない。

Out of scope（Issue #23のScope外を維持）: generalized worktree scheduler / lock server / orchestrator、worktreeごとのSupabase自動provisioning、Docker/network abstraction、stage-tracker固有fix、Supabase以外のDB provider一般化、全verificationの強制serialization、version bump/tag、stage-trackerへのFoundation repin。

## Mechanical check（Normative precondition）

上記SHAに対して実行済み。

| check | result |
| --- | --- |
| `npm test`（15 tests + guardrails） | pass |
| `npm run check:fixture`（drift check） | pass（generated adapters are current） |
| `npm run sync:fixture` 後の再check | pass（差分なし。README変更はAGENTS.md/CLAUDE.md生成に影響しないことを確認） |
| `git diff --check` | pass（whitespace error無し） |

merge-readyで停止する予定です。merge / Issue #23 close authorityはこのスレッドにもありません。