### PR TITLE
Foundation tooling: check.mjsでquality profile driftを検知する

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ node tooling/check.mjs --consumer path/to/consumer
 は non-zero で終了します。policy、profile、consumer product rule を変更した後は
 再生成してください。
 
+`check` は、bootstrap 済みの `.ai-dev-foundation/quality/` が、参照している
+Foundation checkout の `profiles/next-supabase/quality/` と一致しているかも
+検証します。file の missing / extra / content mismatch のいずれかがあれば
+non-zero で終了し、`node tooling/bootstrap-next-supabase.mjs --consumer <path>`
+による再展開を促します。Foundation を repin しても quality profile の再展開を
+忘れると、この quality profile の drift 検知だけが non-zero になります。
+
 同梱の reference consumer は `npm test` で検証できます。
 
 consumer fixture自身の一括verifyは次で実行できます。

--- a/test/sync-check.test.mjs
+++ b/test/sync-check.test.mjs
@@ -67,3 +67,54 @@ test("bootstrap replaces only its Foundation-owned quality directory", async (t)
   await assert.rejects(readFile(staleFile, "utf8"), { code: "ENOENT" });
   assert.equal(await readFile(consumerFile, "utf8"), "consumer-owned");
 });
+
+test("check detects quality profile drift against the pinned Foundation checkout and bootstrap remediates it", async (t) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "ai-dev-foundation-"));
+  const consumer = path.join(temporaryRoot, "consumer");
+  const qualityFile = path.join(consumer, ".ai-dev-foundation", "quality", "eslint.config.mjs");
+  const staleExtraFile = path.join(consumer, ".ai-dev-foundation", "quality", "stale-extra-file.txt");
+  const productRules = path.join(consumer, ".ai-dev-foundation", "product-rules.md");
+  await cp(fixture, consumer, { recursive: true });
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+  const originalProductRules = await readFile(productRules, "utf8");
+
+  // The reference fixture's bootstrapped quality profile is current, so a
+  // freshly copied consumer must pass without any remediation.
+  const currentResult = run("check.mjs", consumer);
+  assert.equal(currentResult.status, 0);
+  assert.match(currentResult.stdout, /quality profile/i);
+
+  // Content mutation of a Foundation-owned quality file is drift.
+  const originalQualityFile = await readFile(qualityFile, "utf8");
+  await writeFile(qualityFile, `${originalQualityFile}\n// consumer edit\n`, "utf8");
+  const mutatedResult = run("check.mjs", consumer);
+  assert.notEqual(mutatedResult.status, 0);
+  assert.match(mutatedResult.stderr, /Foundation-owned quality profile is stale/);
+  assert.match(mutatedResult.stderr, /eslint\.config\.mjs/);
+  assert.match(mutatedResult.stderr, /bootstrap-next-supabase\.mjs/);
+
+  // A Foundation-owned file the consumer never bootstrapped (or deleted) is
+  // also drift, not a silent pass.
+  await rm(qualityFile);
+  const missingResult = run("check.mjs", consumer);
+  assert.notEqual(missingResult.status, 0);
+  assert.match(missingResult.stderr, /eslint\.config\.mjs/);
+
+  // A stale/extra Foundation-owned-directory file the pinned checkout no
+  // longer ships is drift too — the profile isn't current until it matches
+  // exactly, not just a superset.
+  await writeFile(qualityFile, originalQualityFile, "utf8");
+  await writeFile(staleExtraFile, "stale", "utf8");
+  const extraResult = run("check.mjs", consumer);
+  assert.notEqual(extraResult.status, 0);
+  assert.match(extraResult.stderr, /stale-extra-file\.txt/);
+
+  // Remediation via the documented bootstrap command restores a pass.
+  assert.equal(run("bootstrap-next-supabase.mjs", consumer).status, 0);
+  assert.equal(run("check.mjs", consumer).status, 0);
+  await assert.rejects(readFile(staleExtraFile, "utf8"), { code: "ENOENT" });
+
+  // Consumer-owned files outside the quality directory are never part of
+  // this comparison and are left untouched by check/bootstrap.
+  assert.equal(await readFile(productRules, "utf8"), originalProductRules);
+});

--- a/test/sync-check.test.mjs
+++ b/test/sync-check.test.mjs
@@ -118,3 +118,34 @@ test("check detects quality profile drift against the pinned Foundation checkout
   // this comparison and are left untouched by check/bootstrap.
   assert.equal(await readFile(productRules, "utf8"), originalProductRules);
 });
