### PR TITLE
Detect duplicate Supabase migration version prefixes before DB startup

### DIFF
--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -92,22 +92,55 @@ project IDと生成先パスを使う`supabase:types`を定義し、それを実
 diffを失敗させる`supabase:types:check`をblocking checkへ追加します。これはdrift/error
 検知への入口であり、FoundationはSupabase project設定や生成先を決めません。
 
+`supabase/migrations`内のmigration version prefix重複はDB / Docker / Supabase local
+stackを起動する前にfilesystemだけでdeterministicに検知します。consumerは
+`.ai-dev-foundation/quality/check-migration-version-collision.mjs`を
+`supabase:migrations:check`として実行し、DB/Dockerを起動する他のcheckより前の
+blocking checkへ追加します。詳細は「Migration version prefix collision detection」
+を参照してください。
+
 unit/component testとDB/RLS testはtest runnerを固定しません。consumerで該当testが
 存在する場合は、そのcommandをblocking CIへ追加します。
+
+## Migration version prefix collision detection
+
+parallel branch / worktreeでmigrationを追加すると、異なるfilename（例:
+`20260822120000_add_feature_a.sql`と`20260822120000_add_feature_b.sql`）が
+Git上は競合せず共存できます。しかしSupabaseはfilenameの`_`より前の数字列を
+migration versionとして扱うため、これは同一version identityを持つhidden
+collisionです。Git text conflictでは検出できず、実際のDB migrationまで
+表面化しません。
+
+`check-migration-version-collision.mjs`は`supabase/migrations`をfilesystem
+だけで検査し、同一version prefixを持つ異なるfilenameがあればduplicate
+versionと該当filenameすべてを診断してnon-zeroで失敗します。local Supabase
+runtime、Docker、DB接続のいずれも必要としません。`supabase/migrations`
+直下の`<digits>_name.sql`ファイルだけを対象とし、サブディレクトリは
+再帰的に走査しません（Supabase CLI自身の`ListLocalMigrations`と同じ
+scopeです）。
+
+このcheckerはmigration番号のallocationやreservationを行いません。
+collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local stackを
+起動する前に安価に検出するguardrailです。
+
+```text
+node .ai-dev-foundation/quality/check-migration-version-collision.mjs
+```
 
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
 profile固有の追加は`verify:profile`に置きます。これはextension pointであり、pluginの
