### PR TITLE
Foundation policy: human-facing outputはproject既定言語に従うconventionを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,11 @@
 # Foundation repository instructions
 
-このリポジトリ内のMarkdown文書とMarkdown templateは、原則として日本語で記述します。
+このリポジトリ（`ai-dev-foundation`）自身の既定言語は日本語です。
+`policy/core.md`のHuman-facing output languageに従い、このリポジトリ内の
+Markdown文書・Markdown templateに加えて、GitHub Issue/PRのtitle・body・
+comment、review durable evidence comment、planning checkpoint・handoff・
+completion report、セッション中の人間向けprogress report・final reportも、
+原則として日本語で記述します。
 コード、コマンド、識別子、ファイル名、正式な技術用語は必要に応じて英語のまま記述します。
 
 このファイルはFoundation自身を編集するためのrepo-local instructionです。

--- a/policy/core.md
+++ b/policy/core.md
@@ -27,6 +27,51 @@
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。
 `CLAUDE.md` は `AGENTS.md` を参照する thin adapter であり、canonical rule を複製しません。
 
+## Human-facing output language
+
+human-facing output（人間が読むために agent が作成・編集する成果物）の
+既定言語は、その project が持つ既定言語に従います。少なくとも次を対象と
+します。
+
+- Issue / PR の title・body・comment
+- review finding / triage / Resolution / closure の durable evidence comment
+- planning checkpoint、handoff、completion report
+- セッション中の人間向け progress report・final report
+- agent が生成・編集する Markdown / documentation
+
+一方、次は human-facing output の既定言語に関わらず、無理に翻訳せず原語
+（多くの場合英語）のまま保持します。
+
+- source code / identifier / symbol / API / library / framework name
+- file path / command / script name
+- schema / enum / protocol field 等の machine-facing text
+- error / log / provider-native output の引用
+- externally defined technical term / proper noun
+
+human-facing な地の文の中に、上記の technical vocabulary を原語のまま
+混在させることは許容します。検索性や意味精度を落とす過剰な翻訳はしません。
+
+project が既定言語を明示していない場合、agent は言語を仮定せず、その
+project の既存 human-facing artifact や communication から観測できる
+言語に合わせます。
+
+project 自身の既定言語が何であるかは Foundation Kernel が固定する対象
+ではありません。技術非依存な Foundation policy はこの節の reusable な
+原則までとし、特定の project がどの言語を既定とするかは、その project
+の Consumer product rules、または Foundation 自身のように project が
+自らを consumer として扱う場合は project 自身の repo-local instructions
+へ記録します。Technology profile は technology/provider 向けの具体化に
+限定し、project の既定言語を持ちません。
+
+Review Protocol の Selection Contract / Execution Contract / Acquisition
+& Validity Contract / Resolution Contract、および `target_sha` /
+`finding_count` 等の record schema field 名は、この節の対象外の
+machine-facing structure として英語のまま保持します。これらの contract
+を説明する human-facing な本文は、この節の既定言語に従います。
+provider-native bot 自身が固定言語で出力する内容は、この節に対する
+Foundation violation として扱いません。agent が自ら作成する durable な
+summary / resolution comment は、この節の既定言語に従います。
+
 ## Task Protocol
 
 Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -35,6 +35,51 @@
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。
 `CLAUDE.md` は `AGENTS.md` を参照する thin adapter であり、canonical rule を複製しません。
 
+## Human-facing output language
+
+human-facing output（人間が読むために agent が作成・編集する成果物）の
+既定言語は、その project が持つ既定言語に従います。少なくとも次を対象と
+します。
+
+- Issue / PR の title・body・comment
+- review finding / triage / Resolution / closure の durable evidence comment
+- planning checkpoint、handoff、completion report
+- セッション中の人間向け progress report・final report
+- agent が生成・編集する Markdown / documentation
+
+一方、次は human-facing output の既定言語に関わらず、無理に翻訳せず原語
+（多くの場合英語）のまま保持します。
+
+- source code / identifier / symbol / API / library / framework name
+- file path / command / script name
+- schema / enum / protocol field 等の machine-facing text
+- error / log / provider-native output の引用
+- externally defined technical term / proper noun
+
+human-facing な地の文の中に、上記の technical vocabulary を原語のまま
+混在させることは許容します。検索性や意味精度を落とす過剰な翻訳はしません。
+
+project が既定言語を明示していない場合、agent は言語を仮定せず、その
+project の既存 human-facing artifact や communication から観測できる
+言語に合わせます。
+
+project 自身の既定言語が何であるかは Foundation Kernel が固定する対象
+ではありません。技術非依存な Foundation policy はこの節の reusable な
+原則までとし、特定の project がどの言語を既定とするかは、その project
+の Consumer product rules、または Foundation 自身のように project が
+自らを consumer として扱う場合は project 自身の repo-local instructions
+へ記録します。Technology profile は technology/provider 向けの具体化に
+限定し、project の既定言語を持ちません。
+
+Review Protocol の Selection Contract / Execution Contract / Acquisition
+& Validity Contract / Resolution Contract、および `target_sha` /
+`finding_count` 等の record schema field 名は、この節の対象外の
+machine-facing structure として英語のまま保持します。これらの contract
+を説明する human-facing な本文は、この節の既定言語に従います。
+provider-native bot 自身が固定言語で出力する内容は、この節に対する
+Foundation violation として扱いません。agent が自ら作成する durable な
+summary / resolution comment は、この節の既定言語に従います。
+
 ## Task Protocol
 
 Task の canonical context は Issue 本文です。downstream agent への handoff は Issue を短く