+
+test("check detects quality profile drift in a nested subdirectory, not only top-level files", async (t) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "ai-dev-foundation-"));
+  const consumer = path.join(temporaryRoot, "consumer");
+  await cp(fixture, consumer, { recursive: true });
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+
+  const sourceNestedDirectory = path.join(root, "profiles", "next-supabase", "quality", "nested");
+  const sourceNestedFile = path.join(sourceNestedDirectory, "nested.txt");
+  t.after(() => rm(sourceNestedDirectory, { recursive: true, force: true }));
+  await mkdir(sourceNestedDirectory, { recursive: true });
+  await writeFile(sourceNestedFile, "nested-source\n", "utf8");
+
+  // The pinned checkout now ships a nested file the consumer never
+  // bootstrapped: missing-in-a-subdirectory must be caught, not just
+  // missing top-level files.
+  assert.notEqual(run("check.mjs", consumer).status, 0);
+
+  assert.equal(run("bootstrap-next-supabase.mjs", consumer).status, 0);
+  assert.equal(run("check.mjs", consumer).status, 0);
+  assert.equal(
+    await readFile(path.join(consumer, ".ai-dev-foundation", "quality", "nested", "nested.txt"), "utf8"),
+    "nested-source\n",
+  );
+
+  // The checkout stops shipping the nested file; the consumer's copy is now
+  // a stale nested extra and must be reported, not silently ignored because
+  // it is one directory level down.
+  await rm(sourceNestedDirectory, { recursive: true, force: true });
+  assert.notEqual(run("check.mjs", consumer).status, 0);
+});

