### PR TITLE
Review skill: pollCompletion()をfresh再取得ベースに、job conclusion矛盾のObserved exampleを追加する

### DIFF
--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -189,7 +189,10 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `trigger()`: reviewer をどう起動したか（PR 更新での automatic trigger、
   `@reviewer review` のような明示的な command 等）を記録します。
 - `pollCompletion()`: completion をどう確認したか（status の変化、comment の投稿、
-  run の所要時間等）を記録します。CI/status のみでの判断はしません。
+  run の所要時間等）を記録します。CI/status のみでの判断はしません。completion 判定に
+  使う comment / review submission は、判定するその時点で ID を指定して fresh に
+  再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
+  snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
 - `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
   inline/thread comment、review submission/summary、status/check、必要なら
   workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
@@ -228,6 +231,17 @@ Acquisition & Validity Contract の recoverability 要件を満たしやすい�
 capability record 側で再検証可能な observed evidence として扱ってください。
 GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は、上記の
 `collectOutputs()` の persist 手順を必ず行います。
+
+さらに別の観測として、GitHub Actions 経由で PR comment を投稿・編集する reviewer では、
+その reviewer を起動した Actions job/step 自身の conclusion（success/failure）が、同じ
+job が編集した comment 本文の completion 状態と一致しないことが実測されています。
+具体的には、job/step の conclusion が `failure` であっても、対応する comment の body には
+completion を示す marker（例: 全項目 checked の todo list、明示的な complete 文言）と
+実質的な review 内容が既に存在していたケースがありました。この種の reviewer では、
+wrapping job/step の conclusion 単独を completion または failure の根拠にせず、
+comment 本文の completion marker を fresh 再取得した上で直接確認してください。これも
+特定 provider の恒久仕様ではなく、observed evidence として capability/profile 側で
+再検証可能な形で扱います。
 
 ## Manual review pilot
 


### PR DESCRIPTION
## Context

Issue #31 の Discovery（[comment](https://github.com/reitojike/ai-dev-foundation/issues/31#issuecomment-5369604107)）で、stage-tracker実PRのGitHub API生データを実測した結果、以下が判明した。

- Claude GitHub-native `@claude review` は同一 top-level comment を複数回 edit して completion 状態へ収束させる（`created_at != updated_at`）。
- そのうち、wrapping Actions job/step の conclusion が `failure` であっても、同じ job が編集した comment 本文には completion marker（全項目 checked todo list、"Review complete ✅" 等）と実質的な finding が既に存在するケースが複数確認された。job conclusion と comment 本文の completion 状態が矛盾しうる。

PO はこの Discovery を踏まえ、「guidance / review skill の小さな bounded 変更で閉じる」方針を承認済み。本 PR はその最小案を実装する。

`policy/core.md` は Discovery 時点で「CI status は review completion と同義でない」「edited comment を surface として明記済み」であり、追加の必要性が確認できなかったため変更していない。

## Changes

`skills/review-code.md` のみを変更（Normative artifact、bounded change）。

1. `pollCompletion()` bullet に、completion 判定は判定時点で ID を指定して fresh 再取得した state/body を使い、会話内の既知 comment 内容や過去 snapshot だけを pending 継続の根拠にしない旨を追記。
2. Adapter boundary の Observed example に、GitHub Actions 経由で comment を編集する reviewer において wrapping job/step の conclusion と comment 本文の completion 状態が矛盾しうるという実測例（PR #4 run `32340836046` 等）を追加。job conclusion 単独を completion/failure の根拠にしないことを明記。両方とも「特定 provider の恒久仕様ではなく observed evidence」という既存 Observed example と同じ書き方を踏襲。

## Out of scope（Issueの指定通り）

- polling runtime / daemon / provider-specific machinery の新規実装
- `policy/core.md` の変更

## Verification

- 変更前 candidate SHA: `38fa65e`（origin/main）
- freeze した candidate SHA: `b10f231`
- `npm test`（`node --test` 22 tests + `test:guardrails`）: 全て green（変更前後とも）
  - `review skills document procedure without duplicating normative rules` を含む
- deterministic verify は本 PR の branch 上、target SHA と一致した状態で実行済み

## Review evidence

Foundation Review Protocol（Normative document review: mechanical check -> semantic discovery 1 round -> triage/fix -> 必要なら closure）に従い、review を取得しdurable evidenceをこのPR上へ残します。取得次第このPRへコメントとして追記します。

## Merge authority

merge / Issue close / version bump / tag authority を持たないため、merge-ready の状態で停止します。auto-close keyword は含めていません。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>