### PR TITLE
Foundation policy: Issue close前にAcceptance Criteriaをevidence照合するcompletion protocolを追加する (Issue #32)

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -181,6 +181,55 @@ Envelope に属し、Semantic Contract の充足度とは独立です。受け�
 または model 向けの invocation format を Kernel に固定しません。新しい
 prompt schema / DSL / generator の導入を要求しません。
 
+### Issue closure and Acceptance Criteria completion
+
+Task Contract の completion は、Review Protocol の merge-readiness（Merge readiness
+and merge authority）とは別の contract です。merge-ready の成立、または実際の merge
+は、canonical Issue 上の Acceptance Criteria が満たされたことの証跡にはなりません。
+Review が完了していても、Issue Task Contract 上の Acceptance Criteria 確認を省略して
+よいことにはなりません。canonical Issue を completed として close する判断は、この
+節に従います。
+
+canonical Issue を completed として close する前に、少なくとも次を行います。
+
+1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
+   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
+   （canonical Task Contract）と、merge 済み current main または applicable branch
+   の状態を再取得します。
+2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
+   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
+   完了したように見える」という印象だけでは充足の根拠にしません。
+3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
+   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
+   evidence の一部として扱います。
+4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない Acceptance
+   Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。
+   Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance
+   Criteria を捏造しません。
+5. **completion comment** — final SHA、verification 結果、review evidence
+   （Review Protocol の Acquisition & Validity Contract に従う record / result
+   locator を含む）、および未解決事項を、Issue 上の completion comment として
+   記録します。
+
+推奨する sequence は次のとおりです。
+
+`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
+completion comment -> Issue close`
+
+Issue close の execution authority は、Merge readiness and merge authority と同じ
+分離に従います。current Task、Execution Envelope、または explicit な authority が
+close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
+が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
+編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
+（または未達か）を completion handoff として明示的に残した上で停止し、authority
+escalation / handoff します。
+
+auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
+Issue が自動 close される運用を、標準運用にしません。
+
+この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
+workflow engine、または新しい orchestrator を要求しません。
+
 ## Review Protocol
 
 Review の canonical context は本節です。

--- a/policy/core.md
+++ b/policy/core.md
@@ -221,8 +221,8 @@ Issue close の execution authority は、Merge readiness and merge authority �
 close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
 が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
 編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
-（または未達か）を completion handoff として明示的に残した上で停止し、authority
-escalation / handoff します。
+（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、
+authority escalation / handoff します。
 
 auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
 Issue が自動 close される運用を、標準運用にしません。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -189,6 +189,55 @@ Envelope に属し、Semantic Contract の充足度とは独立です。受け�
 または model 向けの invocation format を Kernel に固定しません。新しい
 prompt schema / DSL / generator の導入を要求しません。
 
+### Issue closure and Acceptance Criteria completion
+
+Task Contract の completion は、Review Protocol の merge-readiness（Merge readiness
+and merge authority）とは別の contract です。merge-ready の成立、または実際の merge
+は、canonical Issue 上の Acceptance Criteria が満たされたことの証跡にはなりません。
+Review が完了していても、Issue Task Contract 上の Acceptance Criteria 確認を省略して
+よいことにはなりません。canonical Issue を completed として close する判断は、この
+節に従います。
+
+canonical Issue を completed として close する前に、少なくとも次を行います。
+
+1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
+   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
+   （canonical Task Contract）と、merge 済み current main または applicable branch
+   の状態を再取得します。
+2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
+   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
+   完了したように見える」という印象だけでは充足の根拠にしません。
+3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
+   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
+   evidence の一部として扱います。
+4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない Acceptance
+   Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。
+   Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance
+   Criteria を捏造しません。
+5. **completion comment** — final SHA、verification 結果、review evidence
+   （Review Protocol の Acquisition & Validity Contract に従う record / result
+   locator を含む）、および未解決事項を、Issue 上の completion comment として
+   記録します。
+
+推奨する sequence は次のとおりです。
+
+`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
+completion comment -> Issue close`
+
+Issue close の execution authority は、Merge readiness and merge authority と同じ
+分離に従います。current Task、Execution Envelope、または explicit な authority が
+close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
+が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
+編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
+（または未達か）を completion handoff として明示的に残した上で停止し、authority
+escalation / handoff します。
+
+auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
+Issue が自動 close される運用を、標準運用にしません。
+
+この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
+workflow engine、または新しい orchestrator を要求しません。
+
 ## Review Protocol
 
 Review の canonical context は本節です。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -229,8 +229,8 @@ Issue close の execution authority は、Merge readiness and merge authority �
 close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
 が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
 編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
-（または未達か）を completion handoff として明示的に残した上で停止し、authority
-escalation / handoff します。
+（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、
+authority escalation / handoff します。
 
 auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
 Issue が自動 close される運用を、標準運用にしません。

--- a/test/issue-closure-completion.test.mjs
+++ b/test/issue-closure-completion.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+test("core policy defines the Issue closure and Acceptance Criteria completion protocol (#32)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("### Issue closure and Acceptance Criteria completion"));
+
+  // This must stay a distinct contract from Review Protocol's merge-readiness:
+  // review completion does not stand in for Acceptance Criteria confirmation.
+  assert.ok(
+    containsText(
+      core,
+      "Task Contract の completion は、Review Protocol の merge-readiness（Merge readiness and merge authority）とは別の contract です。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "merge-ready の成立、または実際の merge は、canonical Issue 上の Acceptance Criteria が満たされたことの証跡にはなりません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "Review が完了していても、Issue Task Contract 上の Acceptance Criteria 確認を省略してよいことにはなりません。",
+    ),
+  );
+
+  // The 5 required pre-close steps.
+  assert.ok(containsText(core, "canonical context の再取得"));
+  assert.ok(
+    containsText(
+      core,
+      "close しようとする session 自身の記憶や過去の長文 handoff をそのまま正としてはいけません。",
+    ),
+  );
+  assert.ok(containsText(core, "Acceptance Criteria evidence 照合"));
+  assert.ok(
+    containsText(
+      core,
+      "「実装が完了したように見える」という印象だけでは充足の根拠にしません。",
+    ),
+  );
+  assert.ok(containsText(core, "checkbox 更新"));
+  assert.ok(
+    containsText(
+      core,
+      "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+    ),
+  );
+  assert.ok(containsText(core, "未達・判断不能な項目の扱い"));
+  assert.ok(
+    containsText(
+      core,
+      "evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造しません。",
+    ),
+  );
+  assert.ok(containsText(core, "completion comment"));
+  assert.ok(
+    containsText(
+      core,
+      "final SHA、verification 結果、review evidence（Review Protocol の Acquisition & Validity Contract に従う record / result locator を含む）、および未解決事項を、Issue 上の completion comment として記録します。",
+    ),
+  );
+
+  // The recommended sequence, verbatim from Issue #32.
+  assert.ok(
+    containsText(
+      core,
+      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+    ),
+  );
+
+  // Authority separation mirrors Merge readiness and merge authority: no authority,
+  // no close — leave a completion handoff and stop instead.
+  assert.ok(
+    containsText(
+      core,
+      "Issue close の execution authority は、Merge readiness and merge authority と同じ分離に従います。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "current Task、Execution Envelope、または explicit な authority が close の実行を許可している場合に限り、agent は Issue を close してよいです。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "agent は Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか（または未達か）を completion handoff として明示的に残した上で停止し、authority escalation / handoff します。",
+    ),
+  );
+
+  // Constraint from Issue #32: auto-close keywords must not become the standard
+  // path to a pre-AC-check close (full prohibition of auto-close is out of scope).
+  assert.ok(
+    containsText(
+      core,
+      "auto-close keyword（例: PR 本文の \"Closes #N\"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。",
+    ),
+  );
+
+  // Out of scope for #32: no new bot / workflow-engine / orchestrator machinery.
+  assert.ok(
+    containsText(
+      core,
+      "この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
+    ),
+  );
+
+  // Stays provider-neutral, like the rest of the Kernel.
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("generated consumer AGENTS.md reflects the Issue closure completion protocol", async () => {
+  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+
+  assert.ok(agents.includes("### Issue closure and Acceptance Criteria completion"));
+  assert.ok(
+    containsText(
+      agents,
+      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+    ),
+  );
+});

--- a/test/issue-closure-completion.test.mjs
+++ b/test/issue-closure-completion.test.mjs
@@ -14,120 +14,140 @@ function containsText(haystack, needle) {
   return stripWhitespace(haystack).includes(stripWhitespace(needle));
 }
 
-test("core policy defines the Issue closure and Acceptance Criteria completion protocol (#32)", async () => {
-  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
-
-  assert.ok(core.includes("### Issue closure and Acceptance Criteria completion"));
+// Shared assertion set for the Issue closure and Acceptance Criteria completion
+// protocol (#32). Run against both the canonical policy/core.md and the
+// generated consumer AGENTS.md, since composeAgents() embeds core.md verbatim
+// and this protocol's content must not silently drift between the two.
+function assertIssueClosureCompletionProtocol(text, label) {
+  assert.ok(text.includes("### Issue closure and Acceptance Criteria completion"), `${label}: missing heading`);
 
   // This must stay a distinct contract from Review Protocol's merge-readiness:
   // review completion does not stand in for Acceptance Criteria confirmation.
   assert.ok(
     containsText(
-      core,
+      text,
       "Task Contract の completion は、Review Protocol の merge-readiness（Merge readiness and merge authority）とは別の contract です。",
     ),
+    `${label}: missing merge-readiness separation statement`,
   );
   assert.ok(
     containsText(
-      core,
+      text,
       "merge-ready の成立、または実際の merge は、canonical Issue 上の Acceptance Criteria が満たされたことの証跡にはなりません。",
     ),
+    `${label}: missing merge-ready-is-not-AC-evidence statement`,
   );
   assert.ok(
     containsText(
-      core,
+      text,
       "Review が完了していても、Issue Task Contract 上の Acceptance Criteria 確認を省略してよいことにはなりません。",
     ),
+    `${label}: missing review-completion-does-not-skip-AC statement`,
   );
 
   // The 5 required pre-close steps.
-  assert.ok(containsText(core, "canonical context の再取得"));
+  assert.ok(containsText(text, "canonical context の再取得"), `${label}: missing step 1 label`);
   assert.ok(
     containsText(
-      core,
+      text,
       "close しようとする session 自身の記憶や過去の長文 handoff をそのまま正としてはいけません。",
     ),
+    `${label}: missing step 1 detail`,
   );
-  assert.ok(containsText(core, "Acceptance Criteria evidence 照合"));
+  assert.ok(containsText(text, "Acceptance Criteria evidence 照合"), `${label}: missing step 2 label`);
+  assert.ok(
+    containsText(text, "「実装が完了したように見える」という印象だけでは充足の根拠にしません。"),
+    `${label}: missing step 2 detail`,
+  );
+  assert.ok(containsText(text, "checkbox 更新"), `${label}: missing step 3 label`);
   assert.ok(
     containsText(
-      core,
-      "「実装が完了したように見える」という印象だけでは充足の根拠にしません。",
-    ),
-  );
-  assert.ok(containsText(core, "checkbox 更新"));
-  assert.ok(
-    containsText(
-      core,
+      text,
       "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
     ),
+    `${label}: missing step 3 detail`,
   );
-  assert.ok(containsText(core, "未達・判断不能な項目の扱い"));
+  assert.ok(containsText(text, "未達・判断不能な項目の扱い"), `${label}: missing step 4 label`);
   assert.ok(
     containsText(
-      core,
+      text,
       "evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。",
     ),
+    `${label}: missing step 4 detail`,
   );
   assert.ok(
     containsText(
-      core,
+      text,
       "Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造しません。",
     ),
+    `${label}: missing no-fabricating-AC statement`,
   );
-  assert.ok(containsText(core, "completion comment"));
+  assert.ok(containsText(text, "completion comment"), `${label}: missing step 5 label`);
   assert.ok(
     containsText(
-      core,
+      text,
       "final SHA、verification 結果、review evidence（Review Protocol の Acquisition & Validity Contract に従う record / result locator を含む）、および未解決事項を、Issue 上の completion comment として記録します。",
     ),
+    `${label}: missing step 5 detail`,
   );
 
   // The recommended sequence, verbatim from Issue #32.
   assert.ok(
     containsText(
-      core,
+      text,
       "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
     ),
+    `${label}: missing recommended sequence`,
   );
 
-  // Authority separation mirrors Merge readiness and merge authority: no authority,
-  // no close — leave a completion handoff and stop instead.
+  // Authority separation mirrors Merge readiness and merge authority: no
+  // authority, no close — leave a completion comment and stop instead.
   assert.ok(
     containsText(
-      core,
+      text,
       "Issue close の execution authority は、Merge readiness and merge authority と同じ分離に従います。",
     ),
+    `${label}: missing authority separation statement`,
   );
   assert.ok(
     containsText(
-      core,
+      text,
       "current Task、Execution Envelope、または explicit な authority が close の実行を許可している場合に限り、agent は Issue を close してよいです。",
     ),
+    `${label}: missing authority-permits-close statement`,
   );
   assert.ok(
     containsText(
-      core,
-      "agent は Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか（または未達か）を completion handoff として明示的に残した上で停止し、authority escalation / handoff します。",
+      text,
+      "agent は Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、authority escalation / handoff します。",
     ),
+    `${label}: missing no-authority stop-and-handoff statement`,
   );
 
   // Constraint from Issue #32: auto-close keywords must not become the standard
   // path to a pre-AC-check close (full prohibition of auto-close is out of scope).
   assert.ok(
     containsText(
-      core,
+      text,
       "auto-close keyword（例: PR 本文の \"Closes #N\"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。",
     ),
+    `${label}: missing auto-close-not-standard statement`,
   );
 
   // Out of scope for #32: no new bot / workflow-engine / orchestrator machinery.
   assert.ok(
     containsText(
-      core,
+      text,
       "この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
     ),
+    `${label}: missing no-new-machinery statement`,
   );
+}
+
+test("core policy defines the Issue closure and Acceptance Criteria completion protocol (#32)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assertIssueClosureCompletionProtocol(core, "policy/core.md");
 
   // Stays provider-neutral, like the rest of the Kernel.
   assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
@@ -136,11 +156,5 @@ test("core policy defines the Issue closure and Acceptance Criteria completion p
 test("generated consumer AGENTS.md reflects the Issue closure completion protocol", async () => {
   const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
 
-  assert.ok(agents.includes("### Issue closure and Acceptance Criteria completion"));
-  assert.ok(
-    containsText(
-      agents,
-      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
-    ),
-  );
+  assertIssueClosureCompletionProtocol(agents, "test/fixtures/consumer/AGENTS.md");
 });


### PR DESCRIPTION
## Context

関連: #32

実運用でReviewやmergeが完了していても、Issue close時にAcceptance Criteria
checkboxが未更新のまま残るケースが繰り返し発生していた。Review Protocolの
merge-readinessと、Issue Task Contract上のAcceptance Criteria completionが
混同されないよう、Issue close前のcompletion protocolをFoundation policyの
canonical sourceへ追加する。

## Changes

- `policy/core.md`: Task Protocol配下に `### Issue closure and Acceptance
  Criteria completion` を追加（`### Thin invocation over a canonical Task
  Contract`（#29、mainへmerge済み）の直後）。
  - canonical context再取得 → AC evidence照合 → checkbox更新 →
    未達/判断不能項目の扱い → completion comment、という5ステップと、
    推奨sequence `merge/current main確認 → AC evidence照合 → checkbox更新 →
    completion comment → Issue close` を明記。
  - Issue close execution authorityを、既存の `Merge readiness and merge
    authority` と同じ分離semanticsに従わせた（authorityが無いagentは
    close/本文編集をせず、AC×evidenceを手順5のcompletion commentとして
    残して停止）。
  - auto-close keywordを標準運用にしないこと、新しいbot/orchestrator/
    generalized workflow engineを要求しないことを明記（Issue #32の
    Out of scopeに整合）。
- `test/fixtures/consumer/AGENTS.md`: `npm run sync:fixture` による再生成
  （生成ファイル、手編集なし）。
- `test/issue-closure-completion.test.mjs`: 新設した規範文の主要文言を
  `policy/core.md` と生成済み consumer `AGENTS.md` の両方に対して検証する
  mechanical fixture testを追加（共有assertion関数で両者のcoverageを揃えた）。

## Rebase / integration history

- `83b235a` → `95ff51f`: 初回実装 + closure round fix（後述のreview参照）
- PR #33（Issue #29, Thin invocation over a canonical Task Contract）と
  PR #34（Issue #31, pollCompletion() fresh再取得）がmainへmergeされたため、
  `origin/main`（`e34b9fa`）へrebase。`policy/core.md` /
  `test/fixtures/consumer/AGENTS.md` の挿入位置競合（#29と同じ anchor）を、
  #29の節をそのまま保持した上でこのPRの節をその直後へ配置する形で解消。
  生成fixtureは手編集で解決せず、rebase後に `npm run sync:fixture` で
  再生成（差分ゼロを確認）。
- final SHA: `5d07f33`

## Verification (deterministic, fresh head `5d07f33`)

- `npm test` — 25 tests pass（#29のtest含む）、guardrails 8 fixtures green
- `npm run check:fixture` — 生成 adapter / quality profile ともにdriftなし

## Acceptance Criteria evidence

Issue #32 Acceptance Criteriaとの対応:

- [x] Issue close前にcanonical Task Contract / Acceptance Criteriaを再取得
      することが明記されている → `policy/core.md` 新設節 手順1
- [x] 各ACをevidenceと照合してからcheckboxを更新することが明記されている
      → 同 手順2・3
- [x] 未達・判断不能なACがあれば勝手にcheck / closeしないことが明確 →
      同 手順4
- [x] `merge/main確認 → AC更新 → completion comment → close` の順序が
      分かる → 同節の推奨sequence
- [x] authorityが無いagentのhandoff behaviorが明確 → 同節のexecution
      authority段落（手順5のcompletion commentを参照する形に統一済み）
- [x] Review Protocol completionとIssue AC completionを混同しない →
      節冒頭の分離記述
- [x] 新しいworkflow bot / orchestratorへscope creepしていない → 同節末尾
      の明示的な非要求文、および実装差分に新規tooling/bot追加なし
- [x] applicable deterministic checksがgreen → 上記 Verification 参照

## Review evidence (durable, on this PR)

Normative artifact review（`policy/core.md`）を review-doc.md 手順で実施。
required review数: 1（Selection）。

- Discovery（semantic discovery, 1 round, target `83b235a`）: run
  [32481558788](https://github.com/reitojike/ai-dev-foundation/actions/runs/32481558788)
  （completed/success）。non-blocking finding 2件。
- Resolution: 両finding accepted、commit `95ff51f` でbatch fix。
- Targeted closure verification（target `95ff51f`）: run
  [32482017960](https://github.com/reitojike/ai-dev-foundation/actions/runs/32482017960)
  （completed/success）。2件とも解消確認、新規blocking findingなし。
- **Rebase後のtargeted closure review（target `5d07f33`、このPRの規範文
  自体に変更なし、rebase integrationのみ確認）**: run
  [32484364722](https://github.com/reitojike/ai-dev-foundation/actions/runs/32484364722)
  （completed/success）。#29節との共存・生成AGENTS.mdの一致・規範文の
  無変更を確認、blocking findingなし。非blockingな観察1件（Thin
  invocation節とIssue closure節が同じ原則を異なる文脈で述べている点）は
  reviewer自身が修正不要と判断（false-positive相当としてResolution）。

discovery Resolution・closure Resolution（初回・rebase後とも）いずれも
完了しているため、review-doc.mdの停止条件に従いreview procedure完了 =
merge-readyと判定する。

## Authority

このPRにmerge / Issue close / version-tag実行authorityはない。auto-close
keywordは本文に含めていない。review procedureが完了しmerge-readyとなった
時点で停止し、authority holderへhandoffする。