--- a/tooling/bootstrap-next-supabase.mjs
+++ b/tooling/bootstrap-next-supabase.mjs
@@ -1,11 +1,9 @@
 import { cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { parseConsumerArgument } from "./lib.mjs";
+import { parseConsumerArgument, qualityProfileSourceDirectory } from "./lib.mjs";
 
-const foundationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const consumerDirectory = parseConsumerArgument(process.argv.slice(2));
-const source = path.join(foundationRoot, "profiles", "next-supabase", "quality");
+const source = qualityProfileSourceDirectory;
 const destination = path.join(consumerDirectory, ".ai-dev-foundation", "quality");
 
 await rm(destination, { recursive: true, force: true });

--- a/tooling/check.mjs
+++ b/tooling/check.mjs
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { composeAgents, composeClaude, parseConsumerArgument } from "./lib.mjs";
+import { composeAgents, composeClaude, diffQualityProfile, parseConsumerArgument } from "./lib.mjs";
 
 const consumerDirectory = parseConsumerArgument(process.argv.slice(2));
 const expected = new Map([
@@ -20,10 +20,25 @@ for (const [file, content] of expected) {
   }
 }
 
+const qualityProfileDrift = await diffQualityProfile(consumerDirectory);
+let hasDrift = false;
+
 if (drifted.length > 0) {
   console.error(`Generated adapter drift detected: ${drifted.join(", ")}`);
   console.error("Run: node tooling/sync.mjs --consumer <path>");
+  hasDrift = true;
+}
+
+if (qualityProfileDrift.length > 0) {
+  console.error(
+    `Foundation-owned quality profile is stale (.ai-dev-foundation/quality): ${qualityProfileDrift.join(", ")}`,
+  );
+  console.error("Run: node tooling/bootstrap-next-supabase.mjs --consumer <path>");
+  hasDrift = true;
+}
+
+if (hasDrift) {
   process.exitCode = 1;
 } else {
-  console.log(`Generated adapters are current in ${consumerDirectory}`);
+  console.log(`Generated adapters and quality profile are current in ${consumerDirectory}`);
 }

--- a/tooling/lib.mjs
+++ b/tooling/lib.mjs
@@ -32,8 +32,35 @@ export async function composeClaude() {
   return read("templates/CLAUDE.md");
 }
 
-function toPosixRelativePath(entry) {
-  return entry.split(path.sep).join("/");
+// Lists every non-directory entry (regular file, symlink — broken or not)
+// under `directory` as sorted, POSIX-separated paths relative to it. Uses
+// Dirent typing rather than "try to read it" so a broken symlink is still
+// reported as an entry instead of being mistaken for a missing directory.
+async function listRelativeEntries(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { recursive: true, withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+  return entries
+    .filter((entry) => !entry.isDirectory())
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .map((absolutePath) => path.relative(directory, absolutePath).split(path.sep).join("/"))
+    .sort();
+}
+
+// Only ENOENT (missing file, or a symlink whose target doesn't exist) is
+// treated as "no content"; any other read failure (e.g. permissions) is a
+// real problem and must not be silently reported as ordinary content drift.
+async function readContentOrNull(filePath) {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 // Compares the Foundation-owned quality profile directory
@@ -42,25 +69,28 @@ function toPosixRelativePath(entry) {
 // all reported as drift so a repin without re-running bootstrap cannot pass.
 export async function diffQualityProfile(consumerDirectory) {
   const destination = path.join(consumerDirectory, ".ai-dev-foundation", "quality");
+  const [sourceRelativePaths, destinationRelativePaths] = await Promise.all([
+    listRelativeEntries(qualityProfileSourceDirectory),
+    listRelativeEntries(destination),
+  ]);
+  const destinationRelativePathSet = new Set(destinationRelativePaths);
   const drifted = new Set();
-  const sourceRelativePaths = new Set();
 
-  for (const entry of await readdir(qualityProfileSourceDirectory, { recursive: true })) {
-    const relative = toPosixRelativePath(entry);
+  for (const relative of sourceRelativePaths) {
+    if (!destinationRelativePathSet.has(relative)) {
+      drifted.add(relative); // missing in consumer
+      continue;
+    }
     const [sourceContent, destinationContent] = await Promise.all([
-      readFile(path.join(qualityProfileSourceDirectory, entry), "utf8").catch(() => null),
-      readFile(path.join(destination, entry), "utf8").catch(() => null),
+      readContentOrNull(path.join(qualityProfileSourceDirectory, ...relative.split("/"))),
+      readContentOrNull(path.join(destination, ...relative.split("/"))),
     ]);
-    if (sourceContent === null) continue; // directory entry, not a file
-    sourceRelativePaths.add(relative);
     if (sourceContent !== destinationContent) drifted.add(relative);
   }
 
-  for (const entry of await readdir(destination, { recursive: true }).catch(() => [])) {
-    const relative = toPosixRelativePath(entry);
-    if (sourceRelativePaths.has(relative)) continue;
-    const destinationContent = await readFile(path.join(destination, entry), "utf8").catch(() => null);
-    if (destinationContent !== null) drifted.add(relative); // stale extra file
+  const sourceRelativePathSet = new Set(sourceRelativePaths);
+  for (const relative of destinationRelativePaths) {
+    if (!sourceRelativePathSet.has(relative)) drifted.add(relative); // stale extra entry
   }
 
   return [...drifted].sort();

--- a/tooling/lib.mjs
+++ b/tooling/lib.mjs
@@ -1,8 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const foundationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const qualityProfileSourceDirectory = path.join(foundationRoot, "profiles", "next-supabase", "quality");
 
 export function parseConsumerArgument(argv) {
   const index = argv.indexOf("--consumer");
@@ -29,4 +30,38 @@ export async function composeAgents(consumerDirectory) {
 
 export async function composeClaude() {
   return read("templates/CLAUDE.md");
+}
+
+function toPosixRelativePath(entry) {
+  return entry.split(path.sep).join("/");
+}
+
+// Compares the Foundation-owned quality profile directory
+// (profiles/next-supabase/quality) against a bootstrapped consumer's
+// .ai-dev-foundation/quality. Missing, mismatched, and stale-extra files are
+// all reported as drift so a repin without re-running bootstrap cannot pass.
+export async function diffQualityProfile(consumerDirectory) {
+  const destination = path.join(consumerDirectory, ".ai-dev-foundation", "quality");
+  const drifted = new Set();
+  const sourceRelativePaths = new Set();
+
+  for (const entry of await readdir(qualityProfileSourceDirectory, { recursive: true })) {
+    const relative = toPosixRelativePath(entry);
+    const [sourceContent, destinationContent] = await Promise.all([
+      readFile(path.join(qualityProfileSourceDirectory, entry), "utf8").catch(() => null),
+      readFile(path.join(destination, entry), "utf8").catch(() => null),
+    ]);
+    if (sourceContent === null) continue; // directory entry, not a file
+    sourceRelativePaths.add(relative);
+    if (sourceContent !== destinationContent) drifted.add(relative);
+  }
+
+  for (const entry of await readdir(destination, { recursive: true }).catch(() => [])) {
+    const relative = toPosixRelativePath(entry);
+    if (sourceRelativePaths.has(relative)) continue;
+    const destinationContent = await readFile(path.join(destination, entry), "utf8").catch(() => null);
+    if (destinationContent !== null) drifted.add(relative); // stale extra file
+  }
+
+  return [...drifted].sort();
 }


### PR DESCRIPTION
## Summary

Issue #26の実装。`ai-dev-foundation#26` を参照（このPRはauto-closeさせません。merge判断はPO/authorityに委ねます）。

- `tooling/check.mjs`が、bootstrap済みconsumerの`.ai-dev-foundation/quality/`と、参照しているFoundation checkoutの`profiles/next-supabase/quality/`のdriftを検証するようになりました。file missing / extra / content mismatchのいずれかがあればnon-zeroで終了し、`node tooling/bootstrap-next-supabase.mjs --consumer <path>`によるremediationを案内します。
- `tooling/lib.mjs`に共有の`diffQualityProfile()` / `qualityProfileSourceDirectory`を追加し、`bootstrap-next-supabase.mjs`も同じsource定義を参照するようにしました（source pathの二重定義を解消）。
- `sync.mjs`はAGENTS/CLAUDE adapter同期のみを引き続き所有し、quality profile bootstrapをconvenienceのために統合してはいません（Issue #26のtechnical checkpoint conditionには該当しないと判断）。
- `check`はdetectのみで、consumer stateを書き換えません。

## Design principle / ownership boundary

- Foundation-owned: generated AGENTS/CLAUDE adapter、bootstrap済み`.ai-dev-foundation/quality/`。
- Consumer-owned: product rules、consumer-specific config、application code。今回のdiffはこれらを一切書き換えません。

## Discovery note

実装前にstage-tracker consumer側の`scripts/check-quality-profile-drift.mjs`（`resolveFoundationCheckout()`経由でpinned SHAのFoundation checkoutと比較する既存workaround）を確認しました。これはこのgapに対する既にproduction稼働しているconsumer-local workaroundであり、`diffQualityProfile()`はそのcontent比較ロジック（source側走査 + missing/extra両方向の検出）を、追加artifact（manifest/hash等）なしでFoundation-owned tooling側へ最小移植したものです。stage-tracker側の変更はこのTaskのscope外のため行っていません（follow-upとして別途検討可能）。

## Test evidence（stale / current 両ケース）

`test/sync-check.test.mjs`に追加した回帰testで以下をcoverしています。

- freshly bootstrapped fixtureのconsumer → `check.mjs` pass
- quality profile fileのcontent mutation → fail（`Foundation-owned quality profile is stale`とfile名を明示）
- quality profile fileのmissing → fail
- sourceに無いstale/extra fileがconsumer quality dir に残る → fail
- `bootstrap-next-supabase.mjs`によるremediation → pass に復帰
- 既存のAGENTS/CLAUDE drift test（`sync creates current adapters and check detects both input and output drift`）は無変更のまま green
- consumer-owned file（`product-rules.md`）はcheck/bootstrap前後でcontent不変であることをassert

## Deterministic verification

- `npm test` — 18/18 pass（`test:guardrails` 8 fixture含む）
- `git diff --check` — clean
- 手動end-to-end evidence: `test/fixtures/consumer`をcopyしquality profileのREADME.mdへ1行追記 → `node tooling/check.mjs --consumer <path>`がexit 1で`Foundation-owned quality profile is stale (.ai-dev-foundation/quality): README.md`を出力 → `node tooling/bootstrap-next-supabase.mjs --consumer <path>`後に再度`check.mjs`がexit 0

## Review Selection Contract

- Artifact classification: Executable（consumer verification validityを変えるFoundation tooling change）
- Reviewer / capability: 独立2 perspective — Codex GitHub Review、Claude GitHub-native `@claude review`
- Required review数: 2（両方valid completedであることを要求）
- Target artifact set: `tooling/check.mjs`, `tooling/lib.mjs`, `tooling/bootstrap-next-supabase.mjs`, `test/sync-check.test.mjs`, `README.md`
- Expected target SHA: `e57ff4b6d26e5dfa6f4782d4cbe66002109743aa`（このPRのhead）

Execution / Acquisition & Validity / Resolution / Closureは、このPRへのfollow-upコメントとして記録します（後続sessionがPR上だけで再構成できるようにするため）。0 findingsの場合もpositive completion evidenceを別途記録します。

## Scope guard確認

- generalized artifact/package distribution system、lock server等は導入していません。
- stage-tracker repo、Foundation version/tag、consumer application codeへの変更はありません。
- Next.js + Supabase以外のprofileへの一般化はしていません。

## Stopping point

このPRにmerge authorityはありません。merge-readyの報告のみを行い、mergeはPO/authorityの判断に委ねます。