--- a/test/human-facing-output-language.test.mjs
+++ b/test/human-facing-output-language.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+test("core policy defines a provider/consumer-neutral human-facing output language convention", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("## Human-facing output language"));
+
+  // Reusable principle: follows the project's own default, not a hardcoded language.
+  assert.ok(
+    containsText(
+      core,
+      "human-facing output（人間が読むために agent が作成・編集する成果物）の既定言語は、その project が持つ既定言語に従います。",
+    ),
+  );
+
+  // Covered surfaces from Issue #28's proposed semantics.
+  for (const surface of [
+    "Issue / PR の title・body・comment",
+    "review finding / triage / Resolution / closure の durable evidence comment",
+    "planning checkpoint、handoff、completion report",
+    "セッション中の人間向け progress report・final report",
+    "agent が生成・編集する Markdown / documentation",
+  ]) {
+    assert.ok(core.includes(surface), `missing covered surface: ${surface}`);
+  }
+
+  // Exceptions: machine-facing vocabulary is preserved, not translated.
+  for (const exception of [
+    "source code / identifier / symbol / API / library / framework name",
+    "file path / command / script name",
+    "schema / enum / protocol field 等の machine-facing text",
+    "error / log / provider-native output の引用",
+    "externally defined technical term / proper noun",
+  ]) {
+    assert.ok(core.includes(exception), `missing exception: ${exception}`);
+  }
+  assert.ok(
+    containsText(
+      core,
+      "human-facing な地の文の中に、上記の technical vocabulary を原語のまま混在させることは許容します。",
+    ),
+  );
+
+  // Unspecified-default fallback: observe, don't assume a hardcoded language.
+  assert.ok(
+    containsText(
+      core,
+      "project が既定言語を明示していない場合、agent は言語を仮定せず、その project の既存 human-facing artifact や communication から観測できる言語に合わせます。",
+    ),
+  );
+
+  // Design constraint (Issue #28): Kernel must not hardcode a specific consumer
+  // language (e.g. Japanese) as a mandatory rule.
+  assert.ok(
+    containsText(
+      core,
+      "project 自身の既定言語が何であるかは Foundation Kernel が固定する対象ではありません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "特定の project がどの言語を既定とするかは、その project の Consumer product rules、または Foundation 自身のように project が自らを consumer として扱う場合は project 自身の repo-local instructions へ記録します。",
+    ),
+  );
+  assert.ok(
+    containsText(core, "Technology profile は technology/provider 向けの具体化に限定し、project の既定言語を持ちません。"),
+  );
+  assert.doesNotMatch(
+    core,
+    /日本語(で書|必須|を既定)/,
+    "policy/core.md must not hardcode Japanese (or any specific consumer language) as a mandatory Kernel rule",
+  );
+
+  // Review Protocol's machine-facing contract/field names stay untouched by this convention.
+  assert.ok(
+    containsText(
+      core,
+      "Review Protocol の Selection Contract / Execution Contract / Acquisition & Validity Contract / Resolution Contract、および `target_sha` / `finding_count` 等の record schema field 名は、この節の対象外の machine-facing structure として英語のまま保持します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "provider-native bot 自身が固定言語で出力する内容は、この節に対する Foundation violation として扱いません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "agent が自ら作成する durable な summary / resolution comment は、この節の既定言語に従います。",
+    ),
+  );
+
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("generated consumer AGENTS.md reflects the human-facing output language convention", async () => {
+  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+
+  assert.ok(agents.includes("## Human-facing output language"));
+  assert.ok(
+    containsText(
+      agents,
+      "human-facing output（人間が読むために agent が作成・編集する成果物）の既定言語は、その project が持つ既定言語に従います。",
+    ),
+  );
+});
+
+test("ai-dev-foundation repository instructions declare its own Japanese default and defer to policy/core.md", async () => {
+  const rootAgents = await readFile(path.join(root, "AGENTS.md"), "utf8");
+
+  assert.ok(
+    containsText(rootAgents, "このリポジトリ（`ai-dev-foundation`）自身の既定言語は日本語です。"),
+  );
+  assert.ok(containsText(rootAgents, "`policy/core.md`のHuman-facing output languageに従い"));
+
+  // Covers GitHub outputs / reports, not only in-repo Markdown docs.
+  for (const surface of [
+    "GitHub Issue/PRのtitle・body・comment",
+    "review durable evidence comment",
+    "planning checkpoint・handoff・completion report",
+    "セッション中の人間向けprogress report・final report",
+  ]) {
+    assert.ok(containsText(rootAgents, surface), `missing covered surface in repo-local AGENTS.md: ${surface}`);
+  }
+
+  // This repo-local instruction stays separate from the canonical consumer-facing
+  // policy/templates, per the existing Generated adapters boundary.
+  assert.ok(
+    containsText(
+      rootAgents,
+      "このファイルはFoundation自身を編集するためのrepo-local instructionです。",
+    ),
+  );
+});