-登録機構ではありません。consumerがSupabaseを使う場合、`supabase:types:check`は
-`verify:profile`から呼び出し、typesの再生成後に生成ファイルのdriftをnon-zeroで検知する
-commandにします。DB/RLS testがあるconsumerは同じ`verify:profile`からそのtest commandを
-呼び出します。
+登録機構ではありません。consumerがSupabaseを使う場合、`supabase:migrations:check`
+（DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
+`supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
+driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
+`verify:profile`からそのtest commandを呼び出します。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run supabase:types:check && npm run test:rls",
+    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/profiles/next-supabase/quality/check-migration-version-collision.mjs
+++ b/profiles/next-supabase/quality/check-migration-version-collision.mjs
@@ -7,6 +7,11 @@ import path from 'node:path';
 // migrations directory are considered migrations — ListLocalMigrations skips
 // subdirectories rather than recursing into them, and skips any filename
 // that doesn't match "<digits>_name.sql".
+//
+// Version identity is compared as a raw string, not a number: supabase/cli's
+// own schema_migrations table declares `version text NOT NULL PRIMARY KEY`
+// (apps/cli-go/pkg/migration/history.go), so Supabase's own collision check
+// is a text-equality check, not a numeric one.
 const MIGRATION_FILENAME_PATTERN = /^([0-9]+)_(.*)\.sql$/;
 const migrationsDirectory = path.join(process.cwd(), 'supabase', 'migrations');
 
@@ -19,7 +24,10 @@ async function readMigrationFilenames(directory) {
     if (error.code === 'ENOENT') return [];
     throw error;
   }
-  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+  // Mirrors ListLocalMigrations' `if migration.IsDir() { continue }`: only
+  // directories are excluded, not symlinks — Dirent.isFile() would also
+  // silently exclude a migration file that exists as a symlink.
+  return entries.filter((entry) => !entry.isDirectory()).map((entry) => entry.name);
 }
 
 function groupFilenamesByVersion(filenames) {

--- a/profiles/next-supabase/quality/check-migration-version-collision.mjs
+++ b/profiles/next-supabase/quality/check-migration-version-collision.mjs
@@ -1,0 +1,64 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+// Mirrors supabase/cli's own migration filename parsing (migrateFilePattern
+// in apps/cli-go/pkg/migration/file.go): version identity is the leading run
+// of digits before the first underscore, and only direct .sql files in the
+// migrations directory are considered migrations — ListLocalMigrations skips
+// subdirectories rather than recursing into them, and skips any filename
+// that doesn't match "<digits>_name.sql".
+const MIGRATION_FILENAME_PATTERN = /^([0-9]+)_(.*)\.sql$/;
+const migrationsDirectory = path.join(process.cwd(), 'supabase', 'migrations');
+
+async function readMigrationFilenames(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    // No supabase/migrations directory yet is a valid, collision-free state.
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+}
+
+function groupFilenamesByVersion(filenames) {
+  const filenamesByVersion = new Map();
+  for (const filename of filenames) {
+    const match = MIGRATION_FILENAME_PATTERN.exec(filename);
+    if (!match) continue;
+    const [, version] = match;
+    const matchingFilenames = filenamesByVersion.get(version) ?? [];
+    matchingFilenames.push(filename);
+    filenamesByVersion.set(version, matchingFilenames);
+  }
+  return filenamesByVersion;
+}
+
+const filenames = await readMigrationFilenames(migrationsDirectory);
+const filenamesByVersion = groupFilenamesByVersion(filenames);
+const collisions = [...filenamesByVersion.entries()]
+  .filter(([, matchingFilenames]) => matchingFilenames.length > 1)
+  .sort(([a], [b]) => a.localeCompare(b));
+
+if (collisions.length > 0) {
+  console.error('Duplicate Supabase migration version prefix detected in supabase/migrations:');
+  for (const [version, matchingFilenames] of collisions) {
+    console.error(`  version ${version}:`);
+    for (const filename of [...matchingFilenames].sort()) {
+      console.error(`    - ${filename}`);
+    }
+  }
+  console.error(
+    'Each supabase/migrations file must have a unique <version>_name.sql prefix; rename one of the files above.',
+  );
+  process.exitCode = 1;
+} else {
+  const migrationCount = [...filenamesByVersion.values()].reduce(
+    (total, group) => total + group.length,
+    0,
+  );
+  console.log(
+    `No duplicate Supabase migration version prefixes (checked ${migrationCount} migration file(s)).`,
+  );
+}

--- a/test/consumer-verify.test.mjs
+++ b/test/consumer-verify.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -68,4 +68,39 @@ test("consumer verify fixes the required command set", async () => {
   for (const command of requiredCommands) {
     assert.equal(typeof packageJson.scripts[command], "string");
   }
+});
+
+test("verify:profile runs the filesystem-only migration collision check before any DB/Docker-touching Supabase command", async () => {
+  // Issue #43: the migration version collision guardrail must execute before
+  // the DB / Docker / Supabase local stack is ever touched. supabase:types:check
+  // stands in for the DB/Docker-touching step here (per profile README, real
+  // consumers' supabase:types shells out to `supabase gen types`), so
+  // supabase:migrations:check must be sequenced strictly before it, not just
+  // present somewhere in verify:profile.
+  const packageJson = JSON.parse(await readFile(path.join(fixture, "package.json"), "utf8"));
+  assert.equal(
+    packageJson.scripts["verify:profile"],
+    "npm run supabase:migrations:check && npm run supabase:types:check",
+  );
+  assert.equal(
+    packageJson.scripts["supabase:migrations:check"],
+    "node .ai-dev-foundation/quality/check-migration-version-collision.mjs",
+  );
+});
+
+test("consumer verify detects a duplicate Supabase migration version prefix", async (t) => {
+  const migrationsDirectory = path.join(fixture, "supabase", "migrations");
+  const colliding = path.join(migrationsDirectory, "20260101000000_create_todos_again.sql");
+  t.after(() => rm(colliding, { force: true }));
+
+  // Same version prefix as the fixture's existing 20260101000000_create_todos.sql,
+  // different filename — the Issue #43 canonical failure mode, which Git alone
+  // would never flag as a conflict.
+  await writeFile(colliding, "create table todos_again (id uuid primary key);\n");
+
+  const result = verify();
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Duplicate Supabase migration version prefix detected/);
+  assert.match(result.stderr, /20260101000000_create_todos\.sql/);
+  assert.match(result.stderr, /20260101000000_create_todos_again\.sql/);
 });

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -92,22 +92,55 @@ project IDと生成先パスを使う`supabase:types`を定義し、それを実
 diffを失敗させる`supabase:types:check`をblocking checkへ追加します。これはdrift/error
 検知への入口であり、FoundationはSupabase project設定や生成先を決めません。
 
+`supabase/migrations`内のmigration version prefix重複はDB / Docker / Supabase local
+stackを起動する前にfilesystemだけでdeterministicに検知します。consumerは
+`.ai-dev-foundation/quality/check-migration-version-collision.mjs`を
+`supabase:migrations:check`として実行し、DB/Dockerを起動する他のcheckより前の
+blocking checkへ追加します。詳細は「Migration version prefix collision detection」
+を参照してください。
+
 unit/component testとDB/RLS testはtest runnerを固定しません。consumerで該当testが
 存在する場合は、そのcommandをblocking CIへ追加します。
+
+## Migration version prefix collision detection
+
+parallel branch / worktreeでmigrationを追加すると、異なるfilename（例:
+`20260822120000_add_feature_a.sql`と`20260822120000_add_feature_b.sql`）が
+Git上は競合せず共存できます。しかしSupabaseはfilenameの`_`より前の数字列を
+migration versionとして扱うため、これは同一version identityを持つhidden
+collisionです。Git text conflictでは検出できず、実際のDB migrationまで
+表面化しません。
+
+`check-migration-version-collision.mjs`は`supabase/migrations`をfilesystem
+だけで検査し、同一version prefixを持つ異なるfilenameがあればduplicate
+versionと該当filenameすべてを診断してnon-zeroで失敗します。local Supabase
+runtime、Docker、DB接続のいずれも必要としません。`supabase/migrations`
+直下の`<digits>_name.sql`ファイルだけを対象とし、サブディレクトリは
+再帰的に走査しません（Supabase CLI自身の`ListLocalMigrations`と同じ
+scopeです）。
+
+このcheckerはmigration番号のallocationやreservationを行いません。
+collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local stackを
+起動する前に安価に検出するguardrailです。
+
+```text
+node .ai-dev-foundation/quality/check-migration-version-collision.mjs
+```
 
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
 profile固有の追加は`verify:profile`に置きます。これはextension pointであり、pluginの
-登録機構ではありません。consumerがSupabaseを使う場合、`supabase:types:check`は
-`verify:profile`から呼び出し、typesの再生成後に生成ファイルのdriftをnon-zeroで検知する
-commandにします。DB/RLS testがあるconsumerは同じ`verify:profile`からそのtest commandを
-呼び出します。
+登録機構ではありません。consumerがSupabaseを使う場合、`supabase:migrations:check`
+（DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
+`supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
+driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
+`verify:profile`からそのtest commandを呼び出します。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run supabase:types:check && npm run test:rls",
+    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-migration-version-collision.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-migration-version-collision.mjs
@@ -7,6 +7,11 @@ import path from 'node:path';
 // migrations directory are considered migrations — ListLocalMigrations skips
 // subdirectories rather than recursing into them, and skips any filename
 // that doesn't match "<digits>_name.sql".
