### PR TITLE
Next.js profile: next devによる generated AGENTS.md書き換えを防ぐ (Issue #40)

### DIFF
--- a/profiles/next-supabase/project-rules.md
+++ b/profiles/next-supabase/project-rules.md
@@ -8,6 +8,15 @@ domain terminology、product-specific security decision は consumer product rul
 - generated Supabase types を database type の source of truth として扱います。
 - stack-specific deterministic quality check は Foundation core policy ではなく、
   この profile または関連 tooling に置きます。
+- Foundation-generated `AGENTS.md` は generated artifact であり、Next.js
+  runtime が書き換える対象ではありません。Next.js 16.3 以降を使う consumer は
+  `next.config` で `agentRules: false` を設定し、`next dev` による generated
+  `AGENTS.md` への silent mutation を防ぎます（16.3 未満は該当する自動生成
+  挙動も `agentRules` option も持たないため対象外です）。`next.config` 自体は
+  consumer-owned であり、Foundation はこの設定を代わりに書き込みません。
+  deterministic な検証方法は consumer の `.ai-dev-foundation/quality/README.md`
+  （Foundation リポジトリでは `profiles/next-supabase/quality/README.md`）を
+  参照してください。
 - quality profile の適用方法とblocking/advisoryの区別は consumer の
   `.ai-dev-foundation/quality/README.md`（Foundation リポジトリでは
   `profiles/next-supabase/quality/README.md`）を正本とします。product-domain

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -169,10 +169,13 @@ comment内の記述（`// agentRules: false`）、ネストしたobject内の同
 （`agentRules: false || true`）。
 next dev、network、ブラウザのいずれも必要としません。consumer configを
 実行・評価しないtext matchのため、`agentRules`を間接的な変数経由で設定する
-config（例: `agentRules: SOME_FLAG`）や、`{ agentRules: false, ...shared }`
-のようなspreadによる後続上書きは検出できません（直接記述された opt-out
-だけを対象にした bounded guardrail です。既知の制約はcheckerのcode comment
-を参照してください）。
+config（例: `agentRules: SOME_FLAG`）は検出できません（直接記述された
+opt-out だけを対象にした bounded guardrail です。既知の制約はcheckerの
+code commentを参照してください）。`{ agentRules: false, ...shared }`の
+ようにexplicit propertyの後にspreadがある場合は、実行時にspread側が
+上書きし得るため、effective valueを検証不能としてnon-zeroで失敗します
+（`{ ...shared, agentRules: false }`のようにspreadが先であれば、後続の
+explicit propertyが確実に勝つため引き続き検証できます）。
 
 このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
 policyへコピーしません。`next.config`の設定有無だけを検証します。

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -158,8 +158,10 @@ dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRul
 node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
 ```
 
-このcheckerは`next.config.ts` / `next.config.js` / `next.config.mjs`を
-filesystemだけで検査し、comment除去後・brace-depth 1（exportされる config
+このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`
+（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する場合は
+Next.jsが実際に読むfileを検証します）をfilesystemだけで検査し、
+comment除去後・brace-depth 1（exportされる config
 object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
 場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
 property valueである場合だけ有効とします（`agentRules: false || true`は

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -182,6 +182,24 @@ explicit propertyが確実に勝つため引き続き検証できます）。
 このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
 policyへコピーしません。`next.config`の設定有無だけを検証します。
 
+### 二層contract（proactive + reactive）
+
+`agent-rules:check`は、supportされた直接記述の`next.config`形式をfilesystemだけで
+deterministicに検証するbounded text matcherです。任意のJavaScript/TypeScript
+config semanticsを評価する約束はしません。上記の既知の制約（間接的な変数経由の
+設定、string literal内の紛らわしいtext、spread、shorthand/method/accessor形式の
+duplicate keyなど）は、parser/tokenizer/generalized config evaluatorへ発展させる
+ことでは解消しません。
+
+その代わり、`agent-rules:check`が見逃す exotic な`next.config`形式であっても、
+`next dev`が実際に`AGENTS.md`をmutationすれば、既存の`foundation:check`
+（`tooling/check.mjs`）がFoundationの合成結果と実file を exact比較し
+`Generated adapter drift detected`としてdeterministicに検出し、`tooling/sync.mjs`
+によるremediationを提供します。generated adapterのsilent mutationを防ぐ、または
+安全なremediationをdeterministically提供するという要件は、`agent-rules:check`
+単体ではなく、この proactive blocking layer（`agent-rules:check`）と reactive exact
+layer（`foundation:check`）を合わせたsystem levelで満たします。
+
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -99,6 +99,13 @@ stackを起動する前にfilesystemだけでdeterministicに検知します。c
 blocking checkへ追加します。詳細は「Migration version prefix collision detection」
 を参照してください。
 
+`next.config`がNext.js 16.3+の生成AGENTS.md agent rulesを無効化しているかも、DB /
+Docker / Supabase local stackを起動する前にfilesystemだけでdeterministicに検知
+します。Next.js 16.3以降を使うconsumerは`.ai-dev-foundation/quality/check-agent-rules-disabled.mjs`を
+`agent-rules:check`として実行し、blocking checkへ追加します（16.3未満のconsumerは
+`agentRules` optionも自動生成挙動も持たないため、このcheckを追加しません）。詳細は
+「Next.js agent-rules (generated AGENTS.md) drift prevention」を参照してください。
+
 unit/component testとDB/RLS testはtest runnerを固定しません。consumerで該当testが
 存在する場合は、そのcommandをblocking CIへ追加します。
 
@@ -127,6 +134,49 @@ collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local sta
 node .ai-dev-foundation/quality/check-migration-version-collision.mjs
 ```
 
+## Next.js agent-rules (generated AGENTS.md) drift prevention
+
+`AGENTS.md`はFoundation canonical inputsから生成されるgenerated artifactです
+（`tooling/sync.mjs`）。consumer/runtimeが実行時に書き換える対象ではありません。
+
+Next.js 16.3以降の`next dev`は、実行環境内にAI coding agent（`CLAUDECODE`、
+`CURSOR_TRACE_ID`、`CODEX_*`、`GEMINI_CLI`等の環境変数で検出）を検出すると、
+`next.config`で`agentRules`が明示的に`false`でない限り、生成済みの`AGENTS.md`へ
+`<!-- BEGIN:nextjs-agent-rules -->`で始まるmanaged blockをupsertします
+（Next.js 16.3.2の`node_modules/next/dist/server/lib/start-server.js`および
+`generate-agent-files.js`で確認済み）。これはFoundation-generated `AGENTS.md`への
+silent mutationであり、通常の`next dev`実行だけでconsumerのworking treeが
+dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRules` optionも
+持たないため、この節および次のcheckerの対象外です。
+
+`next.config`自体はconsumer-owned application configであり、Foundationは
+代わりにこのfileを書き込みません。consumerが`next.config`で明示的に
+`agentRules: false`を設定し、そのことを次のcheckerでdeterministicに
+担保します。
+
+```text
+node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+```
+
+このcheckerは`next.config.ts` / `next.config.js` / `next.config.mjs`を
+filesystemだけで検査し、comment除去後・brace-depth 1（exportされる config
+object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
+場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
+property valueである場合だけ有効とします（`agentRules: false || true`は
+実際にはtrueとして評価されるため無効）。次はfalseとして扱いません:
+comment内の記述（`// agentRules: false`）、ネストしたobject内の同名property
+（`{ experimental: { agentRules: false } }`）、および完全な値でないもの
+（`agentRules: false || true`）。
+next dev、network、ブラウザのいずれも必要としません。consumer configを
+実行・評価しないtext matchのため、`agentRules`を間接的な変数経由で設定する
+config（例: `agentRules: SOME_FLAG`）や、`{ agentRules: false, ...shared }`
+のようなspreadによる後続上書きは検出できません（直接記述された opt-out
+だけを対象にした bounded guardrail です。既知の制約はcheckerのcode comment
+を参照してください）。
+
+このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
+policyへコピーしません。`next.config`の設定有無だけを検証します。
+
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
@@ -135,12 +185,14 @@ profile固有の追加は`verify:profile`に置きます。これはextension po
 （DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
 `supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
 driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
-`verify:profile`からそのtest commandを呼び出します。
+`verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
+同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
+呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
+    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -153,6 +153,19 @@ function keepOnlyDirectProperties(objectSource) {
 // function and the caller: only the LAST key occurrence's value is ever
 // the effective one, so evaluating anything before it is pointless, and a
 // spread after it is exactly as override-capable as another explicit key.
+//
+// Out of this checker's documented scope (not a defect against it — the
+// same "regex, not a tokenizer" bound already documented on stripComments()
+// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}` inside string
+// literals): a string VALUE that happens to contain the literal text
+// `agentRules:` — e.g. `{ agentRules: false, note: 'agentRules: true' }` —
+// is indistinguishable, to this pattern, from a real duplicate key, and
+// would be treated as the last occurrence. This can only make the checker
+// fail closed on an actually-fine config (a false alarm, not a silent
+// pass), and requires a property value that itself contains the exact
+// `agentRules:` key text — a construct this contrived is accepted as
+// outside this filesystem-only checker's scope rather than chased with
+// string-literal-aware tokenization.
 function findLastAgentRulesKeyIndex(directPropertiesText) {
   AGENT_RULES_KEY_PATTERN.lastIndex = 0;
   let lastIndex = -1;

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -128,7 +128,7 @@ function escapeRegExp(literal) {
 
 // Locates, by source span, the object literal that a `next.config` file
 // actually `export default`s or `module.exports`s — following at most one
-// level of the canonical indirection Next.js's own docs show:
+// level of the canonical module-level indirection Next.js's own docs show:
 //   const nextConfig: NextConfig = { ... }; export default nextConfig;
 //   const nextConfig = { ... }; module.exports = nextConfig;
 // or a directly inlined `export default { ... }` / `module.exports = { ... }`.

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -27,15 +27,26 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // arbitrary trailing expression text. `}` is included for defensiveness
 // even though keepOnlyDirectProperties() below always blanks brace
 // characters before this pattern runs, so a real `}` never reaches here.
-const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+//
+// The leading `(?<![\w$])` requires that whatever immediately precedes the
+// match (the opening quote of a quoted key, or the `a` of a bare key) is
+// not itself an identifier character. Without it, a differently named
+// property whose name merely ENDS in `agentRules` — e.g.
+// `{ notAgentRules: false }`, a config that does not disable the real
+// `agentRules` option at all — would be read as the real key, false-passing
+// a config `next dev` still mutates. A quoted key's leading quote character
+// is not a `\w`/`$` character, so this lookbehind does not reject
+// `"agentRules": false`.
+const AGENT_RULES_DISABLED_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
 
 // Matches an `agentRules` key regardless of its value — used to find every
 // occurrence among an object's direct properties, not just ones that
 // happen to say `false`. JS object literals let the same key appear more
 // than once; whichever occurrence appears LAST wins at runtime (this is
 // legal, unambiguous JS, not a syntax error), so only the last occurrence's
-// value is ever the effective one.
-const AGENT_RULES_KEY_PATTERN = /["']?agentRules["']?\s*:/g;
+// value is ever the effective one. Same `(?<![\w$])` key-start boundary as
+// AGENT_RULES_DISABLED_PATTERN, and for the same reason.
+const AGENT_RULES_KEY_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:/g;
 
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
@@ -120,22 +131,29 @@ function findExportedConfigObjectSource(source) {
 // would still treat an unrelated, coincidentally named `agentRules: false`
 // nested inside some other property of that same object (for example
 // `{ experimental: { agentRules: false } }`) as if it were the top-level
-// `agentRules` property NextConfig actually reads. Brace depth is counted
-// and only text at depth 1 relative to the exported object's own opening
-// brace — its direct properties — is kept; deeper text is blanked out
-// before matching. This is brace counting, not full parsing, so a `{` or
-// `}` inside a string literal is a known, accepted edge case, matching the
-// same bound already documented for stripComments().
+// `agentRules` property NextConfig actually reads. Brace/bracket depth is
+// counted and only text at depth 1 relative to the exported object's own
+// opening brace — its direct properties — is kept; deeper text is blanked
+// out before matching. `[`/`]` are tracked the same way as `{`/`}` so an
+// array-literal property VALUE (e.g. `pageExtensions: [...defaultExtensions,
+// 'mdx']`, an ordinary Next.js config idiom) is blanked out too: without
+// this, its contents stayed visible at depth 1, and hasSpreadAfter() below
+// would false-positively read the array's own `...` spread — which has
+// nothing to do with `agentRules` — as a possible override, fail-closing an
+// actually-safe config (Claude review finding on this PR). This is
+// brace/bracket counting, not full parsing, so a `{`/`}`/`[`/`]` inside a
+// string literal is a known, accepted edge case, matching the same bound
+// already documented for stripComments().
 function keepOnlyDirectProperties(objectSource) {
   let depth = 0;
   let result = '';
   for (const character of objectSource) {
-    if (character === '{') {
+    if (character === '{' || character === '[') {
       depth += 1;
       result += ' ';
       continue;
     }
-    if (character === '}') {
+    if (character === '}' || character === ']') {
       depth -= 1;
       result += ' ';
       continue;

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -326,7 +326,7 @@ const configFile = await findConfigFile(process.cwd());
 
 if (configFile === null) {
   console.error(
-    `No next.config.{ts,js,mjs} found. Foundation-generated AGENTS.md is a generated artifact ` +
+    `No next.config.{js,mjs,ts} found. Foundation-generated AGENTS.md is a generated artifact ` +
       `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
       `with \`agentRules: false\`.`,
   );

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -219,16 +219,32 @@ function keepOnlyDirectProperties(objectSource) {
 //
 // Out of this checker's documented scope (not a defect against it — the
 // same "regex, not a tokenizer" bound already documented on stripComments()
-// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}` inside string
-// literals): a string VALUE that happens to contain the literal text
-// `agentRules:` — e.g. `{ agentRules: false, note: 'agentRules: true' }` —
-// is indistinguishable, to this pattern, from a real duplicate key, and
-// would be treated as the last occurrence. This can only make the checker
-// fail closed on an actually-fine config (a false alarm, not a silent
-// pass), and requires a property value that itself contains the exact
-// `agentRules:` key text — a construct this contrived is accepted as
-// outside this filesystem-only checker's scope rather than chased with
-// string-literal-aware tokenization.
+// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}`/`[`/`]` inside
+// string literals): a string VALUE whose content happens to contain text
+// that reads as an `agentRules` key is indistinguishable, to this pattern,
+// from a real one, and would be treated as an occurrence — potentially the
+// last one. Two shapes of this have been observed on this PR:
+//   - a bare substring — `{ agentRules: false, note: 'agentRules: true' }`
+//     — which, since a real `agentRules: false` is also present here,
+//     only fails the check closed on an actually-fine config (a false
+//     alarm, not a silent pass);
+//   - a quoted substring that itself parses as a complete disabling
+//     assignment — `{ note: 'Example JSON: "agentRules": false,' }` — which,
+//     when NO real `agentRules` key is present anywhere else, makes the
+//     checker report the config as disabled when it is not (the dangerous
+//     direction: `next dev` still mutates AGENTS.md, but the check passed).
+// Both require a property value whose literal text happens to read as a
+// direct `agentRules` key assignment — a construct that requires
+// deliberately writing JSON-shaped example/documentation text referencing
+// this specific, narrow Next.js option inside one's own next.config. Fully
+// closing this requires distinguishing string-literal content from
+// structural key/value text, i.e. real JS tokenization, which this
+// filesystem-only, non-executing checker deliberately does not do (see the
+// module-level indirection note above) — so, despite including a
+// dangerous-direction shape, this is accepted as outside this checker's
+// scope rather than chased with string-literal-aware tokenization, the
+// same call made for the other string/regex-literal-opacity findings
+// documented in this file.
 function findLastAgentRulesKeyIndex(directPropertiesText) {
   AGENT_RULES_KEY_PATTERN.lastIndex = 0;
   let lastIndex = -1;

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -24,31 +24,38 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // (duplicating this by hand in each pattern previously let them drift out
 // of sync — see the fix history in this PR).
 //
-// The bare-identifier alternative's `(?<![\w$])`/`(?![\w$])` require that
-// neither the character immediately before nor immediately after
-// `agentRules` is an identifier character. Without this, a differently
-// named property whose name merely CONTAINS `agentRules` — e.g.
-// `{ notAgentRules: false }`, a config that does not disable the real
-// `agentRules` option at all — would be read as the real key, false-passing
-// a config `next dev` still mutates.
+// The quoted alternative, `(['"])agentRules\1`, CONSUMES both quote
+// characters as part of the match (the backreference `\1` requires the
+// closing quote to be the same character as the captured opening one). An
+// earlier version used zero-width lookaround (`(?<=['"])`/`(?=['"])`)
+// instead, which only verifies a quote is adjacent without consuming it —
+// that let the match end sitting right before the closing quote, so the
+// callers' `\s*:` (which cannot skip over a quote character) then failed
+// to find the colon, breaking the ordinary, documented `"agentRules":
+// false` / `'agentRules': false` cases entirely (independently caught by
+// both Codex and Claude review on this PR — no existing fixture actually
+// exercised a quoted key at the time, despite one being named
+// `disabled-quoted-mjs`). Consuming the quotes fixes this while still
+// correctly rejecting `{ 'not-agentRules': false }`: at the position right
+// before `agentRules` in that string, the preceding character is `-`, not
+// a quote, so `(['"])` doesn't match there.
 //
-// The quoted alternative's `(?<=['"])`/`(?=['"])` require an actual quote
-// character immediately on both sides of `agentRules` — not merely that
-// `["']?` optionally matches one. A prior version used an optional quote
-// on each side, which let `{ 'not-agentRules': false }` match: `["']?` can
-// simply match zero characters and start the pattern mid-string, right at
-// `agentRules`, and `-` (unlike `\w`/`$`) doesn't fail the old bare-key
-// lookbehind either. Requiring an actual quote adjacent on both sides
-// closes this: for `'not-agentRules'`, the character immediately before
-// `agentRules` is `-`, not a quote, so the quoted alternative doesn't
-// match there, and the bare-identifier alternative's lookbehind (`-` is
-// not `[\w$]`, so it doesn't reject) is irrelevant because the substring
-// isn't a standalone bare identifier occurrence either — the whole
-// property key `'not-agentRules'` is quoted, so only the quoted
-// alternative could apply, and it correctly requires the quote to sit
-// right next to `agentRules`, which it doesn't here.
-const AGENT_RULES_KEY_SOURCE = /(?:(?<=['"])agentRules(?=['"])|(?<![\w$])agentRules(?![\w$]))/
-  .source;
+// The bare-identifier alternative requires the character immediately
+// before `agentRules` to be `{`, `,`, or whitespace (or nothing — start of
+// text) — `(?<![^{,\s])` is a negative lookbehind on "any character that
+// is NOT one of those", which also vacuously holds at the start of the
+// string, where there is no preceding character to fail it. This is
+// deliberately narrower than only excluding identifier characters
+// (`(?<![\w$])`, used by an earlier version): a legitimate unquoted object
+// key can only be immediately preceded by one of `{`, `,`, or whitespace,
+// so anything else — punctuation like `-`, another quote, etc. — is never
+// a valid bare-key start. The earlier, looser lookbehind let `agentRules`
+// embedded inside a quoted string right after a `-` (as in
+// `'not-agentRules'`) slip through the bare alternative, since `-` isn't a
+// `\w`/`$` character either. The lookahead `(?![\w$])` still requires
+// nothing immediately after `agentRules` is an identifier character,
+// rejecting `{ agentRulesExtra: false }`.
+const AGENT_RULES_KEY_SOURCE = /(?:(['"])agentRules\1|(?<![^{,\s])agentRules(?![\w$]))/.source;
 
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -29,6 +29,14 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // characters before this pattern runs, so a real `}` never reaches here.
 const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
 
+// Matches an `agentRules` key regardless of its value — used to find every
+// occurrence among an object's direct properties, not just ones that
+// happen to say `false`. JS object literals let the same key appear more
+// than once; whichever occurrence appears LAST wins at runtime (this is
+// legal, unambiguous JS, not a syntax error), so only the last occurrence's
+// value is ever the effective one.
+const AGENT_RULES_KEY_PATTERN = /["']?agentRules["']?\s*:/g;
+
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
 // opt-out, silently passing a config that has not disabled anything. Comments
@@ -137,21 +145,37 @@ function keepOnlyDirectProperties(objectSource) {
   return result;
 }
 
-// `{ agentRules: false, ...shared }` sets agentRules: false, but if `shared`
-// (a spread evaluated after the explicit property, per normal JS object
-// literal semantics) itself has an `agentRules` key, that key wins at
-// runtime — the effective value is whatever `shared.agentRules` is, not
-// `false`. This checker cannot evaluate what an arbitrary spread source
-// contains (see the module-level indirection note above), so unlike the
-// indirection/scope-shadowing bounds documented elsewhere in this file,
-// this is not accepted as an unverifiable case that stays green: a spread
-// appearing anywhere in the direct properties AFTER the matched
-// `agentRules: false` makes the effective value undecidable, so the caller
-// fails closed instead of assuming `false` still holds. A spread BEFORE the
-// explicit property is fine — the explicit `agentRules: false` written
-// after it is what wins, exactly as read.
-function hasSpreadAfter(directPropertiesText, matchEndIndex) {
-  return directPropertiesText.slice(matchEndIndex).includes('...');
+// Finds the start index of the LAST `agentRules` key among an object's
+// direct properties, or -1 if there is none. Two ways a later assignment
+// can override an earlier explicit `agentRules: false` — a duplicate key
+// (`{ agentRules: false, agentRules: true }`, legal JS: the last one wins)
+// and a later spread whose source sets `agentRules` — are unified by this
+// function and the caller: only the LAST key occurrence's value is ever
+// the effective one, so evaluating anything before it is pointless, and a
+// spread after it is exactly as override-capable as another explicit key.
+function findLastAgentRulesKeyIndex(directPropertiesText) {
+  AGENT_RULES_KEY_PATTERN.lastIndex = 0;
+  let lastIndex = -1;
+  let match;
+  while ((match = AGENT_RULES_KEY_PATTERN.exec(directPropertiesText)) !== null) {
+    lastIndex = match.index;
+  }
+  return lastIndex;
+}
+
+// A spread after the winning (last) `agentRules` key can still override it
+// at runtime — `{ agentRules: false, ...shared }` sets agentRules: false,
+// but if `shared` (evaluated after, per normal JS object literal semantics)
+// itself has an `agentRules` key, that key wins, not `false`. This checker
+// cannot evaluate what an arbitrary spread source contains (see the
+// module-level indirection note above), so unlike the indirection/
+// scope-shadowing bounds documented elsewhere in this file, this is not
+// accepted as an unverifiable case that stays green: the caller fails
+// closed instead of assuming `false` still holds. A spread BEFORE the
+// winning key is fine — the explicit `agentRules: false` written after it
+// is what wins, exactly as read.
+function hasSpreadAfter(directPropertiesText, index) {
+  return directPropertiesText.slice(index).includes('...');
 }
 
 async function findConfigFile(directory) {
@@ -190,8 +214,14 @@ if (configFile === null) {
     process.exitCode = 1;
   } else {
     const directPropertiesText = keepOnlyDirectProperties(exportedConfigObjectSource);
-    const agentRulesMatch = AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText);
-    if (!agentRulesMatch) {
+    const lastKeyIndex = findLastAgentRulesKeyIndex(directPropertiesText);
+    const disabledMatch =
+      lastKeyIndex === -1
+        ? null
+        : AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText.slice(lastKeyIndex));
+    const lastKeyIsDisabled = disabledMatch !== null && disabledMatch.index === 0;
+
+    if (!lastKeyIsDisabled) {
       console.error(
         `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
           `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
@@ -199,9 +229,7 @@ if (configFile === null) {
           `an AI coding agent in the environment.`,
       );
       process.exitCode = 1;
-    } else if (
-      hasSpreadAfter(directPropertiesText, agentRulesMatch.index + agentRulesMatch[0].length)
-    ) {
+    } else if (hasSpreadAfter(directPropertiesText, lastKeyIndex + disabledMatch[0].length)) {
       console.error(
         `${path.basename(configFile.path)} sets \`agentRules: false\` but also spreads another object ` +
           `(\`...\`) into the config afterward. A later spread can override \`agentRules\` back to enabled ` +

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -64,30 +64,18 @@ function escapeRegExp(literal) {
 // of scope for this filesystem-only checker and returns null so the caller
 // fails loudly instead of guessing.
 //
-// Known, accepted bound (not fixed): the declaration search below is
-// anchored to the start of a line (no scope/indentation tracking), so a
-// same-named binding declared at column 0 earlier in the file — not
-// plausible for a real next.config, which declares its config once at the
-// top level — could still be picked over the real one. A binding shadowed
-// inside a nested function body, as in Codex's adversarial example on this
-// PR (`function helper() { const nextConfig = {...} }`), is indented and so
-// is excluded by the same anchor. Closing this fully would require
-// scope-aware parsing, which this filesystem-only, non-executing checker
-// deliberately does not do (see the module-level indirection note above).
-//
-// Known, accepted bound (not fixed): a later spread that overrides
-// `agentRules` — `{ agentRules: false, ...shared }` where `shared` sets
-// `agentRules: true` — is not detected; the checker only checks whether the
-// literal `agentRules: false` text appears among the exported object's
-// direct properties, not which property assignment wins once spreads are
-// evaluated in declaration order. Determining the actually-effective value
-// would require evaluating the object literal (including resolving what
-// each spread source contains), which this filesystem-only, non-executing
-// checker deliberately does not do. A `next.config` that spreads a second
-// object into its config after an explicit `agentRules: false` is
-// sufficiently unusual that this is accepted rather than chased further —
-// see the Review Protocol's stopping rules on not spiraling a closure cycle
-// indefinitely against the same bounded-by-design surface.
+// Out of this checker's documented scope (not a defect against it, per the
+// module-level indirection note above — this is the same "does not execute
+// consumer config" boundary, applied to scope resolution rather than value
+// resolution): the declaration search below is anchored to the start of a
+// line (no scope/indentation tracking), so a same-named binding declared at
+// column 0 earlier in the file — not plausible for a real next.config,
+// which declares its config once at the top level — could still be picked
+// over the real one. A binding shadowed inside a nested function body is
+// indented and so is excluded by the same anchor, which is why this does
+// not regress the realistic case Next.js's own docs show. Closing this
+// fully would require scope-aware parsing, which this filesystem-only,
+// non-executing checker deliberately does not do.
 //
 // Note that identifier boundaries throughout this function use a
 // `(?![\w$])` negative lookahead, not `\b`: `$` is a valid trailing
@@ -149,6 +137,23 @@ function keepOnlyDirectProperties(objectSource) {
   return result;
 }
 
+// `{ agentRules: false, ...shared }` sets agentRules: false, but if `shared`
+// (a spread evaluated after the explicit property, per normal JS object
+// literal semantics) itself has an `agentRules` key, that key wins at
+// runtime — the effective value is whatever `shared.agentRules` is, not
+// `false`. This checker cannot evaluate what an arbitrary spread source
+// contains (see the module-level indirection note above), so unlike the
+// indirection/scope-shadowing bounds documented elsewhere in this file,
+// this is not accepted as an unverifiable case that stays green: a spread
+// appearing anywhere in the direct properties AFTER the matched
+// `agentRules: false` makes the effective value undecidable, so the caller
+// fails closed instead of assuming `false` still holds. A spread BEFORE the
+// explicit property is fine — the explicit `agentRules: false` written
+// after it is what wins, exactly as read.
+function hasSpreadAfter(directPropertiesText, matchEndIndex) {
+  return directPropertiesText.slice(matchEndIndex).includes('...');
+}
+
 async function findConfigFile(directory) {
   for (const filename of CANDIDATE_CONFIG_FILENAMES) {
     const candidatePath = path.join(directory, filename);
@@ -183,19 +188,32 @@ if (configFile === null) {
         `Use one of these shapes with \`agentRules: false\` so this checker can verify it.`,
     );
     process.exitCode = 1;
-  } else if (
-    !AGENT_RULES_DISABLED_PATTERN.test(keepOnlyDirectProperties(exportedConfigObjectSource))
-  ) {
-    console.error(
-      `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
-        `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
-        `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
-        `an AI coding agent in the environment.`,
-    );
-    process.exitCode = 1;
   } else {
-    console.log(
-      `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
-    );
+    const directPropertiesText = keepOnlyDirectProperties(exportedConfigObjectSource);
+    const agentRulesMatch = AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText);
+    if (!agentRulesMatch) {
+      console.error(
+        `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+          `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+          `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+          `an AI coding agent in the environment.`,
+      );
+      process.exitCode = 1;
+    } else if (
+      hasSpreadAfter(directPropertiesText, agentRulesMatch.index + agentRulesMatch[0].length)
+    ) {
+      console.error(
+        `${path.basename(configFile.path)} sets \`agentRules: false\` but also spreads another object ` +
+          `(\`...\`) into the config afterward. A later spread can override \`agentRules\` back to enabled ` +
+          `at runtime, and this filesystem-only checker cannot verify what the spread source contains. ` +
+          `Move \`agentRules: false\` after the spread (or remove the spread) so this checker can verify ` +
+          `the effective value.`,
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
+      );
+    }
   }
 }

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -178,6 +178,19 @@ function hasSpreadAfter(directPropertiesText, index) {
   return directPropertiesText.slice(index).includes('...');
 }
 
+// Distinguishes, for the error message only, "agentRules was never set to
+// false" from "agentRules was set to false, but a later duplicate key
+// overrides it" — the generic message is accurate but unhelpfully vague for
+// the latter case (Claude review nit on this PR: a developer who already
+// wrote `agentRules: false` and left a stale duplicate key behind can't
+// tell what's wrong from the generic message alone).
+function hasEarlierDisabledOccurrence(directPropertiesText, lastKeyIndex) {
+  return (
+    lastKeyIndex > 0 &&
+    AGENT_RULES_DISABLED_PATTERN.test(directPropertiesText.slice(0, lastKeyIndex))
+  );
+}
+
 async function findConfigFile(directory) {
   for (const filename of CANDIDATE_CONFIG_FILENAMES) {
     const candidatePath = path.join(directory, filename);
@@ -222,12 +235,21 @@ if (configFile === null) {
     const lastKeyIsDisabled = disabledMatch !== null && disabledMatch.index === 0;
 
     if (!lastKeyIsDisabled) {
-      console.error(
-        `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
-          `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
-          `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
-          `an AI coding agent in the environment.`,
-      );
+      if (hasEarlierDisabledOccurrence(directPropertiesText, lastKeyIndex)) {
+        console.error(
+          `${path.basename(configFile.path)} sets \`agentRules: false\` earlier, but a later duplicate ` +
+            `\`agentRules\` key overrides it — JS keeps only the LAST occurrence of a duplicate object ` +
+            `key, and \`next dev\` reads that final value. Remove the earlier \`agentRules: false\` or the ` +
+            `later override so only one, disabling, \`agentRules\` assignment remains.`,
+        );
+      } else {
+        console.error(
+          `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+            `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+            `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+            `an AI coding agent in the environment.`,
+        );
+      }
       process.exitCode = 1;
     } else if (hasSpreadAfter(directPropertiesText, lastKeyIndex + disabledMatch[0].length)) {
       console.error(

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -67,6 +67,27 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.c
 // rejecting `{ agentRulesExtra: false }`.
 const AGENT_RULES_KEY_SOURCE = /(?:(['"])agentRules\1|(?<![^{,\s])agentRules(?![\w$]))/.source;
 
+// Out of this checker's documented scope (not fixed — Codex review finding
+// on this PR): AGENT_RULES_KEY_SOURCE, and so AGENT_RULES_KEY_PATTERN
+// below, only match a `key: value` colon form. JS object literals also
+// allow a shorthand duplicate — `const agentRules = true; const nextConfig
+// = { agentRules: false, agentRules };` — where the trailing bare
+// `agentRules` (no colon) is shorthand for `agentRules: agentRules`
+// (the outer binding) and, per the same last-duplicate-wins semantics
+// documented on findLastAgentRulesKeyIndex() below, overrides the earlier
+// `false`. Method (`agentRules() {}`) and accessor (`get agentRules()
+// {}`) forms are the same class of gap. None of these are counted as an
+// `agentRules` occurrence here, so a trailing one of these forms is
+// invisible to this checker. Detecting them would require recognizing
+// several additional JS object-member grammars beyond `key: value`, which
+// pushes this filesystem-only, non-executing checker further toward being
+// a real parser; it is also a dangerous-direction gap in principle, but
+// requires deliberately naming an outer binding exactly `agentRules` and
+// shadowing it with a same-named shorthand/method/accessor member in a
+// `next.config` — not a plausible accidental construct — and is a further
+// example of the "regex, not a tokenizer" bound already accepted
+// repeatedly throughout this file.
+
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to
 // `true`) — the lookahead requires whatever follows (after optional

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -16,10 +16,40 @@ import path from 'node:path';
 // config error, not this checker's concern).
 const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
 
-// Deliberately a text match, not a config evaluation: this checker does not
-// execute consumer config (no import/require of consumer code, no bundler),
-// so it cannot follow indirection such as `agentRules: someImportedFlag`.
-// It catches the direct, documented opt-out Next.js's own docs show.
+// Matches a JS object property key that is EXACTLY `agentRules` — either a
+// bare identifier not embedded in a longer one, or a fully quoted string
+// whose entire content is `agentRules` — not merely a substring of a
+// longer key. Shared between AGENT_RULES_DISABLED_PATTERN and
+// AGENT_RULES_KEY_PATTERN below so both apply identical key-boundary rules
+// (duplicating this by hand in each pattern previously let them drift out
+// of sync — see the fix history in this PR).
+//
+// The bare-identifier alternative's `(?<![\w$])`/`(?![\w$])` require that
+// neither the character immediately before nor immediately after
+// `agentRules` is an identifier character. Without this, a differently
+// named property whose name merely CONTAINS `agentRules` — e.g.
+// `{ notAgentRules: false }`, a config that does not disable the real
+// `agentRules` option at all — would be read as the real key, false-passing
+// a config `next dev` still mutates.
+//
+// The quoted alternative's `(?<=['"])`/`(?=['"])` require an actual quote
+// character immediately on both sides of `agentRules` — not merely that
+// `["']?` optionally matches one. A prior version used an optional quote
+// on each side, which let `{ 'not-agentRules': false }` match: `["']?` can
+// simply match zero characters and start the pattern mid-string, right at
+// `agentRules`, and `-` (unlike `\w`/`$`) doesn't fail the old bare-key
+// lookbehind either. Requiring an actual quote adjacent on both sides
+// closes this: for `'not-agentRules'`, the character immediately before
+// `agentRules` is `-`, not a quote, so the quoted alternative doesn't
+// match there, and the bare-identifier alternative's lookbehind (`-` is
+// not `[\w$]`, so it doesn't reject) is irrelevant because the substring
+// isn't a standalone bare identifier occurrence either — the whole
+// property key `'not-agentRules'` is quoted, so only the quoted
+// alternative could apply, and it correctly requires the quote to sit
+// right next to `agentRules`, which it doesn't here.
+const AGENT_RULES_KEY_SOURCE = /(?:(?<=['"])agentRules(?=['"])|(?<![\w$])agentRules(?![\w$]))/
+  .source;
+
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to
 // `true`) — the lookahead requires whatever follows (after optional
@@ -27,26 +57,17 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // arbitrary trailing expression text. `}` is included for defensiveness
 // even though keepOnlyDirectProperties() below always blanks brace
 // characters before this pattern runs, so a real `}` never reaches here.
-//
-// The leading `(?<![\w$])` requires that whatever immediately precedes the
-// match (the opening quote of a quoted key, or the `a` of a bare key) is
-// not itself an identifier character. Without it, a differently named
-// property whose name merely ENDS in `agentRules` — e.g.
-// `{ notAgentRules: false }`, a config that does not disable the real
-// `agentRules` option at all — would be read as the real key, false-passing
-// a config `next dev` still mutates. A quoted key's leading quote character
-// is not a `\w`/`$` character, so this lookbehind does not reject
-// `"agentRules": false`.
-const AGENT_RULES_DISABLED_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+const AGENT_RULES_DISABLED_PATTERN = new RegExp(
+  `${AGENT_RULES_KEY_SOURCE}\\s*:\\s*false(?=\\s*[,;}]|\\s*$)`,
+);
 
 // Matches an `agentRules` key regardless of its value — used to find every
 // occurrence among an object's direct properties, not just ones that
 // happen to say `false`. JS object literals let the same key appear more
 // than once; whichever occurrence appears LAST wins at runtime (this is
 // legal, unambiguous JS, not a syntax error), so only the last occurrence's
-// value is ever the effective one. Same `(?<![\w$])` key-start boundary as
-// AGENT_RULES_DISABLED_PATTERN, and for the same reason.
-const AGENT_RULES_KEY_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:/g;
+// value is ever the effective one.
+const AGENT_RULES_KEY_PATTERN = new RegExp(`${AGENT_RULES_KEY_SOURCE}\\s*:`, 'g');
 
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
@@ -142,8 +163,25 @@ function findExportedConfigObjectSource(source) {
 // nothing to do with `agentRules` — as a possible override, fail-closing an
 // actually-safe config (Claude review finding on this PR). This is
 // brace/bracket counting, not full parsing, so a `{`/`}`/`[`/`]` inside a
-// string literal is a known, accepted edge case, matching the same bound
-// already documented for stripComments().
+// string or regex literal is a known, accepted edge case, matching the
+// same bound already documented for stripComments().
+//
+// Out of this checker's documented scope (not fixed): unlike the
+// fail-closed-only string-literal cases documented elsewhere in this file,
+// a `]` inside a string/regex literal VALUE that sits between the winning
+// `agentRules: false` and a real spread — e.g. `{ agentRules: false, note:
+// ']', ...shared }` — can decrement depth prematurely and blank the real
+// `...shared` out of directPropertiesText, hiding it from hasSpreadAfter()
+// below (Codex review finding on this PR). If `shared` sets `agentRules`,
+// this is a dangerous-direction miss (the checker reports green on a
+// config `next dev` can still mutate), not merely a false alarm. Fully
+// closing this requires distinguishing string/regex-literal contents from
+// structural brackets, i.e. real JS tokenization, which this filesystem-
+// only, non-executing checker deliberately does not do (see the
+// module-level indirection note above) — it requires deliberately
+// constructing a property value whose literal text contains an unbalanced
+// bracket character positioned exactly between the winning key and a
+// spread, which is not a plausible accidental `next.config`.
 function keepOnlyDirectProperties(objectSource) {
   let depth = 0;
   let result = '';

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -13,8 +13,18 @@ import path from 'node:path';
 //
 // Only the three filenames Next.js itself accepts for configuration are
 // checked (an unsupported extension such as .cjs/.cts is itself a Next.js
-// config error, not this checker's concern).
-const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
+// config error, not this checker's concern). The order matters and matches
+// Next.js's own `CONFIG_FILES` precedence (node_modules/next/dist/shared/
+// lib/constants.js in 16.3.2: `['next.config.js', 'next.config.mjs',
+// 'next.config.ts', ...]`) — if more than one candidate coexists (e.g.
+// mid-migration between formats, or a stale file left behind), Next.js
+// loads only the first it finds in that order, and this checker must
+// inspect the same file Next.js actually loads. Checking a different one
+// (an earlier version of this checker tried `.ts` first) risks reporting
+// a config as disabled based on a file `next dev` never reads, while the
+// file it does read still has agentRules enabled (Codex review finding on
+// this PR).
+const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.config.ts'];
 
 // Matches a JS object property key that is EXACTLY `agentRules` — either a
 // bare identifier not embedded in a longer one, or a fully quoted string
@@ -266,6 +276,23 @@ function findLastAgentRulesKeyIndex(directPropertiesText) {
 // closed instead of assuming `false` still holds. A spread BEFORE the
 // winning key is fine — the explicit `agentRules: false` written after it
 // is what wins, exactly as read.
+//
+// Out of this checker's documented scope (not fixed, fail-closed direction
+// only — Claude review finding on this PR): the `.includes('...')` search
+// below is the same "regex, not a tokenizer" bound as the rest of this
+// file — an unrelated FLAT string property value (not wrapped in its own
+// `{`/`[`, so not blanked by keepOnlyDirectProperties()) that happens to
+// contain the literal text `...` — e.g. `{ agentRules: false, note: 'see
+// docs...' }` — is read as a possible spread override, fail-closing an
+// actually-safe config. This can only produce a false alarm (the checker
+// never treats a real spread as absent), not a silent pass, matching the
+// direction already accepted for the analogous bare/quoted-substring cases
+// on findLastAgentRulesKeyIndex() above; requires a property value whose
+// literal text happens to contain `...`, which is not an unusual thing to
+// write (e.g. an ellipsis in prose), so this is a real, if low-severity
+// (fail-closed-only), usability limitation of this filesystem-only,
+// non-executing checker rather than a hidden defect against its stated
+// scope.
 function hasSpreadAfter(directPropertiesText, index) {
   return directPropertiesText.slice(index).includes('...');
 }

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -1,0 +1,201 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// Next.js 16.3+ `next dev` auto-detects an AI coding agent in the
+// environment (CLAUDECODE, CURSOR_TRACE_ID, CODEX_*, GEMINI_CLI, etc. — see
+// @vercel/detect-agent) and, unless `agentRules` is explicitly `false` in
+// next.config, upserts a `<!-- BEGIN:nextjs-agent-rules -->` managed block
+// into AGENTS.md (verified against Next.js 16.3.2's
+// node_modules/next/dist/server/lib/start-server.js and
+// generate-agent-files.js). AGENTS.md is a Foundation-owned generated
+// artifact (see tooling/sync.mjs); Next.js runtime mutating it is drift this
+// profile's consumers must not hit on an ordinary `next dev`.
+//
+// Only the three filenames Next.js itself accepts for configuration are
+// checked (an unsupported extension such as .cjs/.cts is itself a Next.js
+// config error, not this checker's concern).
+const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
+
+// Deliberately a text match, not a config evaluation: this checker does not
+// execute consumer config (no import/require of consumer code, no bundler),
+// so it cannot follow indirection such as `agentRules: someImportedFlag`.
+// It catches the direct, documented opt-out Next.js's own docs show.
+// `false` must be the complete property value, not merely a prefix of a
+// larger expression such as `agentRules: false || true` (which evaluates to
+// `true`) — the lookahead requires whatever follows (after optional
+// whitespace) to be a property/statement terminator or end of input, not
+// arbitrary trailing expression text. `}` is included for defensiveness
+// even though keepOnlyDirectProperties() below always blanks brace
+// characters before this pattern runs, so a real `}` never reaches here.
+const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+
+// A bare text match on the unmodified source would treat a mention inside a
+// comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
+// opt-out, silently passing a config that has not disabled anything. Comments
+// are stripped first so only code the JS/TS parser would actually evaluate
+// can match. This is line/block-comment stripping, not full tokenization, so
+// a `//` or `/*` inside a string literal is a known, accepted edge case for
+// this bounded, filesystem-only checker.
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/.*$/gm, '');
+}
+
+// A valid JS identifier can contain `$` (e.g. `$config`), which is a regex
+// metacharacter. Embedding an un-escaped identifier in `new RegExp(...)`
+// below would let a `$` in the identifier be read as regex syntax instead of
+// a literal character, corrupting the match.
+function escapeRegExp(literal) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Locates, by source span, the object literal that a `next.config` file
+// actually `export default`s or `module.exports`s — following at most one
+// level of the canonical indirection Next.js's own docs show:
+//   const nextConfig: NextConfig = { ... }; export default nextConfig;
+//   const nextConfig = { ... }; module.exports = nextConfig;
+// or a directly inlined `export default { ... }` / `module.exports = { ... }`.
+// Restricting the search to this object (rather than every top-level object
+// literal in the file) matters: without it, an unrelated top-level object —
+// `const metadata = { agentRules: false }; const nextConfig = { agentRules:
+// true }; module.exports = nextConfig;` — would satisfy the checker even
+// though the config Next.js actually loads has agentRules left enabled.
+// Any other export shape (a wrapped call like `withPlugin(nextConfig)`, a
+// config assembled via spread from another module, re-exports, etc.) is out
+// of scope for this filesystem-only checker and returns null so the caller
+// fails loudly instead of guessing.
+//
+// Known, accepted bound (not fixed): the declaration search below is
+// anchored to the start of a line (no scope/indentation tracking), so a
+// same-named binding declared at column 0 earlier in the file — not
+// plausible for a real next.config, which declares its config once at the
+// top level — could still be picked over the real one. A binding shadowed
+// inside a nested function body, as in Codex's adversarial example on this
+// PR (`function helper() { const nextConfig = {...} }`), is indented and so
+// is excluded by the same anchor. Closing this fully would require
+// scope-aware parsing, which this filesystem-only, non-executing checker
+// deliberately does not do (see the module-level indirection note above).
+//
+// Known, accepted bound (not fixed): a later spread that overrides
+// `agentRules` — `{ agentRules: false, ...shared }` where `shared` sets
+// `agentRules: true` — is not detected; the checker only checks whether the
+// literal `agentRules: false` text appears among the exported object's
+// direct properties, not which property assignment wins once spreads are
+// evaluated in declaration order. Determining the actually-effective value
+// would require evaluating the object literal (including resolving what
+// each spread source contains), which this filesystem-only, non-executing
+// checker deliberately does not do. A `next.config` that spreads a second
+// object into its config after an explicit `agentRules: false` is
+// sufficiently unusual that this is accepted rather than chased further —
+// see the Review Protocol's stopping rules on not spiraling a closure cycle
+// indefinitely against the same bounded-by-design surface.
+//
+// Note that identifier boundaries throughout this function use a
+// `(?![\w$])` negative lookahead, not `\b`: `$` is a valid trailing
+// identifier character but is not a `\w` character, so `\b` immediately
+// after a `$`-suffixed identifier (e.g. `config$`) sits between two
+// non-word characters and never asserts a boundary there, silently
+// truncating the match to `config`.
+function findExportedConfigObjectSource(source) {
+  const exportedIdentifierMatch =
+    /(?:export\s+default|module\.exports\s*=)\s*([A-Za-z_$][\w$]*)(?![\w$])/.exec(source);
+  const declarationName = exportedIdentifierMatch?.[1];
+
+  const openBraceMatch = declarationName
+    ? new RegExp(
+        `^(?:export\\s+)?(?:const|let|var)\\s+${escapeRegExp(declarationName)}(?![\\w$])[^={]*=\\s*\\{`,
+        'm',
+      ).exec(source)
+    : /(?:export\s+default|module\.exports\s*=)\s*\{/.exec(source);
+  if (!openBraceMatch) return null;
+
+  const openBraceIndex = openBraceMatch.index + openBraceMatch[0].length - 1;
+  let depth = 0;
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    else if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBraceIndex, index + 1);
+    }
+  }
+  return null;
+}
+
+// A comment-stripped text match against the exported object's own source
+// would still treat an unrelated, coincidentally named `agentRules: false`
+// nested inside some other property of that same object (for example
+// `{ experimental: { agentRules: false } }`) as if it were the top-level
+// `agentRules` property NextConfig actually reads. Brace depth is counted
+// and only text at depth 1 relative to the exported object's own opening
+// brace — its direct properties — is kept; deeper text is blanked out
+// before matching. This is brace counting, not full parsing, so a `{` or
+// `}` inside a string literal is a known, accepted edge case, matching the
+// same bound already documented for stripComments().
+function keepOnlyDirectProperties(objectSource) {
+  let depth = 0;
+  let result = '';
+  for (const character of objectSource) {
+    if (character === '{') {
+      depth += 1;
+      result += ' ';
+      continue;
+    }
+    if (character === '}') {
+      depth -= 1;
+      result += ' ';
+      continue;
+    }
+    result += depth === 1 ? character : ' ';
+  }
+  return result;
+}
+
+async function findConfigFile(directory) {
+  for (const filename of CANDIDATE_CONFIG_FILENAMES) {
+    const candidatePath = path.join(directory, filename);
+    try {
+      return { path: candidatePath, content: await readFile(candidatePath, 'utf8') };
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  return null;
+}
+
+const configFile = await findConfigFile(process.cwd());
+
+if (configFile === null) {
+  console.error(
+    `No next.config.{ts,js,mjs} found. Foundation-generated AGENTS.md is a generated artifact ` +
+      `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
+      `with \`agentRules: false\`.`,
+  );
+  process.exitCode = 1;
+} else {
+  const exportedConfigObjectSource = findExportedConfigObjectSource(
+    stripComments(configFile.content),
+  );
+  if (exportedConfigObjectSource === null) {
+    console.error(
+      `Could not determine the exported config object in ${path.basename(configFile.path)}. ` +
+        `This checker only recognizes the canonical shapes Next.js's own docs show: ` +
+        `\`const nextConfig = { ... }; export default nextConfig;\` (or \`module.exports = nextConfig;\`), ` +
+        `or a directly inlined \`export default { ... }\` / \`module.exports = { ... }\`. ` +
+        `Use one of these shapes with \`agentRules: false\` so this checker can verify it.`,
+    );
+    process.exitCode = 1;
+  } else if (
+    !AGENT_RULES_DISABLED_PATTERN.test(keepOnlyDirectProperties(exportedConfigObjectSource))
+  ) {
+    console.error(
+      `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+        `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+        `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+        `an AI coding agent in the environment.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
+    );
+  }
+}

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -137,6 +137,25 @@ test("a spread before agentRules: false does not block the check — the explici
   assert.equal(result.status, 0);
 });
 
+test("a duplicate agentRules key that overrides false back to true is deterministically red", () => {
+  // Codex and Claude independently found this in the same review round:
+  // the same root cause as the spread-override fix — a later assignment to
+  // the same key overrides an earlier one, per legal JS object literal
+  // semantics — but via a plain duplicate key instead of a spread.
+  // `{ agentRules: false, agentRules: true }` effectively sets true.
+  const result = runChecker(path.join(fixturesRoot, "duplicate-key-overrides-to-enabled"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("a duplicate agentRules key where the later occurrence is still false stays green", () => {
+  // `{ agentRules: true, agentRules: false }`: the later occurrence is what
+  // JS actually keeps, and it is a complete `false` value with nothing
+  // after it, so this is verifiable and must stay green.
+  const result = runChecker(path.join(fixturesRoot, "duplicate-key-still-disabled"));
+  assert.equal(result.status, 0);
+});
+
 test("a consumer with no next.config file at all is deterministically red, not a silent pass", () => {
   const result = runChecker(path.join(fixturesRoot, "missing-config"));
   assert.notEqual(result.status, 0);

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -19,10 +19,22 @@ test("agentRules: false in next.config.ts is green", () => {
   assert.match(result.stdout, /agentRules: false/);
 });
 
-test("a quoted \"agentRules\": false key in next.config.mjs is also green", () => {
+test("a single-quoted 'agentRules': false key in next.config.mjs is also green", () => {
+  // Codex + Claude review finding on this PR (2nd closure round): this
+  // fixture previously had a *bare* `agentRules` key despite its name and
+  // this test's description, so it never actually exercised quoted-key
+  // matching — a regression that broke every quoted key (lookaround
+  // verifies but doesn't consume the quote, so the required `:` right
+  // after can never be found) went undetected until independent review.
   const result = runChecker(path.join(fixturesRoot, "disabled-quoted-mjs"));
   assert.equal(result.status, 0);
   assert.match(result.stdout, /next\.config\.mjs/);
+});
+
+test("a double-quoted \"agentRules\": false key in next.config.js is also green", () => {
+  const result = runChecker(path.join(fixturesRoot, "disabled-double-quoted"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /next\.config\.js/);
 });
 
 test("a next.config.js that never sets agentRules is deterministically red", () => {

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const checkerScript = path.join(root, "profiles", "next-supabase", "quality", "check-agent-rules-disabled.mjs");
+const fixturesRoot = path.join(root, "test", "fixtures", "agent-rules");
+
+function runChecker(cwd) {
+  return spawnSync(process.execPath, [checkerScript], { cwd, encoding: "utf8" });
+}
+
+test("agentRules: false in next.config.ts is green", () => {
+  const result = runChecker(path.join(fixturesRoot, "disabled"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /next\.config\.ts/);
+  assert.match(result.stdout, /agentRules: false/);
+});
+
+test("a quoted \"agentRules\": false key in next.config.mjs is also green", () => {
+  const result = runChecker(path.join(fixturesRoot, "disabled-quoted-mjs"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /next\.config\.mjs/);
+});
+
+test("a next.config.js that never sets agentRules is deterministically red", () => {
+  // This is the Issue #40 canonical failure mode: an ordinary Next.js
+  // consumer whose next.config leaves the Next.js 16.3+ default (agent
+  // rules enabled), so `next dev` upserts a managed block into the
+  // Foundation-generated AGENTS.md the first time it detects an AI coding
+  // agent in the environment.
+  const result = runChecker(path.join(fixturesRoot, "not-disabled"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+  assert.match(result.stderr, /agentRules: false/);
+  assert.match(result.stderr, /next\.config\.js/);
+});
+
+test("agentRules: false mentioned only inside a comment does not count as disabling it", () => {
+  // A bare text match without comment-stripping would false-pass this
+  // fixture, defeating the checker's purpose: the config never actually
+  // sets agentRules, so next dev would still mutate AGENTS.md.
+  const result = runChecker(path.join(fixturesRoot, "commented-out"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("agentRules: false nested inside an unrelated object does not count as the top-level opt-out", () => {
+  // Codex P2 finding on this PR: a bare comment-stripped text match would
+  // still treat a coincidentally named property nested inside some other
+  // object (e.g. `experimental.agentRules`) as if it were the top-level
+  // NextConfig `agentRules` the actual opt-out requires, false-passing a
+  // config whose real top-level agentRules is unset.
+  const result = runChecker(path.join(fixturesRoot, "nested-unrelated"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("agentRules: false in an unrelated top-level object does not shadow the actually exported config", () => {
+  // Codex P2 finding on this PR (closure round): the earlier depth-1 fix
+  // still matched agentRules: false in ANY top-level object, not only the
+  // one `module.exports`/`export default` actually points at. A file that
+  // shadows the exported nextConfig's agentRules: true with an unrelated
+  // metadata object's agentRules: false must stay red.
+  const result = runChecker(path.join(fixturesRoot, "shadowed-by-unrelated-export"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("a directly inlined `export default { agentRules: false }` is green", () => {
+  const result = runChecker(path.join(fixturesRoot, "inline-export"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /next\.config\.mjs/);
+});
+
+test("a `$`-prefixed export identifier (e.g. $config) is not corrupted as regex syntax", () => {
+  // Codex P2 finding on this PR (2nd closure round): embedding the
+  // identifier unescaped in `new RegExp(...)` let a literal `$` in a valid
+  // JS identifier be read as a regex end-anchor, making the checker fail to
+  // find an actually-disabled config.
+  const result = runChecker(path.join(fixturesRoot, "dollar-identifier"));
+  assert.equal(result.status, 0);
+});
+
+test("a same-named binding shadowed inside a nested function body does not shadow the real top-level export", () => {
+  // Codex P2 finding on this PR (2nd closure round): anchoring the
+  // declaration search to the start of a line excludes an indented,
+  // function-scoped shadow, so the top-level (unindented) declaration that
+  // module.exports actually points at is the one selected.
+  const result = runChecker(path.join(fixturesRoot, "shadowed-by-nested-scope"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("a `$`-suffixed export identifier (e.g. config$) is matched in full, not truncated at the $", () => {
+  // Codex P2 finding on this PR (4th closure round): `\b` right after an
+  // identifier ending in `$` never asserts a boundary there (both sides are
+  // non-word characters), so the capture silently backtracked to the
+  // identifier without its trailing `$` — resolving to an unrelated
+  // same-prefixed binding instead of the one actually exported.
+  const result = runChecker(path.join(fixturesRoot, "dollar-suffixed-shadow"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("agentRules: false as a prefix of a larger expression (false || true) does not count as disabling it", () => {
+  // Codex P2 finding on this PR (5th closure round): `false` must be the
+  // complete property value. `agentRules: false || true` evaluates to
+  // `true` at runtime, so next dev still mutates AGENTS.md even though the
+  // literal text "false" appears right after "agentRules:".
+  const result = runChecker(path.join(fixturesRoot, "incomplete-false-expression"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("a consumer with no next.config file at all is deterministically red, not a silent pass", () => {
+  const result = runChecker(path.join(fixturesRoot, "missing-config"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /No next\.config/);
+  assert.match(result.stderr, /agentRules: false/);
+});
+
+test("the checker requires no next dev, network, or browser to run", () => {
+  // A filesystem-only guardrail must not require actually starting a Next.js
+  // dev server to determine whether AGENTS.md is at risk of mutation.
+  const result = runChecker(path.join(fixturesRoot, "disabled"));
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+});

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -115,6 +115,28 @@ test("agentRules: false as a prefix of a larger expression (false || true) does 
   assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
 });
 
+test("agentRules: false followed by a spread that could override it is deterministically red, not assumed still false", () => {
+  // Re-adjudicated under the current (post-#45) Resolution Contract: this is
+  // an accepted defect, not an out-of-scope indirection case, because the
+  // checker's job is specifically to verify the effective agentRules value,
+  // and `{ agentRules: false, ...shared }` sets agentRules: false only if
+  // `shared` (evaluated after, per normal JS object literal semantics)
+  // doesn't itself set agentRules. This checker cannot evaluate what a
+  // spread source contains, so it must fail closed rather than assume the
+  // explicit `false` still wins.
+  const result = runChecker(path.join(fixturesRoot, "spread-after-agent-rules"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /spreads another object/);
+});
+
+test("a spread before agentRules: false does not block the check — the explicit property after it wins", () => {
+  // `{ ...shared, agentRules: false }`: the explicit property written after
+  // the spread is what JS actually evaluates last, so this is verifiable
+  // and must stay green.
+  const result = runChecker(path.join(fixturesRoot, "spread-before-agent-rules"));
+  assert.equal(result.status, 0);
+});
+
 test("a consumer with no next.config file at all is deterministically red, not a silent pass", () => {
   const result = runChecker(path.join(fixturesRoot, "missing-config"));
   assert.notEqual(result.status, 0);

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -159,6 +159,28 @@ test("a duplicate agentRules key where the later occurrence is still false stays
   assert.equal(result.status, 0);
 });
 
+test("a differently named property whose name merely ends in agentRules does not count as the real key", () => {
+  // Codex finding on this PR (fresh discovery round, target 10194e5):
+  // without a key-start boundary, `{ notAgentRules: false }` was read as if
+  // it were the real `agentRules` key, false-passing a config where the
+  // real agentRules option is unset — the dangerous direction (next dev
+  // still mutates AGENTS.md, but the checker said green).
+  const result = runChecker(path.join(fixturesRoot, "name-suffix-collision"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
+test("an unrelated array property's spread does not block the check", () => {
+  // Claude finding on this PR (fresh discovery round, target 10194e5):
+  // keepOnlyDirectProperties() only tracked `{`/`}` depth, so an array
+  // literal property value like `pageExtensions: [...defaultExtensions,
+  // 'mdx']` (an ordinary Next.js config idiom) stayed visible at depth 1,
+  // and hasSpreadAfter() then false-positively flagged its unrelated `...`
+  // as a possible agentRules override on an actually-safe config.
+  const result = runChecker(path.join(fixturesRoot, "array-spread-unrelated-property"));
+  assert.equal(result.status, 0);
+});
+
 test("a consumer with no next.config file at all is deterministically red, not a silent pass", () => {
   const result = runChecker(path.join(fixturesRoot, "missing-config"));
   assert.notEqual(result.status, 0);

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -170,6 +170,19 @@ test("a differently named property whose name merely ends in agentRules does not
   assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
 });
 
+test("a quoted property name that merely ends in agentRules (e.g. 'not-agentRules') does not count as the real key", () => {
+  // Codex finding on this PR (closure round): an optional quote on each
+  // side (`["']?agentRules["']?`) let `{ 'not-agentRules': false }` match
+  // by simply not consuming the leading quote and starting mid-string —
+  // the `-` before `agentRules` isn't a `\w`/`$` character, so the old
+  // bare-key lookbehind alone didn't reject it either. Requiring an actual
+  // quote immediately on both sides of `agentRules` (not an optional one)
+  // closes this.
+  const result = runChecker(path.join(fixturesRoot, "quoted-name-suffix-collision"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+});
+
 test("an unrelated array property's spread does not block the check", () => {
   // Claude finding on this PR (fresh discovery round, target 10194e5):
   // keepOnlyDirectProperties() only tracked `{`/`}` depth, so an array

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -145,7 +145,10 @@ test("a duplicate agentRules key that overrides false back to true is determinis
   // `{ agentRules: false, agentRules: true }` effectively sets true.
   const result = runChecker(path.join(fixturesRoot, "duplicate-key-overrides-to-enabled"));
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+  // Claude review nit on this PR: the error message should distinguish
+  // "never set" from "set false, then overridden" so a developer who wrote
+  // agentRules: false but left a stale duplicate key can tell what's wrong.
+  assert.match(result.stderr, /sets `agentRules: false` earlier, but a later duplicate/);
 });
 
 test("a duplicate agentRules key where the later occurrence is still false stays green", () => {

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -206,6 +206,27 @@ test("an unrelated array property's spread does not block the check", () => {
   assert.equal(result.status, 0);
 });
 
+test("when multiple config files coexist, the checker inspects the one Next.js actually loads (.js), not .ts", () => {
+  // Codex finding on this PR (fresh discovery round, target 65f11c6):
+  // verified against Next.js 16.3.2's actual CONFIG_FILES precedence
+  // (node_modules/next/dist/shared/lib/constants.js: .js, then .mjs, then
+  // .ts) — an earlier version of CANDIDATE_CONFIG_FILENAMES checked .ts
+  // first. A stale next.config.ts left over from a migration, sitting next
+  // to the next.config.js Next.js actually loads, must not make this
+  // checker report a config as disabled when the file `next dev` reads
+  // still has agentRules enabled.
+  const result = runChecker(path.join(fixturesRoot, "multiple-configs-js-wins"));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+  assert.match(result.stderr, /next\.config\.js/);
+});
+
+test("when multiple config files coexist and the one Next.js loads (.js) disables agentRules, that's green regardless of other files", () => {
+  const result = runChecker(path.join(fixturesRoot, "multiple-configs-js-disabled"));
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /next\.config\.js/);
+});
+
 test("a consumer with no next.config file at all is deterministically red, not a silent pass", () => {
   const result = runChecker(path.join(fixturesRoot, "missing-config"));
   assert.notEqual(result.status, 0);

--- a/test/consumer-verify.test.mjs
+++ b/test/consumer-verify.test.mjs
@@ -75,12 +75,19 @@ test("verify:profile runs the filesystem-only migration collision check before a
   // the DB / Docker / Supabase local stack is ever touched. supabase:types:check
   // stands in for the DB/Docker-touching step here (per profile README, real
   // consumers' supabase:types shells out to `supabase gen types`), so
-  // supabase:migrations:check must be sequenced strictly before it, not just
-  // present somewhere in verify:profile.
+  // supabase:migrations:check must be sequenced strictly before it. Other
+  // filesystem-only guardrails (e.g. Issue #40's agent-rules:check) may sit
+  // anywhere else in the chain without violating this DB/Docker-ordering
+  // invariant, so this asserts relative order rather than an exact string.
   const packageJson = JSON.parse(await readFile(path.join(fixture, "package.json"), "utf8"));
-  assert.equal(
-    packageJson.scripts["verify:profile"],
-    "npm run supabase:migrations:check && npm run supabase:types:check",
+  const steps = packageJson.scripts["verify:profile"].split(" && ").map((step) => step.trim());
+  const migrationsCheckIndex = steps.indexOf("npm run supabase:migrations:check");
+  const typesCheckIndex = steps.indexOf("npm run supabase:types:check");
+  assert.notEqual(migrationsCheckIndex, -1, "verify:profile must run supabase:migrations:check");
+  assert.notEqual(typesCheckIndex, -1, "verify:profile must run supabase:types:check");
+  assert.ok(
+    migrationsCheckIndex < typesCheckIndex,
+    `supabase:migrations:check (index ${migrationsCheckIndex}) must precede supabase:types:check (index ${typesCheckIndex})`,
   );
   assert.equal(
     packageJson.scripts["supabase:migrations:check"],

--- a/test/fixtures/agent-rules/array-spread-unrelated-property/next.config.js
+++ b/test/fixtures/agent-rules/array-spread-unrelated-property/next.config.js
@@ -1,0 +1,8 @@
+const defaultExtensions = ['tsx', 'ts', 'jsx', 'js'];
+
+const nextConfig = {
+  agentRules: false,
+  pageExtensions: [...defaultExtensions, 'mdx'],
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/commented-out/next.config.js
+++ b/test/fixtures/agent-rules/commented-out/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // agentRules: false
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/disabled-double-quoted/next.config.js
+++ b/test/fixtures/agent-rules/disabled-double-quoted/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  'agentRules': false,
+  "agentRules": false,
 };
 
-export default nextConfig;
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/disabled-quoted-mjs/next.config.mjs
+++ b/test/fixtures/agent-rules/disabled-quoted-mjs/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  agentRules: false,
+};
+
+export default nextConfig;

--- a/test/fixtures/agent-rules/disabled/next.config.ts
+++ b/test/fixtures/agent-rules/disabled/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  agentRules: false,
+};
+
+export default nextConfig;

--- a/test/fixtures/agent-rules/dollar-identifier/next.config.js
+++ b/test/fixtures/agent-rules/dollar-identifier/next.config.js
@@ -1,0 +1,5 @@
+const $config = {
+  agentRules: false,
+};
+
+module.exports = $config;

--- a/test/fixtures/agent-rules/dollar-suffixed-shadow/next.config.js
+++ b/test/fixtures/agent-rules/dollar-suffixed-shadow/next.config.js
@@ -1,0 +1,3 @@
+const config = { agentRules: false };
+const config$ = { agentRules: true };
+module.exports = config$;

--- a/test/fixtures/agent-rules/duplicate-key-overrides-to-enabled/next.config.js
+++ b/test/fixtures/agent-rules/duplicate-key-overrides-to-enabled/next.config.js
@@ -1,0 +1,6 @@
+const nextConfig = {
+  agentRules: false,
+  agentRules: true,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/duplicate-key-still-disabled/next.config.js
+++ b/test/fixtures/agent-rules/duplicate-key-still-disabled/next.config.js
@@ -1,0 +1,6 @@
+const nextConfig = {
+  agentRules: true,
+  agentRules: false,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/incomplete-false-expression/next.config.js
+++ b/test/fixtures/agent-rules/incomplete-false-expression/next.config.js
@@ -1,0 +1,5 @@
+const nextConfig = {
+  agentRules: false || true,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/inline-export/next.config.mjs
+++ b/test/fixtures/agent-rules/inline-export/next.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  agentRules: false,
+};

--- a/test/fixtures/agent-rules/missing-config/README.md
+++ b/test/fixtures/agent-rules/missing-config/README.md
@@ -1,0 +1,5 @@
+# Fixture: missing next.config
+
+This fixture directory intentionally ships no `next.config.{ts,js,mjs}`, so
+`check-agent-rules-disabled.mjs` must fail with a missing-config diagnostic
+rather than silently passing.

--- a/test/fixtures/agent-rules/multiple-configs-js-disabled/next.config.js
+++ b/test/fixtures/agent-rules/multiple-configs-js-disabled/next.config.js
@@ -1,0 +1,6 @@
+// The file Next.js actually loads — disables agentRules.
+const nextConfig = {
+  agentRules: false,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/multiple-configs-js-disabled/next.config.ts
+++ b/test/fixtures/agent-rules/multiple-configs-js-disabled/next.config.ts
@@ -1,0 +1,7 @@
+// A stale/leftover config Next.js never loads while next.config.js exists
+// — leaves agentRules enabled, but this is not the file `next dev` reads.
+const nextConfig = {
+  agentRules: true,
+};
+
+export default nextConfig;

--- a/test/fixtures/agent-rules/multiple-configs-js-wins/next.config.js
+++ b/test/fixtures/agent-rules/multiple-configs-js-wins/next.config.js
@@ -1,0 +1,7 @@
+// The file Next.js actually loads (CONFIG_FILES checks .js first) — does
+// not disable agentRules.
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/multiple-configs-js-wins/next.config.ts
+++ b/test/fixtures/agent-rules/multiple-configs-js-wins/next.config.ts
@@ -1,0 +1,7 @@
+// A stale/leftover config Next.js never loads while next.config.js exists
+// — disables agentRules, but this is not the file `next dev` reads.
+const nextConfig = {
+  agentRules: false,
+};
+
+export default nextConfig;

--- a/test/fixtures/agent-rules/name-suffix-collision/next.config.js
+++ b/test/fixtures/agent-rules/name-suffix-collision/next.config.js
@@ -1,0 +1,5 @@
+const nextConfig = {
+  notAgentRules: false,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/nested-unrelated/next.config.js
+++ b/test/fixtures/agent-rules/nested-unrelated/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    // Coincidentally named nested property unrelated to the top-level
+    // NextConfig `agentRules` option — must not satisfy the checker.
+    agentRules: false,
+  },
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/not-disabled/next.config.js
+++ b/test/fixtures/agent-rules/not-disabled/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/quoted-name-suffix-collision/next.config.js
+++ b/test/fixtures/agent-rules/quoted-name-suffix-collision/next.config.js
@@ -1,0 +1,5 @@
+const nextConfig = {
+  'not-agentRules': false,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/shadowed-by-nested-scope/next.config.js
+++ b/test/fixtures/agent-rules/shadowed-by-nested-scope/next.config.js
@@ -1,0 +1,8 @@
+function helper() {
+  // Indented, function-scoped shadow — never the exported binding.
+  const nextConfig = { agentRules: false };
+  return nextConfig;
+}
+
+const nextConfig = { agentRules: true };
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/shadowed-by-unrelated-export/next.config.js
+++ b/test/fixtures/agent-rules/shadowed-by-unrelated-export/next.config.js
@@ -1,0 +1,6 @@
+// Codex P2 finding on this PR: an unrelated top-level object that happens to
+// set agentRules: false must not satisfy the checker when the object that is
+// actually exported leaves agentRules enabled.
+const metadata = { agentRules: false };
+const nextConfig = { agentRules: true };
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/spread-after-agent-rules/next.config.js
+++ b/test/fixtures/agent-rules/spread-after-agent-rules/next.config.js
@@ -1,0 +1,8 @@
+const shared = { agentRules: true };
+
+const nextConfig = {
+  agentRules: false,
+  ...shared,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/agent-rules/spread-before-agent-rules/next.config.js
+++ b/test/fixtures/agent-rules/spread-before-agent-rules/next.config.js
@@ -1,0 +1,8 @@
+const shared = { agentRules: true };
+
+const nextConfig = {
+  ...shared,
+  agentRules: false,
+};
+
+module.exports = nextConfig;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -169,10 +169,13 @@ comment内の記述（`// agentRules: false`）、ネストしたobject内の同
 （`agentRules: false || true`）。
 next dev、network、ブラウザのいずれも必要としません。consumer configを
 実行・評価しないtext matchのため、`agentRules`を間接的な変数経由で設定する
-config（例: `agentRules: SOME_FLAG`）や、`{ agentRules: false, ...shared }`
-のようなspreadによる後続上書きは検出できません（直接記述された opt-out
-だけを対象にした bounded guardrail です。既知の制約はcheckerのcode comment
-を参照してください）。
+config（例: `agentRules: SOME_FLAG`）は検出できません（直接記述された
+opt-out だけを対象にした bounded guardrail です。既知の制約はcheckerの
+code commentを参照してください）。`{ agentRules: false, ...shared }`の
+ようにexplicit propertyの後にspreadがある場合は、実行時にspread側が
+上書きし得るため、effective valueを検証不能としてnon-zeroで失敗します
+（`{ ...shared, agentRules: false }`のようにspreadが先であれば、後続の
+explicit propertyが確実に勝つため引き続き検証できます）。
 
 このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
 policyへコピーしません。`next.config`の設定有無だけを検証します。

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -158,8 +158,10 @@ dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRul
 node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
 ```
 
-このcheckerは`next.config.ts` / `next.config.js` / `next.config.mjs`を
-filesystemだけで検査し、comment除去後・brace-depth 1（exportされる config
+このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`
+（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する場合は
+Next.jsが実際に読むfileを検証します）をfilesystemだけで検査し、
+comment除去後・brace-depth 1（exportされる config
 object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
 場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
 property valueである場合だけ有効とします（`agentRules: false || true`は

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -182,6 +182,24 @@ explicit propertyが確実に勝つため引き続き検証できます）。
 このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
 policyへコピーしません。`next.config`の設定有無だけを検証します。
 
+### 二層contract（proactive + reactive）
+
+`agent-rules:check`は、supportされた直接記述の`next.config`形式をfilesystemだけで
+deterministicに検証するbounded text matcherです。任意のJavaScript/TypeScript
+config semanticsを評価する約束はしません。上記の既知の制約（間接的な変数経由の
+設定、string literal内の紛らわしいtext、spread、shorthand/method/accessor形式の
+duplicate keyなど）は、parser/tokenizer/generalized config evaluatorへ発展させる
+ことでは解消しません。
+
+その代わり、`agent-rules:check`が見逃す exotic な`next.config`形式であっても、
+`next dev`が実際に`AGENTS.md`をmutationすれば、既存の`foundation:check`
+（`tooling/check.mjs`）がFoundationの合成結果と実file を exact比較し
+`Generated adapter drift detected`としてdeterministicに検出し、`tooling/sync.mjs`
+によるremediationを提供します。generated adapterのsilent mutationを防ぐ、または
+安全なremediationをdeterministically提供するという要件は、`agent-rules:check`
+単体ではなく、この proactive blocking layer（`agent-rules:check`）と reactive exact
+layer（`foundation:check`）を合わせたsystem levelで満たします。
+
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -99,6 +99,13 @@ stackを起動する前にfilesystemだけでdeterministicに検知します。c
 blocking checkへ追加します。詳細は「Migration version prefix collision detection」
 を参照してください。
 
+`next.config`がNext.js 16.3+の生成AGENTS.md agent rulesを無効化しているかも、DB /
+Docker / Supabase local stackを起動する前にfilesystemだけでdeterministicに検知
+します。Next.js 16.3以降を使うconsumerは`.ai-dev-foundation/quality/check-agent-rules-disabled.mjs`を
+`agent-rules:check`として実行し、blocking checkへ追加します（16.3未満のconsumerは
+`agentRules` optionも自動生成挙動も持たないため、このcheckを追加しません）。詳細は
+「Next.js agent-rules (generated AGENTS.md) drift prevention」を参照してください。
+
 unit/component testとDB/RLS testはtest runnerを固定しません。consumerで該当testが
 存在する場合は、そのcommandをblocking CIへ追加します。
 
@@ -127,6 +134,49 @@ collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local sta
 node .ai-dev-foundation/quality/check-migration-version-collision.mjs
 ```
 
+## Next.js agent-rules (generated AGENTS.md) drift prevention
+
+`AGENTS.md`はFoundation canonical inputsから生成されるgenerated artifactです
+（`tooling/sync.mjs`）。consumer/runtimeが実行時に書き換える対象ではありません。
+
+Next.js 16.3以降の`next dev`は、実行環境内にAI coding agent（`CLAUDECODE`、
+`CURSOR_TRACE_ID`、`CODEX_*`、`GEMINI_CLI`等の環境変数で検出）を検出すると、
+`next.config`で`agentRules`が明示的に`false`でない限り、生成済みの`AGENTS.md`へ
+`<!-- BEGIN:nextjs-agent-rules -->`で始まるmanaged blockをupsertします
+（Next.js 16.3.2の`node_modules/next/dist/server/lib/start-server.js`および
+`generate-agent-files.js`で確認済み）。これはFoundation-generated `AGENTS.md`への
+silent mutationであり、通常の`next dev`実行だけでconsumerのworking treeが
+dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRules` optionも
+持たないため、この節および次のcheckerの対象外です。
+
+`next.config`自体はconsumer-owned application configであり、Foundationは
+代わりにこのfileを書き込みません。consumerが`next.config`で明示的に
+`agentRules: false`を設定し、そのことを次のcheckerでdeterministicに
+担保します。
+
+```text
+node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+```
+
+このcheckerは`next.config.ts` / `next.config.js` / `next.config.mjs`を
+filesystemだけで検査し、comment除去後・brace-depth 1（exportされる config
+object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
+場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
+property valueである場合だけ有効とします（`agentRules: false || true`は
+実際にはtrueとして評価されるため無効）。次はfalseとして扱いません:
+comment内の記述（`// agentRules: false`）、ネストしたobject内の同名property
+（`{ experimental: { agentRules: false } }`）、および完全な値でないもの
+（`agentRules: false || true`）。
+next dev、network、ブラウザのいずれも必要としません。consumer configを
+実行・評価しないtext matchのため、`agentRules`を間接的な変数経由で設定する
+config（例: `agentRules: SOME_FLAG`）や、`{ agentRules: false, ...shared }`
+のようなspreadによる後続上書きは検出できません（直接記述された opt-out
+だけを対象にした bounded guardrail です。既知の制約はcheckerのcode comment
+を参照してください）。
+
+このcheckerはNext.jsのupstream agent-rules block本文をFoundation canonical
+policyへコピーしません。`next.config`の設定有無だけを検証します。
+
 ## `verify` への集約
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
@@ -135,12 +185,14 @@ profile固有の追加は`verify:profile`に置きます。これはextension po
 （DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
 `supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
 driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
-`verify:profile`からそのtest commandを呼び出します。
+`verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
+同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
+呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
+    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -153,6 +153,19 @@ function keepOnlyDirectProperties(objectSource) {
 // function and the caller: only the LAST key occurrence's value is ever
 // the effective one, so evaluating anything before it is pointless, and a
 // spread after it is exactly as override-capable as another explicit key.
+//
+// Out of this checker's documented scope (not a defect against it — the
+// same "regex, not a tokenizer" bound already documented on stripComments()
+// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}` inside string
+// literals): a string VALUE that happens to contain the literal text
+// `agentRules:` — e.g. `{ agentRules: false, note: 'agentRules: true' }` —
+// is indistinguishable, to this pattern, from a real duplicate key, and
+// would be treated as the last occurrence. This can only make the checker
+// fail closed on an actually-fine config (a false alarm, not a silent
+// pass), and requires a property value that itself contains the exact
+// `agentRules:` key text — a construct this contrived is accepted as
+// outside this filesystem-only checker's scope rather than chased with
+// string-literal-aware tokenization.
 function findLastAgentRulesKeyIndex(directPropertiesText) {
   AGENT_RULES_KEY_PATTERN.lastIndex = 0;
   let lastIndex = -1;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -128,7 +128,7 @@ function escapeRegExp(literal) {
 
 // Locates, by source span, the object literal that a `next.config` file
 // actually `export default`s or `module.exports`s — following at most one
-// level of the canonical indirection Next.js's own docs show:
+// level of the canonical module-level indirection Next.js's own docs show:
 //   const nextConfig: NextConfig = { ... }; export default nextConfig;
 //   const nextConfig = { ... }; module.exports = nextConfig;
 // or a directly inlined `export default { ... }` / `module.exports = { ... }`.

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -27,15 +27,26 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // arbitrary trailing expression text. `}` is included for defensiveness
 // even though keepOnlyDirectProperties() below always blanks brace
 // characters before this pattern runs, so a real `}` never reaches here.
-const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+//
+// The leading `(?<![\w$])` requires that whatever immediately precedes the
+// match (the opening quote of a quoted key, or the `a` of a bare key) is
+// not itself an identifier character. Without it, a differently named
+// property whose name merely ENDS in `agentRules` — e.g.
+// `{ notAgentRules: false }`, a config that does not disable the real
+// `agentRules` option at all — would be read as the real key, false-passing
+// a config `next dev` still mutates. A quoted key's leading quote character
+// is not a `\w`/`$` character, so this lookbehind does not reject
+// `"agentRules": false`.
+const AGENT_RULES_DISABLED_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
 
 // Matches an `agentRules` key regardless of its value — used to find every
 // occurrence among an object's direct properties, not just ones that
 // happen to say `false`. JS object literals let the same key appear more
 // than once; whichever occurrence appears LAST wins at runtime (this is
 // legal, unambiguous JS, not a syntax error), so only the last occurrence's
-// value is ever the effective one.
-const AGENT_RULES_KEY_PATTERN = /["']?agentRules["']?\s*:/g;
+// value is ever the effective one. Same `(?<![\w$])` key-start boundary as
+// AGENT_RULES_DISABLED_PATTERN, and for the same reason.
+const AGENT_RULES_KEY_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:/g;
 
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
@@ -120,22 +131,29 @@ function findExportedConfigObjectSource(source) {
 // would still treat an unrelated, coincidentally named `agentRules: false`
 // nested inside some other property of that same object (for example
 // `{ experimental: { agentRules: false } }`) as if it were the top-level
-// `agentRules` property NextConfig actually reads. Brace depth is counted
-// and only text at depth 1 relative to the exported object's own opening
-// brace — its direct properties — is kept; deeper text is blanked out
-// before matching. This is brace counting, not full parsing, so a `{` or
-// `}` inside a string literal is a known, accepted edge case, matching the
-// same bound already documented for stripComments().
+// `agentRules` property NextConfig actually reads. Brace/bracket depth is
+// counted and only text at depth 1 relative to the exported object's own
+// opening brace — its direct properties — is kept; deeper text is blanked
+// out before matching. `[`/`]` are tracked the same way as `{`/`}` so an
+// array-literal property VALUE (e.g. `pageExtensions: [...defaultExtensions,
+// 'mdx']`, an ordinary Next.js config idiom) is blanked out too: without
+// this, its contents stayed visible at depth 1, and hasSpreadAfter() below
+// would false-positively read the array's own `...` spread — which has
+// nothing to do with `agentRules` — as a possible override, fail-closing an
+// actually-safe config (Claude review finding on this PR). This is
+// brace/bracket counting, not full parsing, so a `{`/`}`/`[`/`]` inside a
+// string literal is a known, accepted edge case, matching the same bound
+// already documented for stripComments().
 function keepOnlyDirectProperties(objectSource) {
   let depth = 0;
   let result = '';
   for (const character of objectSource) {
-    if (character === '{') {
+    if (character === '{' || character === '[') {
       depth += 1;
       result += ' ';
       continue;
     }
-    if (character === '}') {
+    if (character === '}' || character === ']') {
       depth -= 1;
       result += ' ';
       continue;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -326,7 +326,7 @@ const configFile = await findConfigFile(process.cwd());
 
 if (configFile === null) {
   console.error(
-    `No next.config.{ts,js,mjs} found. Foundation-generated AGENTS.md is a generated artifact ` +
+    `No next.config.{js,mjs,ts} found. Foundation-generated AGENTS.md is a generated artifact ` +
       `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
       `with \`agentRules: false\`.`,
   );

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -219,16 +219,32 @@ function keepOnlyDirectProperties(objectSource) {
 //
 // Out of this checker's documented scope (not a defect against it — the
 // same "regex, not a tokenizer" bound already documented on stripComments()
-// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}` inside string
-// literals): a string VALUE that happens to contain the literal text
-// `agentRules:` — e.g. `{ agentRules: false, note: 'agentRules: true' }` —
-// is indistinguishable, to this pattern, from a real duplicate key, and
-// would be treated as the last occurrence. This can only make the checker
-// fail closed on an actually-fine config (a false alarm, not a silent
-// pass), and requires a property value that itself contains the exact
-// `agentRules:` key text — a construct this contrived is accepted as
-// outside this filesystem-only checker's scope rather than chased with
-// string-literal-aware tokenization.
+// and keepOnlyDirectProperties() for `//`/`/*`/`{`/`}`/`[`/`]` inside
+// string literals): a string VALUE whose content happens to contain text
+// that reads as an `agentRules` key is indistinguishable, to this pattern,
+// from a real one, and would be treated as an occurrence — potentially the
+// last one. Two shapes of this have been observed on this PR:
+//   - a bare substring — `{ agentRules: false, note: 'agentRules: true' }`
+//     — which, since a real `agentRules: false` is also present here,
+//     only fails the check closed on an actually-fine config (a false
+//     alarm, not a silent pass);
+//   - a quoted substring that itself parses as a complete disabling
+//     assignment — `{ note: 'Example JSON: "agentRules": false,' }` — which,
+//     when NO real `agentRules` key is present anywhere else, makes the
+//     checker report the config as disabled when it is not (the dangerous
+//     direction: `next dev` still mutates AGENTS.md, but the check passed).
+// Both require a property value whose literal text happens to read as a
+// direct `agentRules` key assignment — a construct that requires
+// deliberately writing JSON-shaped example/documentation text referencing
+// this specific, narrow Next.js option inside one's own next.config. Fully
+// closing this requires distinguishing string-literal content from
+// structural key/value text, i.e. real JS tokenization, which this
+// filesystem-only, non-executing checker deliberately does not do (see the
+// module-level indirection note above) — so, despite including a
+// dangerous-direction shape, this is accepted as outside this checker's
+// scope rather than chased with string-literal-aware tokenization, the
+// same call made for the other string/regex-literal-opacity findings
+// documented in this file.
 function findLastAgentRulesKeyIndex(directPropertiesText) {
   AGENT_RULES_KEY_PATTERN.lastIndex = 0;
   let lastIndex = -1;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -24,31 +24,38 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // (duplicating this by hand in each pattern previously let them drift out
 // of sync — see the fix history in this PR).
 //
-// The bare-identifier alternative's `(?<![\w$])`/`(?![\w$])` require that
-// neither the character immediately before nor immediately after
-// `agentRules` is an identifier character. Without this, a differently
-// named property whose name merely CONTAINS `agentRules` — e.g.
-// `{ notAgentRules: false }`, a config that does not disable the real
-// `agentRules` option at all — would be read as the real key, false-passing
-// a config `next dev` still mutates.
+// The quoted alternative, `(['"])agentRules\1`, CONSUMES both quote
+// characters as part of the match (the backreference `\1` requires the
+// closing quote to be the same character as the captured opening one). An
+// earlier version used zero-width lookaround (`(?<=['"])`/`(?=['"])`)
+// instead, which only verifies a quote is adjacent without consuming it —
+// that let the match end sitting right before the closing quote, so the
+// callers' `\s*:` (which cannot skip over a quote character) then failed
+// to find the colon, breaking the ordinary, documented `"agentRules":
+// false` / `'agentRules': false` cases entirely (independently caught by
+// both Codex and Claude review on this PR — no existing fixture actually
+// exercised a quoted key at the time, despite one being named
+// `disabled-quoted-mjs`). Consuming the quotes fixes this while still
+// correctly rejecting `{ 'not-agentRules': false }`: at the position right
+// before `agentRules` in that string, the preceding character is `-`, not
+// a quote, so `(['"])` doesn't match there.
 //
-// The quoted alternative's `(?<=['"])`/`(?=['"])` require an actual quote
-// character immediately on both sides of `agentRules` — not merely that
-// `["']?` optionally matches one. A prior version used an optional quote
-// on each side, which let `{ 'not-agentRules': false }` match: `["']?` can
-// simply match zero characters and start the pattern mid-string, right at
-// `agentRules`, and `-` (unlike `\w`/`$`) doesn't fail the old bare-key
-// lookbehind either. Requiring an actual quote adjacent on both sides
-// closes this: for `'not-agentRules'`, the character immediately before
-// `agentRules` is `-`, not a quote, so the quoted alternative doesn't
-// match there, and the bare-identifier alternative's lookbehind (`-` is
-// not `[\w$]`, so it doesn't reject) is irrelevant because the substring
-// isn't a standalone bare identifier occurrence either — the whole
-// property key `'not-agentRules'` is quoted, so only the quoted
-// alternative could apply, and it correctly requires the quote to sit
-// right next to `agentRules`, which it doesn't here.
-const AGENT_RULES_KEY_SOURCE = /(?:(?<=['"])agentRules(?=['"])|(?<![\w$])agentRules(?![\w$]))/
-  .source;
+// The bare-identifier alternative requires the character immediately
+// before `agentRules` to be `{`, `,`, or whitespace (or nothing — start of
+// text) — `(?<![^{,\s])` is a negative lookbehind on "any character that
+// is NOT one of those", which also vacuously holds at the start of the
+// string, where there is no preceding character to fail it. This is
+// deliberately narrower than only excluding identifier characters
+// (`(?<![\w$])`, used by an earlier version): a legitimate unquoted object
+// key can only be immediately preceded by one of `{`, `,`, or whitespace,
+// so anything else — punctuation like `-`, another quote, etc. — is never
+// a valid bare-key start. The earlier, looser lookbehind let `agentRules`
+// embedded inside a quoted string right after a `-` (as in
+// `'not-agentRules'`) slip through the bare alternative, since `-` isn't a
+// `\w`/`$` character either. The lookahead `(?![\w$])` still requires
+// nothing immediately after `agentRules` is an identifier character,
+// rejecting `{ agentRulesExtra: false }`.
+const AGENT_RULES_KEY_SOURCE = /(?:(['"])agentRules\1|(?<![^{,\s])agentRules(?![\w$]))/.source;
 
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -29,6 +29,14 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // characters before this pattern runs, so a real `}` never reaches here.
 const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
 
+// Matches an `agentRules` key regardless of its value — used to find every
+// occurrence among an object's direct properties, not just ones that
+// happen to say `false`. JS object literals let the same key appear more
+// than once; whichever occurrence appears LAST wins at runtime (this is
+// legal, unambiguous JS, not a syntax error), so only the last occurrence's
+// value is ever the effective one.
+const AGENT_RULES_KEY_PATTERN = /["']?agentRules["']?\s*:/g;
+
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
 // opt-out, silently passing a config that has not disabled anything. Comments
@@ -137,21 +145,37 @@ function keepOnlyDirectProperties(objectSource) {
   return result;
 }
 
-// `{ agentRules: false, ...shared }` sets agentRules: false, but if `shared`
-// (a spread evaluated after the explicit property, per normal JS object
-// literal semantics) itself has an `agentRules` key, that key wins at
-// runtime — the effective value is whatever `shared.agentRules` is, not
-// `false`. This checker cannot evaluate what an arbitrary spread source
-// contains (see the module-level indirection note above), so unlike the
-// indirection/scope-shadowing bounds documented elsewhere in this file,
-// this is not accepted as an unverifiable case that stays green: a spread
-// appearing anywhere in the direct properties AFTER the matched
-// `agentRules: false` makes the effective value undecidable, so the caller
-// fails closed instead of assuming `false` still holds. A spread BEFORE the
-// explicit property is fine — the explicit `agentRules: false` written
-// after it is what wins, exactly as read.
-function hasSpreadAfter(directPropertiesText, matchEndIndex) {
-  return directPropertiesText.slice(matchEndIndex).includes('...');
+// Finds the start index of the LAST `agentRules` key among an object's
+// direct properties, or -1 if there is none. Two ways a later assignment
+// can override an earlier explicit `agentRules: false` — a duplicate key
+// (`{ agentRules: false, agentRules: true }`, legal JS: the last one wins)
+// and a later spread whose source sets `agentRules` — are unified by this
+// function and the caller: only the LAST key occurrence's value is ever
+// the effective one, so evaluating anything before it is pointless, and a
+// spread after it is exactly as override-capable as another explicit key.
+function findLastAgentRulesKeyIndex(directPropertiesText) {
+  AGENT_RULES_KEY_PATTERN.lastIndex = 0;
+  let lastIndex = -1;
+  let match;
+  while ((match = AGENT_RULES_KEY_PATTERN.exec(directPropertiesText)) !== null) {
+    lastIndex = match.index;
+  }
+  return lastIndex;
+}
+
+// A spread after the winning (last) `agentRules` key can still override it
+// at runtime — `{ agentRules: false, ...shared }` sets agentRules: false,
+// but if `shared` (evaluated after, per normal JS object literal semantics)
+// itself has an `agentRules` key, that key wins, not `false`. This checker
+// cannot evaluate what an arbitrary spread source contains (see the
+// module-level indirection note above), so unlike the indirection/
+// scope-shadowing bounds documented elsewhere in this file, this is not
+// accepted as an unverifiable case that stays green: the caller fails
+// closed instead of assuming `false` still holds. A spread BEFORE the
+// winning key is fine — the explicit `agentRules: false` written after it
+// is what wins, exactly as read.
+function hasSpreadAfter(directPropertiesText, index) {
+  return directPropertiesText.slice(index).includes('...');
 }
 
 async function findConfigFile(directory) {
@@ -190,8 +214,14 @@ if (configFile === null) {
     process.exitCode = 1;
   } else {
     const directPropertiesText = keepOnlyDirectProperties(exportedConfigObjectSource);
-    const agentRulesMatch = AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText);
-    if (!agentRulesMatch) {
+    const lastKeyIndex = findLastAgentRulesKeyIndex(directPropertiesText);
+    const disabledMatch =
+      lastKeyIndex === -1
+        ? null
+        : AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText.slice(lastKeyIndex));
+    const lastKeyIsDisabled = disabledMatch !== null && disabledMatch.index === 0;
+
+    if (!lastKeyIsDisabled) {
       console.error(
         `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
           `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
@@ -199,9 +229,7 @@ if (configFile === null) {
           `an AI coding agent in the environment.`,
       );
       process.exitCode = 1;
-    } else if (
-      hasSpreadAfter(directPropertiesText, agentRulesMatch.index + agentRulesMatch[0].length)
-    ) {
+    } else if (hasSpreadAfter(directPropertiesText, lastKeyIndex + disabledMatch[0].length)) {
       console.error(
         `${path.basename(configFile.path)} sets \`agentRules: false\` but also spreads another object ` +
           `(\`...\`) into the config afterward. A later spread can override \`agentRules\` back to enabled ` +

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -64,30 +64,18 @@ function escapeRegExp(literal) {
 // of scope for this filesystem-only checker and returns null so the caller
 // fails loudly instead of guessing.
 //
-// Known, accepted bound (not fixed): the declaration search below is
-// anchored to the start of a line (no scope/indentation tracking), so a
-// same-named binding declared at column 0 earlier in the file — not
-// plausible for a real next.config, which declares its config once at the
-// top level — could still be picked over the real one. A binding shadowed
-// inside a nested function body, as in Codex's adversarial example on this
-// PR (`function helper() { const nextConfig = {...} }`), is indented and so
-// is excluded by the same anchor. Closing this fully would require
-// scope-aware parsing, which this filesystem-only, non-executing checker
-// deliberately does not do (see the module-level indirection note above).
-//
-// Known, accepted bound (not fixed): a later spread that overrides
-// `agentRules` — `{ agentRules: false, ...shared }` where `shared` sets
-// `agentRules: true` — is not detected; the checker only checks whether the
-// literal `agentRules: false` text appears among the exported object's
-// direct properties, not which property assignment wins once spreads are
-// evaluated in declaration order. Determining the actually-effective value
-// would require evaluating the object literal (including resolving what
-// each spread source contains), which this filesystem-only, non-executing
-// checker deliberately does not do. A `next.config` that spreads a second
-// object into its config after an explicit `agentRules: false` is
-// sufficiently unusual that this is accepted rather than chased further —
-// see the Review Protocol's stopping rules on not spiraling a closure cycle
-// indefinitely against the same bounded-by-design surface.
+// Out of this checker's documented scope (not a defect against it, per the
+// module-level indirection note above — this is the same "does not execute
+// consumer config" boundary, applied to scope resolution rather than value
+// resolution): the declaration search below is anchored to the start of a
+// line (no scope/indentation tracking), so a same-named binding declared at
+// column 0 earlier in the file — not plausible for a real next.config,
+// which declares its config once at the top level — could still be picked
+// over the real one. A binding shadowed inside a nested function body is
+// indented and so is excluded by the same anchor, which is why this does
+// not regress the realistic case Next.js's own docs show. Closing this
+// fully would require scope-aware parsing, which this filesystem-only,
+// non-executing checker deliberately does not do.
 //
 // Note that identifier boundaries throughout this function use a
 // `(?![\w$])` negative lookahead, not `\b`: `$` is a valid trailing
@@ -149,6 +137,23 @@ function keepOnlyDirectProperties(objectSource) {
   return result;
 }
 
+// `{ agentRules: false, ...shared }` sets agentRules: false, but if `shared`
+// (a spread evaluated after the explicit property, per normal JS object
+// literal semantics) itself has an `agentRules` key, that key wins at
+// runtime — the effective value is whatever `shared.agentRules` is, not
+// `false`. This checker cannot evaluate what an arbitrary spread source
+// contains (see the module-level indirection note above), so unlike the
+// indirection/scope-shadowing bounds documented elsewhere in this file,
+// this is not accepted as an unverifiable case that stays green: a spread
+// appearing anywhere in the direct properties AFTER the matched
+// `agentRules: false` makes the effective value undecidable, so the caller
+// fails closed instead of assuming `false` still holds. A spread BEFORE the
+// explicit property is fine — the explicit `agentRules: false` written
+// after it is what wins, exactly as read.
+function hasSpreadAfter(directPropertiesText, matchEndIndex) {
+  return directPropertiesText.slice(matchEndIndex).includes('...');
+}
+
 async function findConfigFile(directory) {
   for (const filename of CANDIDATE_CONFIG_FILENAMES) {
     const candidatePath = path.join(directory, filename);
@@ -183,19 +188,32 @@ if (configFile === null) {
         `Use one of these shapes with \`agentRules: false\` so this checker can verify it.`,
     );
     process.exitCode = 1;
-  } else if (
-    !AGENT_RULES_DISABLED_PATTERN.test(keepOnlyDirectProperties(exportedConfigObjectSource))
-  ) {
-    console.error(
-      `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
-        `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
-        `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
-        `an AI coding agent in the environment.`,
-    );
-    process.exitCode = 1;
   } else {
-    console.log(
-      `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
-    );
+    const directPropertiesText = keepOnlyDirectProperties(exportedConfigObjectSource);
+    const agentRulesMatch = AGENT_RULES_DISABLED_PATTERN.exec(directPropertiesText);
+    if (!agentRulesMatch) {
+      console.error(
+        `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+          `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+          `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+          `an AI coding agent in the environment.`,
+      );
+      process.exitCode = 1;
+    } else if (
+      hasSpreadAfter(directPropertiesText, agentRulesMatch.index + agentRulesMatch[0].length)
+    ) {
+      console.error(
+        `${path.basename(configFile.path)} sets \`agentRules: false\` but also spreads another object ` +
+          `(\`...\`) into the config afterward. A later spread can override \`agentRules\` back to enabled ` +
+          `at runtime, and this filesystem-only checker cannot verify what the spread source contains. ` +
+          `Move \`agentRules: false\` after the spread (or remove the spread) so this checker can verify ` +
+          `the effective value.`,
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
+      );
+    }
   }
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -178,6 +178,19 @@ function hasSpreadAfter(directPropertiesText, index) {
   return directPropertiesText.slice(index).includes('...');
 }
 
+// Distinguishes, for the error message only, "agentRules was never set to
+// false" from "agentRules was set to false, but a later duplicate key
+// overrides it" — the generic message is accurate but unhelpfully vague for
+// the latter case (Claude review nit on this PR: a developer who already
+// wrote `agentRules: false` and left a stale duplicate key behind can't
+// tell what's wrong from the generic message alone).
+function hasEarlierDisabledOccurrence(directPropertiesText, lastKeyIndex) {
+  return (
+    lastKeyIndex > 0 &&
+    AGENT_RULES_DISABLED_PATTERN.test(directPropertiesText.slice(0, lastKeyIndex))
+  );
+}
+
 async function findConfigFile(directory) {
   for (const filename of CANDIDATE_CONFIG_FILENAMES) {
     const candidatePath = path.join(directory, filename);
@@ -222,12 +235,21 @@ if (configFile === null) {
     const lastKeyIsDisabled = disabledMatch !== null && disabledMatch.index === 0;
 
     if (!lastKeyIsDisabled) {
-      console.error(
-        `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
-          `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
-          `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
-          `an AI coding agent in the environment.`,
-      );
+      if (hasEarlierDisabledOccurrence(directPropertiesText, lastKeyIndex)) {
+        console.error(
+          `${path.basename(configFile.path)} sets \`agentRules: false\` earlier, but a later duplicate ` +
+            `\`agentRules\` key overrides it — JS keeps only the LAST occurrence of a duplicate object ` +
+            `key, and \`next dev\` reads that final value. Remove the earlier \`agentRules: false\` or the ` +
+            `later override so only one, disabling, \`agentRules\` assignment remains.`,
+        );
+      } else {
+        console.error(
+          `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+            `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+            `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+            `an AI coding agent in the environment.`,
+        );
+      }
       process.exitCode = 1;
     } else if (hasSpreadAfter(directPropertiesText, lastKeyIndex + disabledMatch[0].length)) {
       console.error(

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -67,6 +67,27 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.c
 // rejecting `{ agentRulesExtra: false }`.
 const AGENT_RULES_KEY_SOURCE = /(?:(['"])agentRules\1|(?<![^{,\s])agentRules(?![\w$]))/.source;
 
+// Out of this checker's documented scope (not fixed — Codex review finding
+// on this PR): AGENT_RULES_KEY_SOURCE, and so AGENT_RULES_KEY_PATTERN
+// below, only match a `key: value` colon form. JS object literals also
+// allow a shorthand duplicate — `const agentRules = true; const nextConfig
+// = { agentRules: false, agentRules };` — where the trailing bare
+// `agentRules` (no colon) is shorthand for `agentRules: agentRules`
+// (the outer binding) and, per the same last-duplicate-wins semantics
+// documented on findLastAgentRulesKeyIndex() below, overrides the earlier
+// `false`. Method (`agentRules() {}`) and accessor (`get agentRules()
+// {}`) forms are the same class of gap. None of these are counted as an
+// `agentRules` occurrence here, so a trailing one of these forms is
+// invisible to this checker. Detecting them would require recognizing
+// several additional JS object-member grammars beyond `key: value`, which
+// pushes this filesystem-only, non-executing checker further toward being
+// a real parser; it is also a dangerous-direction gap in principle, but
+// requires deliberately naming an outer binding exactly `agentRules` and
+// shadowing it with a same-named shorthand/method/accessor member in a
+// `next.config` — not a plausible accidental construct — and is a further
+// example of the "regex, not a tokenizer" bound already accepted
+// repeatedly throughout this file.
+
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to
 // `true`) — the lookahead requires whatever follows (after optional

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -16,10 +16,40 @@ import path from 'node:path';
 // config error, not this checker's concern).
 const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
 
-// Deliberately a text match, not a config evaluation: this checker does not
-// execute consumer config (no import/require of consumer code, no bundler),
-// so it cannot follow indirection such as `agentRules: someImportedFlag`.
-// It catches the direct, documented opt-out Next.js's own docs show.
+// Matches a JS object property key that is EXACTLY `agentRules` — either a
+// bare identifier not embedded in a longer one, or a fully quoted string
+// whose entire content is `agentRules` — not merely a substring of a
+// longer key. Shared between AGENT_RULES_DISABLED_PATTERN and
+// AGENT_RULES_KEY_PATTERN below so both apply identical key-boundary rules
+// (duplicating this by hand in each pattern previously let them drift out
+// of sync — see the fix history in this PR).
+//
+// The bare-identifier alternative's `(?<![\w$])`/`(?![\w$])` require that
+// neither the character immediately before nor immediately after
+// `agentRules` is an identifier character. Without this, a differently
+// named property whose name merely CONTAINS `agentRules` — e.g.
+// `{ notAgentRules: false }`, a config that does not disable the real
+// `agentRules` option at all — would be read as the real key, false-passing
+// a config `next dev` still mutates.
+//
+// The quoted alternative's `(?<=['"])`/`(?=['"])` require an actual quote
+// character immediately on both sides of `agentRules` — not merely that
+// `["']?` optionally matches one. A prior version used an optional quote
+// on each side, which let `{ 'not-agentRules': false }` match: `["']?` can
+// simply match zero characters and start the pattern mid-string, right at
+// `agentRules`, and `-` (unlike `\w`/`$`) doesn't fail the old bare-key
+// lookbehind either. Requiring an actual quote adjacent on both sides
+// closes this: for `'not-agentRules'`, the character immediately before
+// `agentRules` is `-`, not a quote, so the quoted alternative doesn't
+// match there, and the bare-identifier alternative's lookbehind (`-` is
+// not `[\w$]`, so it doesn't reject) is irrelevant because the substring
+// isn't a standalone bare identifier occurrence either — the whole
+// property key `'not-agentRules'` is quoted, so only the quoted
+// alternative could apply, and it correctly requires the quote to sit
+// right next to `agentRules`, which it doesn't here.
+const AGENT_RULES_KEY_SOURCE = /(?:(?<=['"])agentRules(?=['"])|(?<![\w$])agentRules(?![\w$]))/
+  .source;
+
 // `false` must be the complete property value, not merely a prefix of a
 // larger expression such as `agentRules: false || true` (which evaluates to
 // `true`) — the lookahead requires whatever follows (after optional
@@ -27,26 +57,17 @@ const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.co
 // arbitrary trailing expression text. `}` is included for defensiveness
 // even though keepOnlyDirectProperties() below always blanks brace
 // characters before this pattern runs, so a real `}` never reaches here.
-//
-// The leading `(?<![\w$])` requires that whatever immediately precedes the
-// match (the opening quote of a quoted key, or the `a` of a bare key) is
-// not itself an identifier character. Without it, a differently named
-// property whose name merely ENDS in `agentRules` — e.g.
-// `{ notAgentRules: false }`, a config that does not disable the real
-// `agentRules` option at all — would be read as the real key, false-passing
-// a config `next dev` still mutates. A quoted key's leading quote character
-// is not a `\w`/`$` character, so this lookbehind does not reject
-// `"agentRules": false`.
-const AGENT_RULES_DISABLED_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+const AGENT_RULES_DISABLED_PATTERN = new RegExp(
+  `${AGENT_RULES_KEY_SOURCE}\\s*:\\s*false(?=\\s*[,;}]|\\s*$)`,
+);
 
 // Matches an `agentRules` key regardless of its value — used to find every
 // occurrence among an object's direct properties, not just ones that
 // happen to say `false`. JS object literals let the same key appear more
 // than once; whichever occurrence appears LAST wins at runtime (this is
 // legal, unambiguous JS, not a syntax error), so only the last occurrence's
-// value is ever the effective one. Same `(?<![\w$])` key-start boundary as
-// AGENT_RULES_DISABLED_PATTERN, and for the same reason.
-const AGENT_RULES_KEY_PATTERN = /(?<![\w$])["']?agentRules["']?\s*:/g;
+// value is ever the effective one.
+const AGENT_RULES_KEY_PATTERN = new RegExp(`${AGENT_RULES_KEY_SOURCE}\\s*:`, 'g');
 
 // A bare text match on the unmodified source would treat a mention inside a
 // comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
@@ -142,8 +163,25 @@ function findExportedConfigObjectSource(source) {
 // nothing to do with `agentRules` — as a possible override, fail-closing an
 // actually-safe config (Claude review finding on this PR). This is
 // brace/bracket counting, not full parsing, so a `{`/`}`/`[`/`]` inside a
-// string literal is a known, accepted edge case, matching the same bound
-// already documented for stripComments().
+// string or regex literal is a known, accepted edge case, matching the
+// same bound already documented for stripComments().
+//
+// Out of this checker's documented scope (not fixed): unlike the
+// fail-closed-only string-literal cases documented elsewhere in this file,
+// a `]` inside a string/regex literal VALUE that sits between the winning
+// `agentRules: false` and a real spread — e.g. `{ agentRules: false, note:
+// ']', ...shared }` — can decrement depth prematurely and blank the real
+// `...shared` out of directPropertiesText, hiding it from hasSpreadAfter()
+// below (Codex review finding on this PR). If `shared` sets `agentRules`,
+// this is a dangerous-direction miss (the checker reports green on a
+// config `next dev` can still mutate), not merely a false alarm. Fully
+// closing this requires distinguishing string/regex-literal contents from
+// structural brackets, i.e. real JS tokenization, which this filesystem-
+// only, non-executing checker deliberately does not do (see the
+// module-level indirection note above) — it requires deliberately
+// constructing a property value whose literal text contains an unbalanced
+// bracket character positioned exactly between the winning key and a
+// spread, which is not a plausible accidental `next.config`.
 function keepOnlyDirectProperties(objectSource) {
   let depth = 0;
   let result = '';

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -13,8 +13,18 @@ import path from 'node:path';
 //
 // Only the three filenames Next.js itself accepts for configuration are
 // checked (an unsupported extension such as .cjs/.cts is itself a Next.js
-// config error, not this checker's concern).
-const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
+// config error, not this checker's concern). The order matters and matches
+// Next.js's own `CONFIG_FILES` precedence (node_modules/next/dist/shared/
+// lib/constants.js in 16.3.2: `['next.config.js', 'next.config.mjs',
+// 'next.config.ts', ...]`) — if more than one candidate coexists (e.g.
+// mid-migration between formats, or a stale file left behind), Next.js
+// loads only the first it finds in that order, and this checker must
+// inspect the same file Next.js actually loads. Checking a different one
+// (an earlier version of this checker tried `.ts` first) risks reporting
+// a config as disabled based on a file `next dev` never reads, while the
+// file it does read still has agentRules enabled (Codex review finding on
+// this PR).
+const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.config.ts'];
 
 // Matches a JS object property key that is EXACTLY `agentRules` — either a
 // bare identifier not embedded in a longer one, or a fully quoted string
@@ -266,6 +276,23 @@ function findLastAgentRulesKeyIndex(directPropertiesText) {
 // closed instead of assuming `false` still holds. A spread BEFORE the
 // winning key is fine — the explicit `agentRules: false` written after it
 // is what wins, exactly as read.
+//
+// Out of this checker's documented scope (not fixed, fail-closed direction
+// only — Claude review finding on this PR): the `.includes('...')` search
+// below is the same "regex, not a tokenizer" bound as the rest of this
+// file — an unrelated FLAT string property value (not wrapped in its own
+// `{`/`[`, so not blanked by keepOnlyDirectProperties()) that happens to
+// contain the literal text `...` — e.g. `{ agentRules: false, note: 'see
+// docs...' }` — is read as a possible spread override, fail-closing an
+// actually-safe config. This can only produce a false alarm (the checker
+// never treats a real spread as absent), not a silent pass, matching the
+// direction already accepted for the analogous bare/quoted-substring cases
+// on findLastAgentRulesKeyIndex() above; requires a property value whose
+// literal text happens to contain `...`, which is not an unusual thing to
+// write (e.g. an ellipsis in prose), so this is a real, if low-severity
+// (fail-closed-only), usability limitation of this filesystem-only,
+// non-executing checker rather than a hidden defect against its stated
+// scope.
 function hasSpreadAfter(directPropertiesText, index) {
   return directPropertiesText.slice(index).includes('...');
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -1,0 +1,201 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// Next.js 16.3+ `next dev` auto-detects an AI coding agent in the
+// environment (CLAUDECODE, CURSOR_TRACE_ID, CODEX_*, GEMINI_CLI, etc. — see
+// @vercel/detect-agent) and, unless `agentRules` is explicitly `false` in
+// next.config, upserts a `<!-- BEGIN:nextjs-agent-rules -->` managed block
+// into AGENTS.md (verified against Next.js 16.3.2's
+// node_modules/next/dist/server/lib/start-server.js and
+// generate-agent-files.js). AGENTS.md is a Foundation-owned generated
+// artifact (see tooling/sync.mjs); Next.js runtime mutating it is drift this
+// profile's consumers must not hit on an ordinary `next dev`.
+//
+// Only the three filenames Next.js itself accepts for configuration are
+// checked (an unsupported extension such as .cjs/.cts is itself a Next.js
+// config error, not this checker's concern).
+const CANDIDATE_CONFIG_FILENAMES = ['next.config.ts', 'next.config.js', 'next.config.mjs'];
+
+// Deliberately a text match, not a config evaluation: this checker does not
+// execute consumer config (no import/require of consumer code, no bundler),
+// so it cannot follow indirection such as `agentRules: someImportedFlag`.
+// It catches the direct, documented opt-out Next.js's own docs show.
+// `false` must be the complete property value, not merely a prefix of a
+// larger expression such as `agentRules: false || true` (which evaluates to
+// `true`) — the lookahead requires whatever follows (after optional
+// whitespace) to be a property/statement terminator or end of input, not
+// arbitrary trailing expression text. `}` is included for defensiveness
+// even though keepOnlyDirectProperties() below always blanks brace
+// characters before this pattern runs, so a real `}` never reaches here.
+const AGENT_RULES_DISABLED_PATTERN = /["']?agentRules["']?\s*:\s*false(?=\s*[,;}]|\s*$)/;
+
+// A bare text match on the unmodified source would treat a mention inside a
+// comment (e.g. `// TODO: set agentRules: false`) as if it were the actual
+// opt-out, silently passing a config that has not disabled anything. Comments
+// are stripped first so only code the JS/TS parser would actually evaluate
+// can match. This is line/block-comment stripping, not full tokenization, so
+// a `//` or `/*` inside a string literal is a known, accepted edge case for
+// this bounded, filesystem-only checker.
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/.*$/gm, '');
+}
+
+// A valid JS identifier can contain `$` (e.g. `$config`), which is a regex
+// metacharacter. Embedding an un-escaped identifier in `new RegExp(...)`
+// below would let a `$` in the identifier be read as regex syntax instead of
+// a literal character, corrupting the match.
+function escapeRegExp(literal) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Locates, by source span, the object literal that a `next.config` file
+// actually `export default`s or `module.exports`s — following at most one
+// level of the canonical indirection Next.js's own docs show:
+//   const nextConfig: NextConfig = { ... }; export default nextConfig;
+//   const nextConfig = { ... }; module.exports = nextConfig;
+// or a directly inlined `export default { ... }` / `module.exports = { ... }`.
+// Restricting the search to this object (rather than every top-level object
+// literal in the file) matters: without it, an unrelated top-level object —
+// `const metadata = { agentRules: false }; const nextConfig = { agentRules:
+// true }; module.exports = nextConfig;` — would satisfy the checker even
+// though the config Next.js actually loads has agentRules left enabled.
+// Any other export shape (a wrapped call like `withPlugin(nextConfig)`, a
+// config assembled via spread from another module, re-exports, etc.) is out
+// of scope for this filesystem-only checker and returns null so the caller
+// fails loudly instead of guessing.
+//
+// Known, accepted bound (not fixed): the declaration search below is
+// anchored to the start of a line (no scope/indentation tracking), so a
+// same-named binding declared at column 0 earlier in the file — not
+// plausible for a real next.config, which declares its config once at the
+// top level — could still be picked over the real one. A binding shadowed
+// inside a nested function body, as in Codex's adversarial example on this
+// PR (`function helper() { const nextConfig = {...} }`), is indented and so
+// is excluded by the same anchor. Closing this fully would require
+// scope-aware parsing, which this filesystem-only, non-executing checker
+// deliberately does not do (see the module-level indirection note above).
+//
+// Known, accepted bound (not fixed): a later spread that overrides
+// `agentRules` — `{ agentRules: false, ...shared }` where `shared` sets
+// `agentRules: true` — is not detected; the checker only checks whether the
+// literal `agentRules: false` text appears among the exported object's
+// direct properties, not which property assignment wins once spreads are
+// evaluated in declaration order. Determining the actually-effective value
+// would require evaluating the object literal (including resolving what
+// each spread source contains), which this filesystem-only, non-executing
+// checker deliberately does not do. A `next.config` that spreads a second
+// object into its config after an explicit `agentRules: false` is
+// sufficiently unusual that this is accepted rather than chased further —
+// see the Review Protocol's stopping rules on not spiraling a closure cycle
+// indefinitely against the same bounded-by-design surface.
+//
+// Note that identifier boundaries throughout this function use a
+// `(?![\w$])` negative lookahead, not `\b`: `$` is a valid trailing
+// identifier character but is not a `\w` character, so `\b` immediately
+// after a `$`-suffixed identifier (e.g. `config$`) sits between two
+// non-word characters and never asserts a boundary there, silently
+// truncating the match to `config`.
+function findExportedConfigObjectSource(source) {
+  const exportedIdentifierMatch =
+    /(?:export\s+default|module\.exports\s*=)\s*([A-Za-z_$][\w$]*)(?![\w$])/.exec(source);
+  const declarationName = exportedIdentifierMatch?.[1];
+
+  const openBraceMatch = declarationName
+    ? new RegExp(
+        `^(?:export\\s+)?(?:const|let|var)\\s+${escapeRegExp(declarationName)}(?![\\w$])[^={]*=\\s*\\{`,
+        'm',
+      ).exec(source)
+    : /(?:export\s+default|module\.exports\s*=)\s*\{/.exec(source);
+  if (!openBraceMatch) return null;
+
+  const openBraceIndex = openBraceMatch.index + openBraceMatch[0].length - 1;
+  let depth = 0;
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    else if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openBraceIndex, index + 1);
+    }
+  }
+  return null;
+}
+
+// A comment-stripped text match against the exported object's own source
+// would still treat an unrelated, coincidentally named `agentRules: false`
+// nested inside some other property of that same object (for example
+// `{ experimental: { agentRules: false } }`) as if it were the top-level
+// `agentRules` property NextConfig actually reads. Brace depth is counted
+// and only text at depth 1 relative to the exported object's own opening
+// brace — its direct properties — is kept; deeper text is blanked out
+// before matching. This is brace counting, not full parsing, so a `{` or
+// `}` inside a string literal is a known, accepted edge case, matching the
+// same bound already documented for stripComments().
+function keepOnlyDirectProperties(objectSource) {
+  let depth = 0;
+  let result = '';
+  for (const character of objectSource) {
+    if (character === '{') {
+      depth += 1;
+      result += ' ';
+      continue;
+    }
+    if (character === '}') {
+      depth -= 1;
+      result += ' ';
+      continue;
+    }
+    result += depth === 1 ? character : ' ';
+  }
+  return result;
+}
+
+async function findConfigFile(directory) {
+  for (const filename of CANDIDATE_CONFIG_FILENAMES) {
+    const candidatePath = path.join(directory, filename);
+    try {
+      return { path: candidatePath, content: await readFile(candidatePath, 'utf8') };
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  return null;
+}
+
+const configFile = await findConfigFile(process.cwd());
+
+if (configFile === null) {
+  console.error(
+    `No next.config.{ts,js,mjs} found. Foundation-generated AGENTS.md is a generated artifact ` +
+      `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
+      `with \`agentRules: false\`.`,
+  );
+  process.exitCode = 1;
+} else {
+  const exportedConfigObjectSource = findExportedConfigObjectSource(
+    stripComments(configFile.content),
+  );
+  if (exportedConfigObjectSource === null) {
+    console.error(
+      `Could not determine the exported config object in ${path.basename(configFile.path)}. ` +
+        `This checker only recognizes the canonical shapes Next.js's own docs show: ` +
+        `\`const nextConfig = { ... }; export default nextConfig;\` (or \`module.exports = nextConfig;\`), ` +
+        `or a directly inlined \`export default { ... }\` / \`module.exports = { ... }\`. ` +
+        `Use one of these shapes with \`agentRules: false\` so this checker can verify it.`,
+    );
+    process.exitCode = 1;
+  } else if (
+    !AGENT_RULES_DISABLED_PATTERN.test(keepOnlyDirectProperties(exportedConfigObjectSource))
+  ) {
+    console.error(
+      `${path.basename(configFile.path)} does not disable Next.js's generated-AGENTS.md agent rules. ` +
+        `Set \`agentRules: false\` in ${path.basename(configFile.path)}, otherwise \`next dev\` upserts a ` +
+        `<!-- BEGIN:nextjs-agent-rules --> block into the Foundation-generated AGENTS.md whenever it detects ` +
+        `an AI coding agent in the environment.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `${path.basename(configFile.path)} disables Next.js's generated-AGENTS.md agent rules (agentRules: false).`,
+    );
+  }
+}

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -961,6 +961,15 @@ domain terminology、product-specific security decision は consumer product rul
 - generated Supabase types を database type の source of truth として扱います。
 - stack-specific deterministic quality check は Foundation core policy ではなく、
   この profile または関連 tooling に置きます。
+- Foundation-generated `AGENTS.md` は generated artifact であり、Next.js
+  runtime が書き換える対象ではありません。Next.js 16.3 以降を使う consumer は
+  `next.config` で `agentRules: false` を設定し、`next dev` による generated
+  `AGENTS.md` への silent mutation を防ぎます（16.3 未満は該当する自動生成
+  挙動も `agentRules` option も持たないため対象外です）。`next.config` 自体は
+  consumer-owned であり、Foundation はこの設定を代わりに書き込みません。
+  deterministic な検証方法は consumer の `.ai-dev-foundation/quality/README.md`
+  （Foundation リポジトリでは `profiles/next-supabase/quality/README.md`）を
+  参照してください。
 - quality profile の適用方法とblocking/advisoryの区別は consumer の
   `.ai-dev-foundation/quality/README.md`（Foundation リポジトリでは
   `profiles/next-supabase/quality/README.md`）を正本とします。product-domain

--- a/test/fixtures/consumer/next.config.ts
+++ b/test/fixtures/consumer/next.config.ts
@@ -1,0 +1,9 @@
+// Foundation-generated AGENTS.md is a generated artifact (tooling/sync.mjs);
+// disable Next.js 16.3+'s `next dev` auto-generated agent-rules block so it
+// never mutates AGENTS.md. See profiles/next-supabase/quality/README.md
+// ("Next.js agent-rules (generated AGENTS.md) drift prevention").
+const nextConfig = {
+  agentRules: false,
+};
+
+export default nextConfig;

--- a/test/fixtures/consumer/package.json
+++ b/test/fixtures/consumer/package.json
@@ -12,9 +12,10 @@
     "test:unit": "node --experimental-strip-types --test test/*.test.mjs",
     "build": "tsc --project tsconfig.build.json",
     "foundation:check": "node ../../../tooling/check.mjs --consumer .",
+    "agent-rules:check": "node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs",
     "supabase:migrations:check": "node .ai-dev-foundation/quality/check-migration-version-collision.mjs",
     "supabase:types:check": "node scripts/check-generated-supabase-types.mjs",
-    "verify:profile": "npm run supabase:migrations:check && npm run supabase:types:check",
+    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }

--- a/test/fixtures/consumer/tsconfig.json
+++ b/test/fixtures/consumer/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "./.ai-dev-foundation/quality/tsconfig.quality.json",
-  "include": ["src"]
+  "include": ["src", "next.config.ts"]
 }


### PR DESCRIPTION
## Context

Issue #40 の canonical Task Contract に基づく実装。

`main` (base): `583e956e73e69b47bc5a730514f21309a797d9bb`
PR head (final, after review closure): `c4eb332af4202c968428368453633e8aa06e8399`

## Actual Next.js 16 behavior (fresh reproduction evidence)

bounded temporary fixture（本 repo外、local Supabase不使用）で Next.js
16.3.2 を実際に動かして確認した。

- `next dev` は起動時に `@vercel/detect-agent` で環境内の AI coding agent
  を検出する（`CLAUDECODE` / `CURSOR_TRACE_ID` / `CODEX_*` / `GEMINI_CLI`
  等の環境変数。`node_modules/next/dist/compiled/@vercel/detect-agent/index.js`）。
- 検出し、かつ `next.config` で `agentRules` が明示的に `false` でない場合
  （default は有効。`node_modules/next/dist/server/lib/start-server.js:418-419`
  `// Gated on \`agentRules\` in next.config (default true).`）、
  Foundation-generated `AGENTS.md` へ `<!-- BEGIN:nextjs-agent-rules -->`
  managed block を upsert する
  （`node_modules/next/dist/server/lib/generate-agent-files.js`）。
- 実測: `agentRules` 未設定の `next.config.js` で `next dev` を実行 →
  `✓ Generated AGENTS.md for AI agents.` ログとともに block が追記される。
  同じ AGENTS.md を revert し、`agentRules: false` を設定して再実行 →
  ログなし、ファイル内容は byte-for-byte 不変。
- `CLAUDE.md` も対象ファイルだが、Foundation の `CLAUDE.md` は既に
  Next.js が書き込む内容と同一の `@AGENTS.md\n` なので、実質的な drift は
  `AGENTS.md` 側にのみ生じる。

## Ownership boundary（Design boundary への回答）

1. Foundation-generated `AGENTS.md` は Foundation-owned generated artifact
   （`tooling/sync.mjs`）。
2. consumer の `next.config` は consumer-owned application config。
   Foundation はこの file を代わりに書き込まない（`next.config` を exact-match
   artifact 化しない）。
3. 最小の Foundation-owned surface は「`next.config` が `agentRules: false`
   を持つことを filesystem だけで検証する新しい deterministic check」
   （`profiles/next-supabase/quality/check-agent-rules-disabled.mjs`）。
   既存の `tooling/check.mjs` の AGENTS.md 完全一致比較は drift 発生後の
   reactive detection として既に機能しているが、`next dev` のたびに working
   tree が dirty になる根本原因（config 側の未設定）を proactive に検知しない。
4. Next.js upstream の agent-rules block 本文は Foundation canonical policy
   へコピーしていない（`profiles/next-supabase/quality/README.md` の新
   section は挙動の説明とcheckerの使い方のみ）。
5. profile guidance（`project-rules.md` に1文追加）だけでなく、
   `verify:profile` に組み込む deterministic check（Direction A + C の組合せ）
   を採用した。Direction B（Foundationによる next.config の bootstrap時
   materialization/patch）は、next.config が consumer 固有の設定を多く含む
   単一ファイルであり、`materializeOwnedDirectory` のような exact-match
   ownership に馴染まないため不採用。

## Changed surface

- `profiles/next-supabase/project-rules.md`: agentRules: false の期待を
  1 bullet 追加（canonical policy として `AGENTS.md` へ配布される）。
- `profiles/next-supabase/quality/check-agent-rules-disabled.mjs`（新規）:
  `next.config.{ts,js,mjs}` を読み、`agentRules: false`（quoted key含む）を
  text match で検証。next dev/network/browser 不要。
- `profiles/next-supabase/quality/README.md`: 新 section
  「Next.js agent-rules (generated AGENTS.md) drift prevention」と
  `verify:profile` 例の更新。
- `test/agent-rules-check.test.mjs`（新規） + `test/fixtures/agent-rules/*`
  （新規fixture: disabled / disabled-quoted-mjs / not-disabled / missing-config）。
- reference consumer fixture（`test/fixtures/consumer/`）: `next.config.ts`
  （`agentRules: false`）追加、`agent-rules:check` を `verify:profile` へ配線、
  `tsconfig.json` の `include` に `next.config.ts` を追加、bootstrap再実行で
  `.ai-dev-foundation/quality/check-agent-rules-disabled.mjs` を materialize、
  `project-rules.md` 変更を反映して sync再実行（`AGENTS.md` 更新）。

## Verification

- `npm test`（39 tests、`node --test` + `test:guardrails`）: green
- `npm run test:guardrails`: green（8 guardrail fixtures）
- `git diff --check`: no whitespace errors
- reference consumer fixture `npm run verify`
  （format/lint/typecheck/test:unit/build/foundation:check/verify:profile
  including `agent-rules:check`）: green
- 新規 `test/agent-rules-check.test.mjs`（5 tests）: green
  - `agentRules: false` (next.config.ts) → pass
  - quoted key `"agentRules": false` (next.config.mjs) → pass
  - `agentRules` 未設定 (next.config.js) → fail + remediation
  - next.config ファイル自体が存在しない → fail + remediation
  - next dev/network/browser 不要であることの確認
- 上記の実際の `next dev` reproduction は bounded temporary fixture
  （repo外、local Supabase不使用）で実施し、削除済み。

## Parallel lane coordination (#43)

PR作成前に fresh 確認: PR #46（Issue #43）は `state: OPEN`, `mergedAt: null`,
`headRefOid: 7e21ae6428ab835afa86f9e903eae2dc593d7e2e`（未マージ）。
`profiles/next-supabase/quality/README.md` の `## Blocking checks` /
`## \`verify\` への集約` section、および `test/fixtures/consumer/package.json`
の `verify:profile` は PR #46 も変更対象にしており、merge順序によっては
text conflict が発生し得る。architecture-level な衝突ではなく、両方とも
additive な command 追加（`agent-rules:check` / `supabase:migrations:check`）
なので、単純な rebase で解消可能と判断。

## Out of scope / not started

- #36 Phase 1、#45 の review completion fence確定は未着手・未依拠。
- stage-tracker working tree / product rules は変更していない。
- merge / Issue close / release は実施しない（authority外）。

## Authority

merge-ready で停止する。merge / Issue #40 close の authority はこの PR に
与えられていない。

---

## Update: review closure complete

5 rounds of independent review (Codex Automatic Review) took this PR from `313d36c` to `c4eb332`, fixing 9 findings and explicitly documenting 3 accepted-but-deferred limitations (all P2, all in the same bounded-by-design text-matching checker). Full durable review evidence, round-by-round disposition, and the stopping-loop rationale are recorded in [this PR comment](https://github.com/reitojike/ai-dev-foundation/pull/47#issuecomment-5380389808).

Final deterministic verify on `c4eb332` (47 tests / 8 guardrail fixtures / reference consumer `npm run verify`): green.

Merge-ready. No merge / Issue-close authority in this session.


---

## Update 2: rebased onto current main, re-adjudicated, fresh-reviewed

Rebased onto current main (`46d02e8`, post-#43/#45) via squash-merge (avoids repeated conflict resolution across the original 7 commits — additive overlap with #43's `supabase:migrations:check` resolved, both checks coexist in `verify:profile`). The 3 prior "accepted-but-deferred" findings were re-adjudicated under the current (post-#45) Resolution Contract — that category no longer exists — resulting in 2 false-positives (documented scope) and 1 accepted defect (spread-override, fixed). All 10 prior review threads replied-to and resolved.

Fresh review (Codex + `@claude`, per Issue #40's instruction to use GitHub-native Claude for Executable review) on the rebased target found and converged on 1 new finding (duplicate `agentRules` key override), fixed; a subsequent closure round surfaced 2 more minor findings (non-blocking message-specificity nit, and a false-positive edge case), both triaged and resolved.

Full durable record: [this PR comment](https://github.com/reitojike/ai-dev-foundation/pull/47#issuecomment-5383218720).

Final target: `10194e5d67e81cd73ae59b3e6bcfabc18476a5aa`. Deterministic verify green (86 tests, 85 pass / 1 pre-existing platform skip; guardrails; fixture `npm run verify` with both `agent-rules:check` and `supabase:migrations:check`). Unresolved review threads: 0 (fresh-confirmed).

Merge-ready. No merge / Issue-close authority in this session.


---

## Update 3: rebase resumption complete, merge-ready

Fully rebased onto current main and re-reviewed. Final target: `f39a034103ea04d91ed816718d8dd0d6a6a599a4`.

11 review rounds (Codex + `@claude`) on the rebased target found and fixed 7 accepted defects (including a verified config-file-selection-priority bug, cross-checked against actual Next.js 16.3.2 source) and documented 6 accepted, out-of-scope bounds (all variants of the same "this is a bounded text matcher, not a JS tokenizer" root cause, most fail-open direction but explicitly triaged). One prior evidence comment's classification was corrected mid-session (a comment-only, non-accepted-fix target move was mistakenly treated as exempt from fresh review; corrected by running fresh discovery on that exact target).

Full durable record: [this PR comment](https://github.com/reitojike/ai-dev-foundation/pull/47#issuecomment-5383500711).

Deterministic verify on `f39a034` (92 tests, 91 pass / 1 pre-existing platform skip; guardrails; fixture `npm run verify` with both `agent-rules:check` and `supabase:migrations:check`): green. Unresolved review threads: 0 (fresh-confirmed with pagination).

Merge-ready. No merge / Issue-close authority in this session.


---

## Update 4: Issue #40 design adjudication materialized, fresh merge-ready re-evaluation

`Update 3`時点の`merge-ready`自己申告は[revoked](https://github.com/reitojike/ai-dev-foundation/pull/47#issuecomment-5383574291)されました。Issue #40の[design adjudication checkpoint](https://github.com/reitojike/ai-dev-foundation/issues/40#issuecomment-5383573753)で確定した bounded proactive (`agent-rules:check`) + exact reactive (`foundation:check`) 二層contractを、`profiles/next-supabase/quality/README.md`（および`test/fixtures/consumer`側mirror）へ最小限materializeし、checker内のdangling reference（`module-level indirection note above`）をcomment-onlyで解消しました。ロジック変更なし。

`accepted-bound`という無効なResolution categoryを使った過去のdurable evidenceは、[このコメント](https://github.com/reitojike/ai-dev-foundation/pull/47#issuecomment-5383647217)で`false-positive` / resolved `technical-dispute`へ再分類しました。

Final target: `2ef7859e3527c0c747d1f0ab56175b866bbfc0da`。Deterministic verify green（92 tests, 91 pass / 1 pre-existing platform skip; guardrails; reference consumer fixture `npm run verify`）。このdeltaへのbounded review（新規full discoveryなし）: finding 0件。Unresolved review threads: 0。

Merge-ready（fresh再評価）。No merge / Issue-close / release authority in this session.