### PR DESCRIPTION
## 概要

Issue #28 のTask Contractに基づき、human-facing output（Issue/PR/handoff/completion report/review durable evidence comment等）の既定言語をconsumer/projectの既定言語に従わせるreusableなconventionをFoundationへ追加しました。

- `policy/core.md` に新節 `## Human-facing output language` を追加。対象surface（Issue/PR title・body・comment、review durable evidence comment、planning checkpoint/handoff/completion report、progress/final report、agentが生成・編集するMarkdown/documentation）と、翻訳しない例外（source code / identifier / API名 / file path / command / schema・enum・protocol field / error・log・provider-native outputの引用 / proper noun）を明記しました。
- project が既定言語を明示していない場合は言語を仮定せず、既存artifactから観測する fallback を明記しました。
- Foundation Kernelへ特定言語（日本語）をhard-codeしないという設計制約を守るため、project自身の既定言語は各projectのConsumer product rules、またはFoundation自身のようにprojectが自らをconsumerとして扱う場合はproject自身のrepo-local instructionsへ記録する旨を明記しました。
- Review Protocolのmachine-facing structure（Selection/Execution/Acquisition & Validity/Resolution Contract、`target_sha`/`finding_count`等のrecord schema field名）はこのconventionの対象外であり、英語のまま保持することを明記しました。provider-native botの固定言語出力はFoundation violationとして扱わない旨も明記しています。
- `ai-dev-foundation`リポジトリ自身のrepo-local instructions（`AGENTS.md`）を拡張し、既存の「Markdown文書/templateは日本語」に加えて、GitHub Issue/PR/comment、review durable evidence comment、handoff、completion report、セッション中のprogress/final reportも日本語default対象であることを明記しました。
- `test/fixtures/consumer/AGENTS.md` を `npm run sync:fixture` で再生成し、生成されるconsumer adapterへ新conventionが反映されていることを確認しました。
- 新しいdeterministic test（`test/human-facing-output-language.test.mjs`）で、上記のconvention文言・Kernelへの日本語hard-code禁止・Review Protocol machine-facing structure不変・生成fixtureへの反映を検証しています。

## Scope

stage-tracker側の `.ai-dev-foundation/product-rules.md` への反映は、PO確認の結果、本PRのscope外としました（stage-tracker repinのタイミングに委ねます）。

## Review Selection（記録用）

- Artifact classification: Normative（AGENTS/policy文書）
- Selection: 独立reviewerとして Codex GitHub Review と Claude GitHub-native `@claude review` の2系統を想定
- Target: このPRのhead SHA（`policy/core.md` review protocolに従い、reviewerのdurable evidence commentへtarget SHAを記録してください）

## Test plan

- [x] `npm test`（全22 test green + guardrails green）
- [x] `git diff --check` clean
- [ ] Codex GitHub Review によるdiscoveryとresolution
- [ ] Claude GitHub-native `@claude review` によるdiscoveryとresolution

## Stopping point

本PRはmerge-readyになった時点で停止します。merge、Issue #28のclose、version bump、tag作成、stage-tracker repinの実行権限は本PRの作業agentにはありません。