+//
+// Version identity is compared as a raw string, not a number: supabase/cli's
+// own schema_migrations table declares `version text NOT NULL PRIMARY KEY`
+// (apps/cli-go/pkg/migration/history.go), so Supabase's own collision check
+// is a text-equality check, not a numeric one.
 const MIGRATION_FILENAME_PATTERN = /^([0-9]+)_(.*)\.sql$/;
 const migrationsDirectory = path.join(process.cwd(), 'supabase', 'migrations');
 
@@ -19,7 +24,10 @@ async function readMigrationFilenames(directory) {
     if (error.code === 'ENOENT') return [];
     throw error;
   }
-  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+  // Mirrors ListLocalMigrations' `if migration.IsDir() { continue }`: only
+  // directories are excluded, not symlinks — Dirent.isFile() would also
+  // silently exclude a migration file that exists as a symlink.
+  return entries.filter((entry) => !entry.isDirectory()).map((entry) => entry.name);
 }
 
 function groupFilenamesByVersion(filenames) {

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-migration-version-collision.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-migration-version-collision.mjs
@@ -1,0 +1,64 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+// Mirrors supabase/cli's own migration filename parsing (migrateFilePattern
+// in apps/cli-go/pkg/migration/file.go): version identity is the leading run
+// of digits before the first underscore, and only direct .sql files in the
+// migrations directory are considered migrations — ListLocalMigrations skips
+// subdirectories rather than recursing into them, and skips any filename
+// that doesn't match "<digits>_name.sql".
+const MIGRATION_FILENAME_PATTERN = /^([0-9]+)_(.*)\.sql$/;
+const migrationsDirectory = path.join(process.cwd(), 'supabase', 'migrations');
+
+async function readMigrationFilenames(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    // No supabase/migrations directory yet is a valid, collision-free state.
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+}
+
+function groupFilenamesByVersion(filenames) {
+  const filenamesByVersion = new Map();
+  for (const filename of filenames) {
+    const match = MIGRATION_FILENAME_PATTERN.exec(filename);
+    if (!match) continue;
+    const [, version] = match;
+    const matchingFilenames = filenamesByVersion.get(version) ?? [];
+    matchingFilenames.push(filename);
+    filenamesByVersion.set(version, matchingFilenames);
+  }
+  return filenamesByVersion;
+}
+
+const filenames = await readMigrationFilenames(migrationsDirectory);
+const filenamesByVersion = groupFilenamesByVersion(filenames);
+const collisions = [...filenamesByVersion.entries()]
+  .filter(([, matchingFilenames]) => matchingFilenames.length > 1)
+  .sort(([a], [b]) => a.localeCompare(b));
+
+if (collisions.length > 0) {
+  console.error('Duplicate Supabase migration version prefix detected in supabase/migrations:');
+  for (const [version, matchingFilenames] of collisions) {
+    console.error(`  version ${version}:`);
+    for (const filename of [...matchingFilenames].sort()) {
+      console.error(`    - ${filename}`);
+    }
+  }
+  console.error(
+    'Each supabase/migrations file must have a unique <version>_name.sql prefix; rename one of the files above.',
+  );
+  process.exitCode = 1;
+} else {
+  const migrationCount = [...filenamesByVersion.values()].reduce(
+    (total, group) => total + group.length,
+    0,
+  );
+  console.log(
+    `No duplicate Supabase migration version prefixes (checked ${migrationCount} migration file(s)).`,
+  );
+}

--- a/test/fixtures/consumer/package.json
+++ b/test/fixtures/consumer/package.json
@@ -12,8 +12,9 @@
     "test:unit": "node --experimental-strip-types --test test/*.test.mjs",
     "build": "tsc --project tsconfig.build.json",
     "foundation:check": "node ../../../tooling/check.mjs --consumer .",
+    "supabase:migrations:check": "node .ai-dev-foundation/quality/check-migration-version-collision.mjs",
     "supabase:types:check": "node scripts/check-generated-supabase-types.mjs",
-    "verify:profile": "npm run supabase:types:check",
+    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/test/fixtures/consumer/supabase/migrations/20260101000000_create_todos.sql
+++ b/test/fixtures/consumer/supabase/migrations/20260101000000_create_todos.sql
@@ -1,0 +1,4 @@
+create table todos (
+  id uuid primary key default gen_random_uuid(),
+  title text not null
+);

--- a/test/fixtures/consumer/supabase/migrations/20260101000100_add_todos_title_index.sql
+++ b/test/fixtures/consumer/supabase/migrations/20260101000100_add_todos_title_index.sql
@@ -1,0 +1,1 @@
+create index todos_title_idx on todos (title);

--- a/test/fixtures/migrations/duplicate-version/supabase/migrations/20260822120000_add_feature_a.sql
+++ b/test/fixtures/migrations/duplicate-version/supabase/migrations/20260822120000_add_feature_a.sql
@@ -1,0 +1,3 @@
+create table feature_a (
+  id uuid primary key default gen_random_uuid()
+);

--- a/test/fixtures/migrations/duplicate-version/supabase/migrations/20260822120000_add_feature_b.sql
+++ b/test/fixtures/migrations/duplicate-version/supabase/migrations/20260822120000_add_feature_b.sql
@@ -1,0 +1,3 @@
+create table feature_b (
+  id uuid primary key default gen_random_uuid()
+);

--- a/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/20260101000000_create_widgets.sql
+++ b/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/20260101000000_create_widgets.sql
@@ -1,0 +1,3 @@
+create table widgets (
+  id uuid primary key default gen_random_uuid()
+);

--- a/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/README.md
+++ b/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/README.md
@@ -1,0 +1,1 @@
+Not a migration file; must not be treated as one.

--- a/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/archive/20260101000000_create_widgets.sql
+++ b/test/fixtures/migrations/nested-and-unrelated/supabase/migrations/archive/20260101000000_create_widgets.sql
@@ -1,0 +1,6 @@
+-- Same version prefix as the top-level migration on purpose: this file lives
+-- in a nested subdirectory that Supabase's own migration loader does not
+-- recurse into, so it must not be treated as a colliding migration.
+create table widgets (
+  id uuid primary key default gen_random_uuid()
+);

--- a/test/fixtures/migrations/valid/supabase/migrations/20260101000000_create_widgets.sql
+++ b/test/fixtures/migrations/valid/supabase/migrations/20260101000000_create_widgets.sql
@@ -1,0 +1,3 @@
+create table widgets (
+  id uuid primary key default gen_random_uuid()
+);

--- a/test/fixtures/migrations/valid/supabase/migrations/20260101000100_add_widgets_name.sql
+++ b/test/fixtures/migrations/valid/supabase/migrations/20260101000100_add_widgets_name.sql
@@ -1,0 +1,1 @@
+alter table widgets add column name text;

--- a/test/migration-version-collision.test.mjs
+++ b/test/migration-version-collision.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const checkerScript = path.join(root, "profiles", "next-supabase", "quality", "check-migration-version-collision.mjs");
+const fixturesRoot = path.join(root, "test", "fixtures", "migrations");
+
+function runChecker(cwd) {
+  return spawnSync(process.execPath, [checkerScript], { cwd, encoding: "utf8" });
+}
+
+test("a valid migration set is green", () => {
+  const result = runChecker(path.join(fixturesRoot, "valid"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No duplicate Supabase migration version prefixes/);
+  assert.match(result.stdout, /checked 2 migration file\(s\)/);
+});
+
+test("different filenames sharing the same version prefix are deterministically red", () => {
+  // This is the Issue #43 canonical failure mode: distinct filenames that
+  // never conflict in Git but collide on Supabase's migration version
+  // identity (the digits before the first underscore).
+  const result = runChecker(path.join(fixturesRoot, "duplicate-version"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Duplicate Supabase migration version prefix detected/);
+});
+
+test("the failure diagnostic names the duplicate version and every colliding filename", () => {
+  const result = runChecker(path.join(fixturesRoot, "duplicate-version"));
+  assert.match(result.stderr, /version 20260822120000/);
+  assert.match(result.stderr, /20260822120000_add_feature_a\.sql/);
+  assert.match(result.stderr, /20260822120000_add_feature_b\.sql/);
+});
+
+test("nested subdirectories and non-migration files do not produce false positives", () => {
+  // supabase/migrations/archive/20260101000000_create_widgets.sql shares its
+  // version prefix with the top-level 20260101000000_create_widgets.sql, but
+  // Supabase's own migration loader does not recurse into subdirectories, so
+  // this must stay green. supabase/migrations/README.md does not match the
+  // <digits>_name.sql pattern and must also be ignored.
+  const result = runChecker(path.join(fixturesRoot, "nested-and-unrelated"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /checked 1 migration file\(s\)/);
+});
+
+test("a repository with no supabase/migrations directory yet is green, not an error", async (t) => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "ai-dev-foundation-migrations-"));
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+
+  const result = runChecker(temporaryRoot);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /checked 0 migration file\(s\)/);
+});
+
+test("the checker requires no DB, Docker, or Supabase CLI on PATH", () => {
+  // A filesystem-only guardrail must not fail merely because no local
+  // Supabase runtime is available — the whole point is to run before any
+  // DB/Docker/Supabase startup step. spawnSync inherits this process's PATH
+  // unchanged, so a pass here is direct evidence the checker did not shell
+  // out to `supabase`, `docker`, or a database connection.
+  const result = runChecker(path.join(fixturesRoot, "valid"));
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+});

