### PR TITLE
Foundation policy: canonical Task Contractがある場合のthin invocation conventionを追加する (#29)

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -138,11 +138,11 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 
 ### Thin invocation over a canonical Task Contract
 
-canonical Task Contract が durable な project surface（Issue 本文等）に
-既に存在する場合、agent invocation はその内容を原則として再掲せず参照
-します。長い session-local prompt がなければ Task を再開できないことを
-目指すのではなく、durable な canonical Task Contract から新しい
-agent/session が作業を再開できることを目指します。
+Task の canonical context は Issue 本文です（本節冒頭）。この canonical
+Task Contract が既に Issue 本文へ存在する場合、agent invocation はその
+内容を原則として再掲せず、Issue を参照します。長い session-local prompt
+がなければ Task を再開できないことを目指すのではなく、durable な Issue
+本文から新しい agent/session が作業を再開できることを目指します。
 
 canonical Task Contract が存在する場合、invocation / handoff prompt へ
 含めるのは原則として次に限定します。
@@ -161,9 +161,9 @@ Criteria / design constraint 等を、理由なく invocation prompt へ複製�
 せん。
 
 material な追加 decision が session を跨いで継続的に必要になる場合は、
-可能な限り durable surface（Issue 本文の更新等）へ materialize した上で、
-invocation からはそれを参照します。invocation prompt 自体を追加 decision
-の正本にしません。
+可能な限り durable な Issue 本文へ materialize した上で、invocation
+からはそれを参照します。invocation prompt 自体を追加 decision の正本に
+しません。
 
 短い prompt 自体を目的にしません。canonical Task Contract が不十分な場合
 や、緊急の session-local constraint がある場合は、必要な情報を invocation

--- a/policy/core.md
+++ b/policy/core.md
@@ -136,6 +136,45 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 人間を message bus にしません。人間への escalation は、product intent、authority、権限、
 または受容不能な trade-off に限ります。
 
+### Thin invocation over a canonical Task Contract
+
+canonical Task Contract が durable な project surface（Issue 本文等）に
+既に存在する場合、agent invocation はその内容を原則として再掲せず参照
+します。長い session-local prompt がなければ Task を再開できないことを
+目指すのではなく、durable な canonical Task Contract から新しい
+agent/session が作業を再開できることを目指します。
+
+canonical Task Contract が存在する場合、invocation / handoff prompt へ
+含めるのは原則として次に限定します。
+
+- canonical Task Contract の locator
+- handoff 値を current と仮定せず、current state を再取得する指示
+- Task Contract へまだ materialize されていない session 固有の追加
+  decision / constraint
+- execution authority
+- stopping condition
+- 必要な review / verification への pointer（詳細が canonical guidance に
+  ある場合は再掲しない）
+
+canonical Task Contract に既に存在する background / scope / Acceptance
+Criteria / design constraint 等を、理由なく invocation prompt へ複製しま
+せん。
+
+material な追加 decision が session を跨いで継続的に必要になる場合は、
+可能な限り durable surface（Issue 本文の更新等）へ materialize した上で、
+invocation からはそれを参照します。invocation prompt 自体を追加 decision
+の正本にしません。
+
+短い prompt 自体を目的にしません。canonical Task Contract が不十分な場合
+や、緊急の session-local constraint がある場合は、必要な情報を invocation
+へ含めてよく、機械的な短文化のために欠落させてはいけません。canonical
+Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の
+更新を優先します。
+
+この convention は provider-neutral です。特定の CLI、agent runtime、
+または model 向けの invocation format を Kernel に固定しません。新しい
+prompt schema / DSL / generator の導入を要求しません。
+
 ## Review Protocol
 
 Review の canonical context は本節です。

--- a/policy/core.md
+++ b/policy/core.md
@@ -171,6 +171,12 @@ material な追加 decision が session を跨いで継続的に必要になる�
 Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の
 更新を優先します。
 
+thin invocation は、受け手の agent/session が Issue 本文へアクセスできる
+ことを前提とします。この access 可否は available tools 等の Execution
+Envelope に属し、Semantic Contract の充足度とは独立です。受け手が Issue
+本文へアクセスできることを保証できない場合、locator の提示だけで済ませ
+ず、必要な Task Contract の内容を invocation へ直接含めます。
+
 この convention は provider-neutral です。特定の CLI、agent runtime、
 または model 向けの invocation format を Kernel に固定しません。新しい
 prompt schema / DSL / generator の導入を要求しません。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -179,6 +179,12 @@ material な追加 decision が session を跨いで継続的に必要になる�
 Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の
 更新を優先します。
 
+thin invocation は、受け手の agent/session が Issue 本文へアクセスできる
+ことを前提とします。この access 可否は available tools 等の Execution
+Envelope に属し、Semantic Contract の充足度とは独立です。受け手が Issue
+本文へアクセスできることを保証できない場合、locator の提示だけで済ませ
+ず、必要な Task Contract の内容を invocation へ直接含めます。
+
 この convention は provider-neutral です。特定の CLI、agent runtime、
 または model 向けの invocation format を Kernel に固定しません。新しい
 prompt schema / DSL / generator の導入を要求しません。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -146,11 +146,11 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 
 ### Thin invocation over a canonical Task Contract
 
-canonical Task Contract が durable な project surface（Issue 本文等）に
-既に存在する場合、agent invocation はその内容を原則として再掲せず参照
-します。長い session-local prompt がなければ Task を再開できないことを
-目指すのではなく、durable な canonical Task Contract から新しい
-agent/session が作業を再開できることを目指します。
+Task の canonical context は Issue 本文です（本節冒頭）。この canonical
+Task Contract が既に Issue 本文へ存在する場合、agent invocation はその
+内容を原則として再掲せず、Issue を参照します。長い session-local prompt
+がなければ Task を再開できないことを目指すのではなく、durable な Issue
+本文から新しい agent/session が作業を再開できることを目指します。
 
 canonical Task Contract が存在する場合、invocation / handoff prompt へ
 含めるのは原則として次に限定します。
@@ -169,9 +169,9 @@ Criteria / design constraint 等を、理由なく invocation prompt へ複製�
 せん。
 
 material な追加 decision が session を跨いで継続的に必要になる場合は、
-可能な限り durable surface（Issue 本文の更新等）へ materialize した上で、
-invocation からはそれを参照します。invocation prompt 自体を追加 decision
-の正本にしません。
+可能な限り durable な Issue 本文へ materialize した上で、invocation
+からはそれを参照します。invocation prompt 自体を追加 decision の正本に
+しません。
 
 短い prompt 自体を目的にしません。canonical Task Contract が不十分な場合
 や、緊急の session-local constraint がある場合は、必要な情報を invocation

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -144,6 +144,45 @@ handoff を毎 Task で義務化しませんが、High role を終える時点�
 人間を message bus にしません。人間への escalation は、product intent、authority、権限、
 または受容不能な trade-off に限ります。
 
+### Thin invocation over a canonical Task Contract
+
+canonical Task Contract が durable な project surface（Issue 本文等）に
+既に存在する場合、agent invocation はその内容を原則として再掲せず参照
+します。長い session-local prompt がなければ Task を再開できないことを
+目指すのではなく、durable な canonical Task Contract から新しい
+agent/session が作業を再開できることを目指します。
+
+canonical Task Contract が存在する場合、invocation / handoff prompt へ
+含めるのは原則として次に限定します。
+
+- canonical Task Contract の locator
+- handoff 値を current と仮定せず、current state を再取得する指示
+- Task Contract へまだ materialize されていない session 固有の追加
+  decision / constraint
+- execution authority
+- stopping condition
+- 必要な review / verification への pointer（詳細が canonical guidance に
+  ある場合は再掲しない）
+
+canonical Task Contract に既に存在する background / scope / Acceptance
+Criteria / design constraint 等を、理由なく invocation prompt へ複製しま
+せん。
+
+material な追加 decision が session を跨いで継続的に必要になる場合は、
+可能な限り durable surface（Issue 本文の更新等）へ materialize した上で、
+invocation からはそれを参照します。invocation prompt 自体を追加 decision
+の正本にしません。
+
+短い prompt 自体を目的にしません。canonical Task Contract が不十分な場合
+や、緊急の session-local constraint がある場合は、必要な情報を invocation
+へ含めてよく、機械的な短文化のために欠落させてはいけません。canonical
+Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の
+更新を優先します。
+
+この convention は provider-neutral です。特定の CLI、agent runtime、
+または model 向けの invocation format を Kernel に固定しません。新しい
+prompt schema / DSL / generator の導入を要求しません。
+
 ## Review Protocol
 
 Review の canonical context は本節です。

--- a/test/task-protocol.test.mjs
+++ b/test/task-protocol.test.mjs
@@ -76,6 +76,20 @@ test("core policy defines a thin invocation convention over a canonical Task Con
     /canonical\s+Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の\s+更新を優先します。/,
   );
 
+  // Guardrail (Codex P2 finding on PR #33 closure round): thin invocation
+  // presupposes the receiving agent/session can actually reach the Issue
+  // (an Execution Envelope / capability property, independent of Semantic
+  // Contract sufficiency). When that access isn't guaranteed, the invoker
+  // must inline the needed Task Contract content rather than a bare locator.
+  assert.match(
+    core,
+    /thin invocation は、受け手の agent\/session が Issue 本文へアクセスできる\s+ことを前提とします。/,
+  );
+  assert.match(
+    core,
+    /受け手が Issue\s+本文へアクセスできることを保証できない場合、locator の提示だけで済ませ\s+ず、必要な Task Contract の内容を invocation へ直接含めます。/,
+  );
+
   // Provider-neutral: no new prompt schema/DSL/generator, no hardcoded CLI/model.
   assert.match(core, /この convention は provider-neutral です。/);
   assert.match(core, /新しい\s+prompt schema \/ DSL \/ generator の導入を要求しません。/);

--- a/test/task-protocol.test.mjs
+++ b/test/task-protocol.test.mjs
@@ -39,8 +39,13 @@ test("core policy defines a thin invocation convention over a canonical Task Con
   // exists on a durable surface.
   assert.match(
     core,
-    /canonical Task Contract が durable な project surface（Issue 本文等）に\s+既に存在する場合、agent invocation はその内容を原則として再掲せず参照\s+します。/,
+    /Task の canonical context は Issue 本文です（本節冒頭）。この canonical\s+Task Contract が既に Issue 本文へ存在する場合、agent invocation はその\s+内容を原則として再掲せず、Issue を参照します。/,
   );
+
+  // Regression guard (Codex P2 finding on PR #33): the new section must not
+  // introduce a broader "durable surface" than the single canonical context
+  // ("Issue 本文") already fixed earlier in this Task Protocol section.
+  assert.doesNotMatch(core, /durable な project surface（Issue 本文等）/);
 
   // Representative examples of what invocation/handoff prompts should still carry.
   for (const item of [

--- a/test/task-protocol.test.mjs
+++ b/test/task-protocol.test.mjs
@@ -29,3 +29,50 @@ test("core policy defines the provider-neutral Task Protocol", async () => {
   assert.match(core, /Execution\s+Envelope の制約や事故を semantic decision として吸収してはいけません/);
   assert.doesNotMatch(core, /claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
 });
+
+test("core policy defines a thin invocation convention over a canonical Task Contract (Issue #29)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("### Thin invocation over a canonical Task Contract"));
+
+  // Core rule: reference, don't restate, when a canonical Task Contract already
+  // exists on a durable surface.
+  assert.match(
+    core,
+    /canonical Task Contract が durable な project surface（Issue 本文等）に\s+既に存在する場合、agent invocation はその内容を原則として再掲せず参照\s+します。/,
+  );
+
+  // Representative examples of what invocation/handoff prompts should still carry.
+  for (const item of [
+    "canonical Task Contract の locator",
+    "handoff 値を current と仮定せず、current state を再取得する指示",
+    "Task Contract へまだ materialize されていない session 固有の追加",
+    "execution authority",
+    "stopping condition",
+    "必要な review / verification への pointer",
+  ]) {
+    assert.ok(core.includes(item), `missing invocation-retained item: ${item}`);
+  }
+
+  // Material recurring decisions belong on the durable surface, not the prompt.
+  assert.match(
+    core,
+    /material な追加 decision が session を跨いで継続的に必要になる場合は、/,
+  );
+
+  // Guardrail: this must not become a mechanical shortening rule when the
+  // Task Contract itself is insufficient.
+  assert.match(
+    core,
+    /短い prompt 自体を目的にしません。canonical Task Contract が不十分な場合/,
+  );
+  assert.match(
+    core,
+    /canonical\s+Task Contract の不足に気付いた場合は、省略ではなく Task Contract 自体の\s+更新を優先します。/,
+  );
+
+  // Provider-neutral: no new prompt schema/DSL/generator, no hardcoded CLI/model.
+  assert.match(core, /この convention は provider-neutral です。/);
+  assert.match(core, /新しい\s+prompt schema \/ DSL \/ generator の導入を要求しません。/);
+  assert.doesNotMatch(core, /claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});


### PR DESCRIPTION
## Context

Issue #29 を参照。GitHub Issue本文をcanonical Task Contractとして十分にmaterializeしている場合でも、agent invocation（開始指示）でIssue本文の内容を長く再掲する運用があり、これがcontract drift・authorityの曖昧化・session間handoffの肥大化につながっていた。

## Change

`policy/core.md` の Task Protocol へ「Thin invocation over a canonical Task Contract」節を追加した。

- canonical Task Contractがdurable surface（Issue本文等）に存在する場合、invocationはその内容を原則として再掲せず参照する
- invocationに残すべきsession固有情報を列挙: Task Contractのlocator / current state再取得指示 / まだmaterializeされていないsession固有decision・constraint / execution authority / stopping condition / review・verificationへのpointer
- material な追加decisionが継続的に必要な場合は、durable surfaceへmaterializeする方針を明記
- guardrail: Task Contractが不十分な場合や緊急のsession-local constraintがある場合は必要な情報をinvocationへ含めてよく、機械的な短文化ruleにはしない
- provider-neutral: 新しいprompt schema / DSL / generatorを導入せず、特定CLI/model向けformatをKernelに固定しない

Placementは既存の `### Handoff and escalation` に隣接する最小追加とし、新しいprompt DSL / schema / generator、Issue template再設計、provider固有runtime、Task Protocol自体のmaterial再設計は行っていない（Issueのscope/placement制約に従うbounded変更）。

`test/task-protocol.test.mjs` に新節の内容をmechanicalに検証するtestを追加し、`test/fixtures/consumer/AGENTS.md` を `npm run sync:fixture` で再生成した。

## Verification

- `npm test`: 23 tests pass, guardrails green（deterministic verify, target SHA: このPRのhead commit）

## Scope / authority

- merge / Issue close / version bump / tag authority はこのPRにありません。
- 本PRにauto-close keywordは含めていません（Issue #29 は手動でcloseしてください）。
- 次のFoundation versionのblockerにはせず、bounded improvementとして扱っています（Issue #29 Sequencing節に従う）。

merge-readyでの停止を想定しています。review evidenceは本PR上にcommentとして追記します。