--- a/test/migration-version-collision.test.mjs
+++ b/test/migration-version-collision.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -55,6 +55,40 @@ test("a repository with no supabase/migrations directory yet is green, not an er
   const result = runChecker(temporaryRoot);
   assert.equal(result.status, 0);
   assert.match(result.stdout, /checked 0 migration file\(s\)/);
+});
+
+test("a migration file that exists only as a symlink is still scanned, not silently skipped", async (t) => {
+  // Regression for a Claude review finding on PR #46: supabase/cli's own
+  // ListLocalMigrations only excludes directory entries (`if
+  // migration.IsDir() { continue }`), so a migration file that is a symlink
+  // is still picked up by the real Supabase CLI. An earlier implementation
+  // filtered with Dirent.isFile(), which silently excludes symlinks too and
+  // would miss a collision routed through one.
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "ai-dev-foundation-migrations-"));
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+  const migrationsDirectory = path.join(temporaryRoot, "supabase", "migrations");
+  await mkdir(migrationsDirectory, { recursive: true });
+  await writeFile(path.join(migrationsDirectory, "20260101000000_create_widgets.sql"), "-- real file\n");
+
+  try {
+    await symlink(
+      "20260101000000_create_widgets.sql",
+      path.join(migrationsDirectory, "20260101000000_create_widgets_symlink.sql"),
+    );
+  } catch (error) {
+    // Creating symlinks requires elevated privileges on some platforms
+    // (e.g. Windows without Developer Mode); skip rather than fail there.
+    t.skip(`symlink creation not permitted on this platform: ${error.code}`);
+    return;
+  }
+
+  // Same version prefix as the real file, reached only through the symlink:
+  // this must be detected as a collision, not silently dropped.
+  const result = runChecker(temporaryRoot);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /version 20260101000000/);
+  assert.match(result.stderr, /20260101000000_create_widgets\.sql/);
+  assert.match(result.stderr, /20260101000000_create_widgets_symlink\.sql/);
 });
 
 test("the checker requires no DB, Docker, or Supabase CLI on PATH", () => {


### PR DESCRIPTION
## Context

Issue #43 のcanonical Task Contract:
https://github.com/reitojike/ai-dev-foundation/issues/43

Origin: `reitojike/stage-tracker#45`。parallel worktree開発で、異なるmigration
filenameが同じSupabase migration version prefixを持つhidden collisionが実際に
発生した（Git text conflictでは検出できず、actual DB migration段階まで表面化
しなかった）。

## What this does

`profiles/next-supabase/quality/check-migration-version-collision.mjs` という
Foundation-owned、filesystem-onlyのcheckerを追加する。

- `supabase/migrations` 直下の`<digits>_name.sql`ファイルを走査する（サブ
  ディレクトリは再帰しない — supabase/cli自身の`ListLocalMigrations`と同じ
  scope）
- version identityの抽出は supabase/cli の `migrateFilePattern`
  (`^([0-9]+)_(.*)\.sql$`, `apps/cli-go/pkg/migration/file.go`) と同じ regex
- 異なるfilenameが同じversionを持てば、該当filenameすべてを列挙した
  diagnosticとともにnon-zeroで終了する
- DB / Docker / Supabase local stackを一切必要としない

配布は既存のquality-profile bootstrap/check machinery（
`tooling/bootstrap-next-supabase.mjs` / `tooling/check.mjs` の
`diffQualityProfile`）にそのまま乗る。新しいdistribution機構は追加していない。

reference consumer fixture (`test/fixtures/consumer`) の `verify:profile` に
`supabase:migrations:check` を追加し、DB/Dockerを触る `supabase:types:check`
より前に実行されるよう順序を固定した。

## Out of scope（Issue #43 Scope discipline どおり）

- migration番号のcentral allocator / reservation service
- worktree coordinator / daemon / scheduler
- 既存consumerのmigration一括renumber
- Foundation KernelへのSupabase固有rule追加

## Verification

- `npm test`: 42 pass / 0 fail（既存34 + 新規8）
- `npm run test:guardrails`: 8 fixture green
- `test/migration-version-collision.test.mjs`: valid set green / duplicate
  version red / diagnostic内容 / nested subdirectory・unrelated fileでの
  false positiveなし / `supabase/migrations`が存在しない場合もgreen / DB・
  Docker・Supabase CLIなしで動作することを確認
- `test/consumer-verify.test.mjs`: `verify:profile`内で
  `supabase:migrations:check`が`supabase:types:check`より先に実行される
  ことをpackage.json記述レベルで固定し、reference consumerの`npm run verify`
  が実際にduplicate version prefixを検知することを確認
- reference consumer `npm run verify`: green（`supabase:migrations:check`
  ステップを含む）

Test plan は下記参照。

## Test plan

- [x] `npm test`
- [x] `npm run test:guardrails`
- [x] `cd test/fixtures/consumer && npm run verify`
- [x] duplicate version prefix fixture → non-zero + diagnostic確認
- [x] valid fixture → zero確認
- [x] nested/unrelated file → false positiveなし確認
- [x] `supabase/migrations`不在 → green確認

---

このPRにauto-close keywordは含めていません。Issue #43のAcceptance Criteria
照合とcloseは別authorityに委ねます。merge実行authorityもこのsessionには
ありません。