### PR TITLE
merge-ready宣言前のasync review completion fenceを確立する (#45)

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -294,7 +294,10 @@ Resolution が完了している必要があります。discovery Resolution を
    review completion の blocker です。
    - consumer が configured automatic reviewer として明示している
    - 取得済み evidence が、その actor による review 行為をその review target 上で
-     識別させる
+     識別させる。**この判定は current target に限りません。** 同じ review flow の
+     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
+     actor は、以降の target でも expected member として残ります。target が移動
+     しただけで member から外してはいけません
 3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
    completion state が `unknown` であること自体は blocker にしません。ただし actual
    finding が観測された場合、その finding は Resolution Contract の対象です。
@@ -533,8 +536,8 @@ stopping rules を置き換えず、参照します。
 5. finding を Resolution Contract に従って triage する。ancestor target で発見された
    finding も対象とする。
 6. triage されていない finding が review surface 上に残っていないことを確認する。
-7. merge-ready は、**required ∪ expected の各 member の review obligation が
-   satisfied している**ことをもって成立する。
+7. merge-ready は、**expected review set の各 member（optional / advisory を含む）の
+   review obligation が satisfied している**ことをもって成立する。
 
 **review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
 判定対象です。
@@ -548,21 +551,35 @@ stopping rules を置き換えず、参照します。
   1. その member が既に出した finding の Resolution が完了していること（target
      completion state が `not-bound` / `declined` でも同じ）。
   2. target completion state が `completed@target` または `declined` であること。
-     **ただし、accepted fix による target 変更の後、Review stopping rules に従って
-     targeted closure で十分と判定され、その member について追加の discovery が不要と
-     判断される場合、この条件を要求しません。** この例外に依拠する場合は、どの
-     stopping rules 判断に基づくかを記録します。
+     **ただし、次をすべて満たす場合に限り、この条件を要求しません。**
+     - その member が、accepted fix の直前の target では `completed@target` であり、
+       target が移動したことだけによって `not-bound` になった
+     - その target 移動について、Review stopping rules に従い targeted closure で
+       十分と判定されている
+     - その member について、current target に対する run が in-flight でない
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
+
+この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
+義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
+義務は免除しません。** current target に対する run が observed で in-flight なら、
+terminal state（completed / failed / declined）に達するまで待ちます。一度も
+`completed@target` になっていない member へこの例外を適用してはいけません。
+この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
 state と、上記の記録された stopping rules 判断に基づきます。
 
-手順 7 は、**全 member が final target で completed であることを要求するものでは
-ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
-stopping rules に従います。targeted closure で十分と判定される bounded fix について、
-同じ reviewer による final target の full re-review を強制しません。
+expected member の target completion state が `failed`、または Failure / retry の
+bounded retry でも解消しない恒久的な `unknown` である場合、条件 2 の成立を無期限に
+待ちません。Failure / retry に従って escalate するか、Selection Contract を明示的に
+変更してその member の class を確定し直し、その判断と根拠を記録します。いずれの場合
+も、条件 1（既に出した finding の Resolution）は残ります。
+
+手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
+full re-review を新たに要求するものではありません。どこまで再 review が必要かは
+Review stopping rules に従い、上記の例外がその範囲を定めます。
 
 この fence の評価後、merge-ready を宣言する前に **review-relevant な state 変化**が
 あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化

--- a/policy/core.md
+++ b/policy/core.md
@@ -295,9 +295,19 @@ Resolution が完了している必要があります。discovery Resolution を
    - consumer が configured automatic reviewer として明示している
    - 取得済み evidence が、その actor による review 行為をその review target 上で
      識別させる
-3. **optional / advisory** — consumer が advisory と宣言した reviewer。completion
-   state が `unknown` であること自体は blocker にしません。ただし actual finding が
-   観測された場合、その finding は Resolution Contract の対象です。
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
+   completion state が `unknown` であること自体は blocker にしません。ただし actual
+   finding が観測された場合、その finding は Resolution Contract の対象です。
+
+一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
+observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
+review 行為を行っても optional のままです（その finding は Resolution Contract の対象
+です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
+
+consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
+するかは、その consumer の product rules、または当該 Task の Selection 記録に置きます。
+Kernel はこの宣言の置き場所を要求しますが、宣言のための schema / field / template を
+規定しません。
 
 2 の後者について、actor を expected member とする根拠は、その surface item 自体が
 **review participation として識別できる**ことです。review target 上に presence が
@@ -313,7 +323,14 @@ member とした根拠を記録すること**のみを要求し、provider 名�
 持ちません。
 
 reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、その reviewer を blocker にしません。
+表現してよく、**expected / optional の member についてはその reviewer を blocker に
+しません**。
+
+**required member は非参加の宣言によって blocker から外れません。** required とした
+reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
+代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
+まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
+gate を迂回する経路にしてはいけません。
 
 expected review set は、consumer が明示しておらず、かつその review target 上へまだ
 review participation evidence を出していない reviewer を含められません。この residual
@@ -413,20 +430,32 @@ recoverable な evidence として扱いません。record schema 自体（特�
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。
 
-**positive completion evidence は target-bound です。** ある reviewer の、確定した
-review target に対する completion state を `completed` とできるのは、取得済み surface
-item のうち、その target への resolvable な参照を持つ positive completion evidence が
-存在する場合に限ります。そのような evidence が無い場合、その reviewer のその target に
-対する state は `unknown` であり、`0 findings` へ変換してはいけません。
+**run record state と target completion state は別の対象です。** 上記の record schema の
+`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
+**ある reviewer が、確定した review target について現在どこまで完了しているか**を
+**target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
+`failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
+ancestor target に対する run は、run record としては `status: completed` かつ
+`validity: invalid` であり、同時にその reviewer の current target に対する target
+completion state は `not-bound` です。この 2 つは矛盾しません。
+
+**positive completion evidence は target-bound です。** ある reviewer の target
+completion state を `completed@target` とできるのは、取得済み surface item のうち、
+その target への resolvable な参照を持つ positive completion evidence が存在する場合に
+限ります。そのような evidence が無い場合、その state は `unknown`（または、reviewed
+target を確定できた上で一致しない場合は `not-bound`）であり、`0 findings` へ変換しては
+いけません。
 
 reviewed target を確定させる evidence には、**その review run が実際に review した
 target を安定して表す field / surface** を使います。review target の移動に追随して
 値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
 が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
-**binding の根拠を記録すること**のみを定めます。
+**binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
+場合、その binding は成立しておらず、target completion state は `unknown` です。**
 
-確定した reviewed target が expected target と一致しない completed run は、次の 2 軸で
-扱いを分けます。両者を混同してはいけません。
+target completion state が `not-bound` である reviewer（reviewed target が expected
+target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
+両者を混同してはいけません。
 
 - **evidence 軸**: その run を、current target の `0 findings` 主張や discovery
   evidence の根拠として使えません。
@@ -485,23 +514,48 @@ stopping rules を置き換えず、参照します。
 1. 確定した final candidate target を freeze する。
 2. Selection Contract に従って expected review set を閉じる。observed review
    participation は、この評価時点の fresh acquisition で判定する。
-3. set の各 member について、fresh acquisition で completion state を判定する。
+3. set の各 member について、fresh acquisition で target completion state を判定する。
    positive completion evidence が無い member を `0 findings` へ変換しない。
 4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
    帰属させる。
 5. finding を Resolution Contract に従って triage する。ancestor target で発見された
    finding も対象とする。
-6. unresolved review thread が 0 であることを確認する。
-7. merge-ready は、**required ∪ expected の各 member に課された review obligation が
-   Review stopping rules に従って satisfied している**ことをもって成立する。
+6. triage されていない finding が review surface 上に残っていないことを確認する。
+7. merge-ready は、**required ∪ expected の各 member の review obligation が
+   satisfied している**ことをもって成立する。
+
+**review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
+判定対象です。
+
+- **required member**: Selection Contract の required review 数を満たす valid な run が
+  揃っていること、およびその finding の Resolution が完了していること。非参加の宣言では
+  この obligation は解除されません（Selection Contract 参照）。
+- **expected member**: 次の両方。
+  1. その member が既に出した finding の Resolution が完了していること（target
+     completion state が `not-bound` でも同じ）。
+  2. その member の**不在または沈黙を、current target の `0 findings` / discovery
+     evidence として使っていない**こと。使う場合は target completion state が
+     `completed@target` である必要があります。使わない場合、target completion state が
+     `unknown` であること自体は blocker ではありません。
+- **optional / advisory member**: その member が既に出した finding の Resolution が
+  完了していること。target completion state は blocker ではありません。
 
 手順 7 は、**全 member が final target で completed であることを要求するものでは
 ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
 stopping rules に従います。targeted closure で十分と判定される bounded fix について、
 同じ reviewer による final target の full re-review を強制しません。
 
-この fence の評価後、merge-ready を宣言する前に review target または review surface の
-state が変化した場合、その fence 評価は無効となり、再評価します。
+この fence の評価後、merge-ready を宣言する前に **review-relevant な state 変化**が
+あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化
+とは、review target の変化、および expected review set の membership・target completion
+state・finding・Resolution 状態のいずれかを変えうる surface の変化です。review 意味を
+持たない surface の変化（通常の human comment 等）や、**agent 自身が本 Contract に従って
+persist する durable evidence の記録そのもの**は、review-relevant な変化に当たらず、
+fence を無効化しません。
+
+この再評価は無制限に繰り返しません。review-relevant な変化が繰り返し発生して fence が
+収束しない場合、その繰り返し自体を停止条件として扱い、Review stopping rules と同様に
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
 
 この fence は merge-ready の成立条件であり、merge を実行してよいという判断とは同義では
 ありません。merge execution authority は本節冒頭の分離に従います。

--- a/policy/core.md
+++ b/policy/core.md
@@ -339,8 +339,10 @@ reviewer が非参加を宣言した場合、その required review obligation �
 まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
 gate を迂回する経路にしてはいけません。
 
-expected review set は、consumer が明示しておらず、かつその review target 上へまだ
-review participation evidence を出していない reviewer を含められません。この residual
+expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
+target 上にも**まだ review participation evidence を出していない reviewer を含め
+られません。ancestor target で participation evidence を出している reviewer は、
+上記の carry-over により member です。この residual
 limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
 configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
 
@@ -552,10 +554,11 @@ stopping rules を置き換えず、参照します。
      completion state が `not-bound` / `declined` でも同じ）。
   2. target completion state が `completed@target` または `declined` であること。
      **ただし、次をすべて満たす場合に限り、この条件を要求しません。**
-     - その member が、accepted fix の直前の target では `completed@target` であり、
-       target が移動したことだけによって `not-bound` になった
-     - その target 移動について、Review stopping rules に従い targeted closure で
-       十分と判定されている
+     - その member が、この review flow のいずれかの target で `completed@target`
+       になっている
+     - その completion 以降の target 移動がすべて accepted fix によるものであり、
+       いずれも Review stopping rules に従い targeted closure で十分と判定されて
+       いる（連続する targeted closure を跨いでこの条件を辿れます）
      - その member について、current target に対する run が in-flight でない
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
@@ -563,9 +566,11 @@ stopping rules を置き換えず、参照します。
 この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
 義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
 義務は免除しません。** current target に対する run が observed で in-flight なら、
-terminal state（completed / failed / declined）に達するまで待ちます。一度も
-`completed@target` になっていない member へこの例外を適用してはいけません。
-この例外に依拠する場合、上記 3 点の充足を記録します。
+その run が terminate する（run record が `status` の終端値として確定する）まで
+待ちます。ここで待つ対象は run record state であり、target completion state では
+ありません。run が終端した結果 `validity: invalid` であっても、待機義務としては
+充足です。一度も `completed@target` になっていない member へこの例外を適用しては
+いけません。この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
@@ -576,6 +581,9 @@ bounded retry でも解消しない恒久的な `unknown` である場合、条�
 待ちません。Failure / retry に従って escalate するか、Selection Contract を明示的に
 変更してその member の class を確定し直し、その判断と根拠を記録します。いずれの場合
 も、条件 1（既に出した finding の Resolution）は残ります。
+この route を、条件 2 の gate を迂回する経路にしてはいけません。bounded retry を
+形だけ行って恒久 failure と宣言したり、待機を避けるために class を再宣言したりする
+ことは、この route の用途ではありません。
 
 手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
 full re-review を新たに要求するものではありません。どこまで再 review が必要かは

--- a/policy/core.md
+++ b/policy/core.md
@@ -323,8 +323,12 @@ member とした根拠を記録すること**のみを要求し、provider 名�
 持ちません。
 
 reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、**expected / optional の member についてはその reviewer を blocker に
-しません**。
+表現してよく、**expected / optional の member については、その reviewer の target
+completion state を理由に blocker としません**。
+
+**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
+discharge しません。** ancestor target で出した finding についても同じです。非参加の
+宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
 
 **required member は非参加の宣言によって blocker から外れません。** required とした
 reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
@@ -431,7 +435,9 @@ parser 0 件、status success のみを `no findings` へ変換してはいけ�
 completion evidence のない empty output は `unknown` として扱います。
 
 **run record state と target completion state は別の対象です。** 上記の record schema の
-`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
+`status` / `validity` は、**個々の review run** の状態を表します。`unknown` / `failure`
+の語は本 Contract 内で複数の対象について現れるため、どちらの対象について述べているかを
+必ず明示します。これとは別に、
 **ある reviewer が、確定した review target について現在どこまで完了しているか**を
 **target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
 `failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
@@ -452,6 +458,12 @@ target を安定して表す field / surface** を使います。review target �
 が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
 **binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
 場合、その binding は成立しておらず、target completion state は `unknown` です。**
+
+本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
+membership class とその根拠、target completion state とその binding の根拠、および
+current target の clean / discovery evidence として採用した run——は、個々の run record
+schema ではなく、その review stage の Selection / fence 記録として persist します。
+これらは run 単位ではなく reviewer 単位・stage 単位の情報であるためです。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -528,17 +540,24 @@ stopping rules を置き換えず、参照します。
 判定対象です。
 
 - **required member**: Selection Contract の required review 数を満たす valid な run が
-  揃っていること、およびその finding の Resolution が完了していること。非参加の宣言では
+  揃っていること、およびその finding の Resolution が完了していること。ここでの
+  `validity` は、**その run が属する review stage の expected target** に対して判定
+  します。必ずしも final target に対して判定するのではありません。非参加の宣言では
   この obligation は解除されません（Selection Contract 参照）。
 - **expected member**: 次の両方。
   1. その member が既に出した finding の Resolution が完了していること（target
-     completion state が `not-bound` でも同じ）。
-  2. その member の**不在または沈黙を、current target の `0 findings` / discovery
-     evidence として使っていない**こと。使う場合は target completion state が
-     `completed@target` である必要があります。使わない場合、target completion state が
-     `unknown` であること自体は blocker ではありません。
+     completion state が `not-bound` / `declined` でも同じ）。
+  2. target completion state が `completed@target` または `declined` であること。
+     **ただし、accepted fix による target 変更の後、Review stopping rules に従って
+     targeted closure で十分と判定され、その member について追加の discovery が不要と
+     判断される場合、この条件を要求しません。** この例外に依拠する場合は、どの
+     stopping rules 判断に基づくかを記録します。
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
+
+expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
+いない」等）で満たしたことにしてはいけません。判定は observable な target completion
+state と、上記の記録された stopping rules 判断に基づきます。
 
 手順 7 は、**全 member が final target で completed であることを要求するものでは
 ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
@@ -549,9 +568,10 @@ stopping rules に従います。targeted closure で十分と判定される bo
 あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化
 とは、review target の変化、および expected review set の membership・target completion
 state・finding・Resolution 状態のいずれかを変えうる surface の変化です。review 意味を
-持たない surface の変化（通常の human comment 等）や、**agent 自身が本 Contract に従って
-persist する durable evidence の記録そのもの**は、review-relevant な変化に当たらず、
-fence を無効化しません。
+持たない surface の変化（通常の human comment 等）や、**agent 自身が Review Protocol の
+各 Contract および本 fence に従って persist する durable evidence（acquisition record、
+triage / Resolution の記録、merge-ready report を含む）の記録そのもの**は、
+review-relevant な変化に当たらず、fence を無効化しません。
 
 この再評価は無制限に繰り返しません。review-relevant な変化が繰り返し発生して fence が
 収束しない場合、その繰り返し自体を停止条件として扱い、Review stopping rules と同様に

--- a/policy/core.md
+++ b/policy/core.md
@@ -278,8 +278,47 @@ Resolution が完了している必要があります。discovery Resolution を
 - artifact classification
 - reviewer / capability の選択
 - required review 数
+- expected review set（下記）
 - target artifact set
 - expected target SHA / commit range
+
+**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
+選択していなくても、その repository / review target に対して review を行う reviewer が
+存在し得ます。Selection では次の和集合を expected review set として確定します。
+
+1. **required** — Selection Contract で明示的に required とした reviewer。
+   required review 数を満たす対象であり、その review obligation は merge /
+   review completion の blocker です。
+2. **expected** — required ではないが、次のいずれかに該当する reviewer。
+   required review 数には算入しませんが、その review obligation は merge /
+   review completion の blocker です。
+   - consumer が configured automatic reviewer として明示している
+   - 取得済み evidence が、その actor による review 行為をその review target 上で
+     識別させる
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。completion
+   state が `unknown` であること自体は blocker にしません。ただし actual finding が
+   観測された場合、その finding は Resolution Contract の対象です。
+
+2 の後者について、actor を expected member とする根拠は、その surface item 自体が
+**review participation として識別できる**ことです。review target 上に presence が
+あるだけでは足りず、次は単独では expected member 化の根拠になりません。
+
+- 通常の human comment（議論・質問・進捗報告等）
+- CI actor（workflow / status / check の author であること）
+- review 以外の目的で投稿する bot
+
+どの surface item が review participation を構成するかの識別は Review Adapter
+boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
+member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
+持ちません。
+
+reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
+表現してよく、その reviewer を blocker にしません。
+
+expected review set は、consumer が明示しておらず、かつその review target 上へまだ
+review participation evidence を出していない reviewer を含められません。この residual
+limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
+configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
 
 #### Execution Contract
 
@@ -374,6 +413,26 @@ recoverable な evidence として扱いません。record schema 自体（特�
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。
 
+**positive completion evidence は target-bound です。** ある reviewer の、確定した
+review target に対する completion state を `completed` とできるのは、取得済み surface
+item のうち、その target への resolvable な参照を持つ positive completion evidence が
+存在する場合に限ります。そのような evidence が無い場合、その reviewer のその target に
+対する state は `unknown` であり、`0 findings` へ変換してはいけません。
+
+reviewed target を確定させる evidence には、**その review run が実際に review した
+target を安定して表す field / surface** を使います。review target の移動に追随して
+値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
+が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
+**binding の根拠を記録すること**のみを定めます。
+
+確定した reviewed target が expected target と一致しない completed run は、次の 2 軸で
+扱いを分けます。両者を混同してはいけません。
+
+- **evidence 軸**: その run を、current target の `0 findings` 主張や discovery
+  evidence の根拠として使えません。
+- **finding 軸**: その run で既に発見された finding は Resolution obligation として
+  残ります。review target が移動したことだけを理由に discharge されません。
+
 review run の状態は少なくとも `none` / `unknown` / `failure` を区別し、混同してはいけません。
 
 #### Resolution Contract
@@ -394,6 +453,9 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
   の finding（未解決の needs-verification / technical-dispute /
   intent-question 等を含む）が残る間は、その review stage の Resolution
   は完了せず、merge / review completion の根拠にしない
+- 確定した review target より前の target（ancestor）で発見された finding も
+  Resolution Contract の対象である。review target が移動したことだけを理由に
+  discharge されない
 
 ### Merge readiness and merge authority
 
@@ -415,6 +477,35 @@ merge authority が明示されていない場合、または別 authority の�
 ことを意味しません。GitHub の required approval 数を増やす rule でも
 ありません。provider や model 固有の rule にもしません。
 
+#### Merge-ready completion fence
+
+merge-ready を宣言する前に、次を最後の action として評価します。この fence は Review
+stopping rules を置き換えず、参照します。
+
+1. 確定した final candidate target を freeze する。
+2. Selection Contract に従って expected review set を閉じる。observed review
+   participation は、この評価時点の fresh acquisition で判定する。
+3. set の各 member について、fresh acquisition で completion state を判定する。
+   positive completion evidence が無い member を `0 findings` へ変換しない。
+4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
+   帰属させる。
+5. finding を Resolution Contract に従って triage する。ancestor target で発見された
+   finding も対象とする。
+6. unresolved review thread が 0 であることを確認する。
+7. merge-ready は、**required ∪ expected の各 member に課された review obligation が
+   Review stopping rules に従って satisfied している**ことをもって成立する。
+
+手順 7 は、**全 member が final target で completed であることを要求するものでは
+ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
+stopping rules に従います。targeted closure で十分と判定される bounded fix について、
+同じ reviewer による final target の full re-review を強制しません。
+
+この fence の評価後、merge-ready を宣言する前に review target または review surface の
+state が変化した場合、その fence 評価は無効となり、再評価します。
+
+この fence は merge-ready の成立条件であり、merge を実行してよいという判断とは同義では
+ありません。merge execution authority は本節冒頭の分離に従います。
+
 ### Review Adapter boundary
 
 provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
@@ -434,6 +525,16 @@ capability/profile の更新時に再検証可能にします。
 
 収集した evidence は、comment ID / review ID / run ID / timestamp / target SHA
 または commit range を可能な範囲で保持します。
+
+次の 2 つの識別も adapter の責務です。Kernel は要求だけを定め、判定材料を持ちません。
+
+- どの surface item が **review participation** を構成するか（Selection Contract の
+  expected review set 参照）
+- どの field / surface が **reviewed target を安定して表す**か、および、どれが review
+  target の移動に追随して値が変化するか（Acquisition & Validity Contract 参照）
+
+これらの判定材料は、恒久仕様ではなく再検証可能な observed evidence として
+capability/profile 側に置きます。
 
 ### Failure / retry
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -295,8 +295,9 @@ comment 本文の completion marker を fresh 再取得した上で直接確認�
 field の両方を持つことがあります。実測では、同一 finding について前者は投稿時の target を
 保持し続けた一方、後者は PR の head 移動後に新しい head の値へ変化していました。後者を
 binding の根拠にすると、ancestor target に対する review を current target の completion
-evidence と誤認します。binding には安定側の field を使い、どちらが安定かを確認できない
-場合は `unknown` として扱ってください。
+evidence と誤認します。この observation は、どちらの field を binding の根拠にしてよいかを
+判断するための材料です。binding の安定性要件と、安定性を確認できない場合の扱いは
+Acquisition & Validity Contract（`policy/core.md`）に従ってください。
 
 同じ実測で、次の 2 点も確認しています。いずれも provider の恒久仕様ではなく、
 capability/profile 側で再検証可能な observed evidence として扱います。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -62,6 +62,13 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
+   あわせて Selection Contract に従って expected review set を閉じます。自分が
+   trigger した reviewer だけを set に入れて終わりにせず、consumer が configured
+   automatic reviewer として明示しているもの、およびその review target 上に review
+   行為が識別できる actor を含めます。actor を expected member とした根拠（どの
+   surface item を review participation とみなしたか）を記録します。通常の human
+   comment、CI actor、review 以外の目的の bot を、presence だけを理由に expected
+   member 化しません。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -73,6 +80,19 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    は invalid として表現できます）。
    `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
    の定義に従って記録します。
+   ある reviewer をその target について `completed` とするには、取得済み surface
+   item のうち、その target への resolvable な参照を持つ positive completion
+   evidence が必要です。見つからない場合は `unknown` とし、`0 findings` へ変換
+   しません。
+   reviewed target を確定させるときは、その run が実際に review した target を
+   安定して表す field / surface を使います。review target の移動に追随して値が
+   変化する field / surface（例えば、現在の head を指すよう更新されるもの）を
+   binding の根拠にしてはいけません。どちらが安定かを確認できない場合、その
+   binding は成立しておらず `unknown` です。binding に使った根拠を記録します。
+   reviewed target が expected target と一致しない completed run は、evidence 軸と
+   finding 軸を分けて扱います。その run を current target の `0 findings` /
+   discovery evidence の根拠には使えませんが、その run で既に発見された finding は
+   Resolution obligation として残ります（手順 6）。
 6. **Required review gate & aggregate / triage** — Selection Contract で
    required とした review 数ぶんの `validity: valid` な run が揃うまで triage
    へ進みません。
@@ -83,6 +103,11 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    needs-verification / technical-dispute / intent-question）へ仕分けます。
    human escalation と technical dispute の扱い、重大 finding を dismiss する
    際の確認要否は Resolution Contract に従います。
+   finding の集約対象は valid な run に限りません。ancestor target に対する run の
+   ように `validity: valid` でない run であっても、そこで既に発見された finding は
+   Resolution Contract の対象です。`validity` は evidence 軸の判定であり、finding を
+   捨ててよい根拠ではありません。review target が移動したことだけを理由に、既存の
+   finding を discharge しません。
 7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding が
    あれば root-cause ごとにまとめて fix します。
    accepted finding が無ければ candidate SHA は変更されません。
@@ -192,6 +217,20 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     完了順序は
     問いません。
 
+    そのうえで、merge-ready を宣言する直前の最後の action として、
+    `policy/core.md` の Merge-ready completion fence を評価します。宣言の
+    直前に、expected review set を fresh acquisition で閉じ直し、各 member の
+    completion state を fresh に判定し、finding を安定 evidence 由来の
+    reviewed target へ帰属させ、unresolved review thread が 0 であることを
+    確認します。会話内で既に見た snapshot をこの判定の根拠にしません。
+    fence 評価と宣言の間に review target または review surface の state が
+    変化した場合、その fence 評価は無効です。再評価してから宣言します。
+    この fence は、全 member が final target で completed であることを要求
+    しません。要求するのは、各 member の review obligation が Review stopping
+    rules に従って satisfied していることです。targeted closure で十分と
+    判定される bounded fix について、同じ reviewer による final target の
+    full re-review を強制しません。
+
 ## Adapter boundary（manual pilot）
 
 provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()` /
@@ -253,6 +292,27 @@ wrapping job/step の conclusion 単独を completion または failure の根�
 comment 本文の completion marker を fresh 再取得した上で直接確認してください。これも
 特定 provider の恒久仕様ではなく、observed evidence として capability/profile 側で
 再検証可能な形で扱います。
+
+さらに別の観測として、inline/thread comment を持つ reviewer では、その comment が
+「実際に review された target」を表す field と、「現在の head」に追随して値が更新される
+field の両方を持つことがあります。実測では、同一 finding について前者は投稿時の target を
+保持し続けた一方、後者は PR の head 移動後に新しい head の値へ変化していました。後者を
+binding の根拠にすると、ancestor target に対する review を current target の completion
+evidence と誤認します。binding には安定側の field を使い、どちらが安定かを確認できない
+場合は `unknown` として扱ってください。
+
+同じ実測で、次の 2 点も確認しています。いずれも provider の恒久仕様ではなく、
+capability/profile 側で再検証可能な observed evidence として扱います。
+
+- ある automatic reviewer は、review 結果を comment 系 surface にのみ残し、
+  check/status surface を一切生成しませんでした。この reviewer について
+  check/status の有無を completion の根拠にはできません。
+- 別の reviewer は、`success` の commit status を出しながら、その description が
+  「automatic review は無効化されているため review をスキップした」ことを表して
+  いました。green な status が review 完了ではなく **review 未実施**を意味する
+  実例です。status の state だけを見て completion へ変換してはいけません。一方、
+  これは非参加を positive に宣言している evidence でもあるため、`unknown` とは
+  区別して扱えます。
 
 ## Manual review pilot
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -66,9 +66,11 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    set に入れて終わりにしません。membership の境界（何が member になり、presence
    だけでは何が member にならないか）と class ごとの扱いは Selection Contract
    （`policy/core.md`）が定めます。
-   この skill で行う実務は次です。review target 上の actor を fresh acquisition で
-   列挙し、各 actor をどの class としたか、および member とした場合はその根拠（どの
-   surface item を review participation とみなしたか）を記録します。
+   この skill で行う実務は次です。この review flow のいずれかの target 上に現れた
+   actor を fresh acquisition で列挙し（current target に限らず、ancestor target で
+   参加した actor も対象です）、各 actor をどの class としたか、および member と
+   した場合はその根拠（どの surface item を review participation とみなしたか）を
+   記録します。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -62,13 +62,13 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
-   あわせて Selection Contract に従って expected review set を閉じます。自分が
-   trigger した reviewer だけを set に入れて終わりにせず、consumer が configured
-   automatic reviewer として明示しているもの、およびその review target 上に review
-   行為が識別できる actor を含めます。actor を expected member とした根拠（どの
-   surface item を review participation とみなしたか）を記録します。通常の human
-   comment、CI actor、review 以外の目的の bot を、presence だけを理由に expected
-   member 化しません。
+   あわせて expected review set を確定します。自分が trigger した reviewer だけを
+   set に入れて終わりにしません。membership の境界（何が member になり、presence
+   だけでは何が member にならないか）と class ごとの扱いは Selection Contract
+   （`policy/core.md`）が定めます。
+   この skill で行う実務は次です。review target 上の actor を fresh acquisition で
+   列挙し、各 actor をどの class としたか、および member とした場合はその根拠（どの
+   surface item を review participation とみなしたか）を記録します。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -80,25 +80,21 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    は invalid として表現できます）。
    `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
    の定義に従って記録します。
-   ある reviewer をその target について `completed` とするには、取得済み surface
-   item のうち、その target への resolvable な参照を持つ positive completion
-   evidence が必要です。見つからない場合は `unknown` とし、`0 findings` へ変換
-   しません。
-   reviewed target を確定させるときは、その run が実際に review した target を
-   安定して表す field / surface を使います。review target の移動に追随して値が
-   変化する field / surface（例えば、現在の head を指すよう更新されるもの）を
-   binding の根拠にしてはいけません。どちらが安定かを確認できない場合、その
-   binding は成立しておらず `unknown` です。binding に使った根拠を記録します。
-   reviewed target が expected target と一致しない completed run は、evidence 軸と
-   finding 軸を分けて扱います。その run を current target の `0 findings` /
-   discovery evidence の根拠には使えませんが、その run で既に発見された finding は
-   Resolution obligation として残ります（手順 6）。
+   run record の `status` / `validity` とは別に、各 reviewer の target completion
+   state を Acquisition & Validity Contract に従って判定します。判定に使う positive
+   completion evidence の target-bound 要件、binding へ使う field / surface の安定性
+   要件、binding が成立しない場合の扱い、および `not-bound` な reviewer の evidence 軸 /
+   finding 軸の分離は、いずれも `policy/core.md` が定めます。
+   この skill で行う実務は次です。どの surface item を positive completion evidence と
+   したか、どの field / surface を安定と判断して binding の根拠にしたか、そしてその
+   判断を確認できたかどうかを記録します。安定性を必要な精度で確認できないまま binding が
+   成立したものとして扱わないでください。
 6. **Required review gate & aggregate / triage** — Selection Contract で
    required とした review 数ぶんの `validity: valid` な run が揃うまで triage
    へ進みません。
    揃わない run（invalid / unknown / failure）の扱いは Failure / retry
    （`policy/core.md`）に従います。
-   required 数の valid run が揃ったら、valid な run から finding を集約し、
+   required 数の valid run が揃ったら finding を集約し、
    Resolution Contract（`policy/core.md`）のカテゴリ（fix / false-positive /
    needs-verification / technical-dispute / intent-question）へ仕分けます。
    human escalation と technical dispute の扱い、重大 finding を dismiss する
@@ -138,7 +134,9 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    5. Selection で required とした review 数ぶんの valid run が揃うまで
       triage へ進みません。揃わない run の扱いは Failure / retry
       （`policy/core.md`）に従います。
-   6. valid な run の finding を Resolution Contract で triage します。
+   6. finding を Resolution Contract で triage します。手順 6 と同じく、
+      集約対象は valid な run に限りません。`validity: valid` でない run で
+      既に発見された finding も Resolution Contract の対象です。
    7. accepted finding があれば、手順 7 と同じ batch fix semantics で
       まとめて fix します。
    8. その fix によって target が変わった場合、手順 8 と同じ
@@ -218,18 +216,17 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     問いません。
 
     そのうえで、merge-ready を宣言する直前の最後の action として、
-    `policy/core.md` の Merge-ready completion fence を評価します。宣言の
-    直前に、expected review set を fresh acquisition で閉じ直し、各 member の
-    completion state を fresh に判定し、finding を安定 evidence 由来の
-    reviewed target へ帰属させ、unresolved review thread が 0 であることを
-    確認します。会話内で既に見た snapshot をこの判定の根拠にしません。
-    fence 評価と宣言の間に review target または review surface の state が
-    変化した場合、その fence 評価は無効です。再評価してから宣言します。
-    この fence は、全 member が final target で completed であることを要求
-    しません。要求するのは、各 member の review obligation が Review stopping
-    rules に従って satisfied していることです。targeted closure で十分と
-    判定される bounded fix について、同じ reviewer による final target の
-    full re-review を強制しません。
+    `policy/core.md` の Merge-ready completion fence を評価します。
+    merge-ready の成立条件、review obligation の定義、および
+    review-relevant な state 変化による fence の無効化は `policy/core.md`
+    が定めます。
+    この skill で行う実務は次です。宣言の直前に expected review set を
+    fresh acquisition で閉じ直し、各 member の target completion state を
+    fresh に判定し、finding を安定 evidence 由来の reviewed target へ
+    帰属させ、triage されていない finding が review surface 上に残って
+    いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
+    しません。provider が thread の resolution 状態を持つ場合は、その
+    surface も未 triage finding の確認に使えます。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -70,10 +70,12 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    ように `validity: valid` でない run であっても、そこで既に発見された finding は
    Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
    判定であり、finding を捨ててよい根拠ではありません。
-   ある reviewer をその target について `completed@target` とするには、その target
-   への resolvable な参照を持つ positive completion evidence が必要です。binding には
-   reviewed target を安定して表す field / surface を使い、review target の移動に
-   追随して値が変化するものを根拠にしません。
+   run record の `status` / `validity` とは別に、各 reviewer の target completion
+   state を判定します。positive completion evidence の target-bound 要件、binding へ
+   使う field / surface の安定性要件、および binding が成立しない場合の扱いは、
+   いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
+   この skill で行う実務は、どの surface item を positive completion evidence とし、
+   どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -25,8 +25,10 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    上で、markdown の形式チェック（lint / format / link 切れ等、repository
    が持つ機械的な check）を実行します。
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
-   range、target artifact set、reviewer / capability、required review 数を
-   確定します。
+   range、target artifact set、reviewer / capability、required review 数、
+   および expected review set を確定します。expected review set は自分が
+   trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
+   記録は Selection Contract（`policy/core.md`）に従います。
    手順 1 で記録した mechanical check 対象の target と、ここで確定する
    target が一致することを確認します。一致しない場合は、確定した target に
    対して手順 1 の mechanical check を再実行してから先へ進みます。
@@ -63,8 +65,15 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    な run が揃うまで triage へ進みません。
    揃わない run（invalid / unknown / failure）の扱いは Failure / retry
    （`policy/core.md`）に従います。
-   valid な run の finding だけを triage へ進めます。
-   invalid / unknown / failure な run の finding は triage に使用しません。
+   required 数の valid run が揃うことは triage へ進むための gate ですが、
+   finding の集約対象は valid な run に限りません。ancestor target に対する run の
+   ように `validity: valid` でない run であっても、そこで既に発見された finding は
+   Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
+   判定であり、finding を捨ててよい根拠ではありません。
+   ある reviewer をその target について `completed@target` とするには、その target
+   への resolvable な参照を持つ positive completion evidence が必要です。binding には
+   reviewed target を安定して表す field / surface を使い、review target の移動に
+   追随して値が変化するものを根拠にしません。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -106,6 +115,13 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    手順 7 の closure が行われなかった場合（accepted fix が無く target
    SHA / range も target artifact set も変更されていない場合）、この
    手順は不要です。
+9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
+   宣言する場合は、宣言の直前の最後の action として、Merge-ready completion
+   fence（`policy/core.md`）を評価します。会話内で既に見た snapshot をこの
+   判定の根拠にせず、expected review set と各 member の target completion
+   state を fresh acquisition で判定し直します。merge-ready の成立条件と、
+   review-relevant な state 変化による fence の無効化は `policy/core.md` に
+   従います。
 
 ## 停止条件
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -295,8 +295,9 @@ comment 本文の completion marker を fresh 再取得した上で直接確認�
 field の両方を持つことがあります。実測では、同一 finding について前者は投稿時の target を
 保持し続けた一方、後者は PR の head 移動後に新しい head の値へ変化していました。後者を
 binding の根拠にすると、ancestor target に対する review を current target の completion
-evidence と誤認します。binding には安定側の field を使い、どちらが安定かを確認できない
-場合は `unknown` として扱ってください。
+evidence と誤認します。この observation は、どちらの field を binding の根拠にしてよいかを
+判断するための材料です。binding の安定性要件と、安定性を確認できない場合の扱いは
+Acquisition & Validity Contract（`policy/core.md`）に従ってください。
 
 同じ実測で、次の 2 点も確認しています。いずれも provider の恒久仕様ではなく、
 capability/profile 側で再検証可能な observed evidence として扱います。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -62,6 +62,13 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
+   あわせて Selection Contract に従って expected review set を閉じます。自分が
+   trigger した reviewer だけを set に入れて終わりにせず、consumer が configured
+   automatic reviewer として明示しているもの、およびその review target 上に review
+   行為が識別できる actor を含めます。actor を expected member とした根拠（どの
+   surface item を review participation とみなしたか）を記録します。通常の human
+   comment、CI actor、review 以外の目的の bot を、presence だけを理由に expected
+   member 化しません。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -73,6 +80,19 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    は invalid として表現できます）。
    `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
    の定義に従って記録します。
+   ある reviewer をその target について `completed` とするには、取得済み surface
+   item のうち、その target への resolvable な参照を持つ positive completion
+   evidence が必要です。見つからない場合は `unknown` とし、`0 findings` へ変換
+   しません。
+   reviewed target を確定させるときは、その run が実際に review した target を
+   安定して表す field / surface を使います。review target の移動に追随して値が
+   変化する field / surface（例えば、現在の head を指すよう更新されるもの）を
+   binding の根拠にしてはいけません。どちらが安定かを確認できない場合、その
+   binding は成立しておらず `unknown` です。binding に使った根拠を記録します。
+   reviewed target が expected target と一致しない completed run は、evidence 軸と
+   finding 軸を分けて扱います。その run を current target の `0 findings` /
+   discovery evidence の根拠には使えませんが、その run で既に発見された finding は
+   Resolution obligation として残ります（手順 6）。
 6. **Required review gate & aggregate / triage** — Selection Contract で
    required とした review 数ぶんの `validity: valid` な run が揃うまで triage
    へ進みません。
@@ -83,6 +103,11 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    needs-verification / technical-dispute / intent-question）へ仕分けます。
    human escalation と technical dispute の扱い、重大 finding を dismiss する
    際の確認要否は Resolution Contract に従います。
+   finding の集約対象は valid な run に限りません。ancestor target に対する run の
+   ように `validity: valid` でない run であっても、そこで既に発見された finding は
+   Resolution Contract の対象です。`validity` は evidence 軸の判定であり、finding を
+   捨ててよい根拠ではありません。review target が移動したことだけを理由に、既存の
+   finding を discharge しません。
 7. **Batch fix + root-cause** — Resolution Contract に従い、accepted finding が
    あれば root-cause ごとにまとめて fix します。
    accepted finding が無ければ candidate SHA は変更されません。
@@ -192,6 +217,20 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     完了順序は
     問いません。
 
+    そのうえで、merge-ready を宣言する直前の最後の action として、
+    `policy/core.md` の Merge-ready completion fence を評価します。宣言の
+    直前に、expected review set を fresh acquisition で閉じ直し、各 member の
+    completion state を fresh に判定し、finding を安定 evidence 由来の
+    reviewed target へ帰属させ、unresolved review thread が 0 であることを
+    確認します。会話内で既に見た snapshot をこの判定の根拠にしません。
+    fence 評価と宣言の間に review target または review surface の state が
+    変化した場合、その fence 評価は無効です。再評価してから宣言します。
+    この fence は、全 member が final target で completed であることを要求
+    しません。要求するのは、各 member の review obligation が Review stopping
+    rules に従って satisfied していることです。targeted closure で十分と
+    判定される bounded fix について、同じ reviewer による final target の
+    full re-review を強制しません。
+
 ## Adapter boundary（manual pilot）
 
 provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()` /
@@ -253,6 +292,27 @@ wrapping job/step の conclusion 単独を completion または failure の根�
 comment 本文の completion marker を fresh 再取得した上で直接確認してください。これも
 特定 provider の恒久仕様ではなく、observed evidence として capability/profile 側で
 再検証可能な形で扱います。
+
+さらに別の観測として、inline/thread comment を持つ reviewer では、その comment が
+「実際に review された target」を表す field と、「現在の head」に追随して値が更新される
+field の両方を持つことがあります。実測では、同一 finding について前者は投稿時の target を
+保持し続けた一方、後者は PR の head 移動後に新しい head の値へ変化していました。後者を
+binding の根拠にすると、ancestor target に対する review を current target の completion
+evidence と誤認します。binding には安定側の field を使い、どちらが安定かを確認できない
+場合は `unknown` として扱ってください。
+
+同じ実測で、次の 2 点も確認しています。いずれも provider の恒久仕様ではなく、
+capability/profile 側で再検証可能な observed evidence として扱います。
+
+- ある automatic reviewer は、review 結果を comment 系 surface にのみ残し、
+  check/status surface を一切生成しませんでした。この reviewer について
+  check/status の有無を completion の根拠にはできません。
+- 別の reviewer は、`success` の commit status を出しながら、その description が
+  「automatic review は無効化されているため review をスキップした」ことを表して
+  いました。green な status が review 完了ではなく **review 未実施**を意味する
+  実例です。status の state だけを見て completion へ変換してはいけません。一方、
+  これは非参加を positive に宣言している evidence でもあるため、`unknown` とは
+  区別して扱えます。
 
 ## Manual review pilot
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -66,9 +66,11 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    set に入れて終わりにしません。membership の境界（何が member になり、presence
    だけでは何が member にならないか）と class ごとの扱いは Selection Contract
    （`policy/core.md`）が定めます。
-   この skill で行う実務は次です。review target 上の actor を fresh acquisition で
-   列挙し、各 actor をどの class としたか、および member とした場合はその根拠（どの
-   surface item を review participation とみなしたか）を記録します。
+   この skill で行う実務は次です。この review flow のいずれかの target 上に現れた
+   actor を fresh acquisition で列挙し（current target に限らず、ancestor target で
+   参加した actor も対象です）、各 actor をどの class としたか、および member と
+   した場合はその根拠（どの surface item を review participation とみなしたか）を
+   記録します。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -62,13 +62,13 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
-   あわせて Selection Contract に従って expected review set を閉じます。自分が
-   trigger した reviewer だけを set に入れて終わりにせず、consumer が configured
-   automatic reviewer として明示しているもの、およびその review target 上に review
-   行為が識別できる actor を含めます。actor を expected member とした根拠（どの
-   surface item を review participation とみなしたか）を記録します。通常の human
-   comment、CI actor、review 以外の目的の bot を、presence だけを理由に expected
-   member 化しません。
+   あわせて expected review set を確定します。自分が trigger した reviewer だけを
+   set に入れて終わりにしません。membership の境界（何が member になり、presence
+   だけでは何が member にならないか）と class ごとの扱いは Selection Contract
+   （`policy/core.md`）が定めます。
+   この skill で行う実務は次です。review target 上の actor を fresh acquisition で
+   列挙し、各 actor をどの class としたか、および member とした場合はその根拠（どの
+   surface item を review participation とみなしたか）を記録します。
 4. **Execution** — Execution Contract に従い、Selection で確定した expected
    target SHA / applicable な commit range と target artifact set を各
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -80,25 +80,21 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    は invalid として表現できます）。
    `none` / `unknown` / `failure` は completion / validity と混同せず、Contract
    の定義に従って記録します。
-   ある reviewer をその target について `completed` とするには、取得済み surface
-   item のうち、その target への resolvable な参照を持つ positive completion
-   evidence が必要です。見つからない場合は `unknown` とし、`0 findings` へ変換
-   しません。
-   reviewed target を確定させるときは、その run が実際に review した target を
-   安定して表す field / surface を使います。review target の移動に追随して値が
-   変化する field / surface（例えば、現在の head を指すよう更新されるもの）を
-   binding の根拠にしてはいけません。どちらが安定かを確認できない場合、その
-   binding は成立しておらず `unknown` です。binding に使った根拠を記録します。
-   reviewed target が expected target と一致しない completed run は、evidence 軸と
-   finding 軸を分けて扱います。その run を current target の `0 findings` /
-   discovery evidence の根拠には使えませんが、その run で既に発見された finding は
-   Resolution obligation として残ります（手順 6）。
+   run record の `status` / `validity` とは別に、各 reviewer の target completion
+   state を Acquisition & Validity Contract に従って判定します。判定に使う positive
+   completion evidence の target-bound 要件、binding へ使う field / surface の安定性
+   要件、binding が成立しない場合の扱い、および `not-bound` な reviewer の evidence 軸 /
+   finding 軸の分離は、いずれも `policy/core.md` が定めます。
+   この skill で行う実務は次です。どの surface item を positive completion evidence と
+   したか、どの field / surface を安定と判断して binding の根拠にしたか、そしてその
+   判断を確認できたかどうかを記録します。安定性を必要な精度で確認できないまま binding が
+   成立したものとして扱わないでください。
 6. **Required review gate & aggregate / triage** — Selection Contract で
    required とした review 数ぶんの `validity: valid` な run が揃うまで triage
    へ進みません。
    揃わない run（invalid / unknown / failure）の扱いは Failure / retry
    （`policy/core.md`）に従います。
-   required 数の valid run が揃ったら、valid な run から finding を集約し、
+   required 数の valid run が揃ったら finding を集約し、
    Resolution Contract（`policy/core.md`）のカテゴリ（fix / false-positive /
    needs-verification / technical-dispute / intent-question）へ仕分けます。
    human escalation と technical dispute の扱い、重大 finding を dismiss する
@@ -138,7 +134,9 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    5. Selection で required とした review 数ぶんの valid run が揃うまで
       triage へ進みません。揃わない run の扱いは Failure / retry
       （`policy/core.md`）に従います。
-   6. valid な run の finding を Resolution Contract で triage します。
+   6. finding を Resolution Contract で triage します。手順 6 と同じく、
+      集約対象は valid な run に限りません。`validity: valid` でない run で
+      既に発見された finding も Resolution Contract の対象です。
    7. accepted finding があれば、手順 7 と同じ batch fix semantics で
       まとめて fix します。
    8. その fix によって target が変わった場合、手順 8 と同じ
@@ -218,18 +216,17 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     問いません。
 
     そのうえで、merge-ready を宣言する直前の最後の action として、
-    `policy/core.md` の Merge-ready completion fence を評価します。宣言の
-    直前に、expected review set を fresh acquisition で閉じ直し、各 member の
-    completion state を fresh に判定し、finding を安定 evidence 由来の
-    reviewed target へ帰属させ、unresolved review thread が 0 であることを
-    確認します。会話内で既に見た snapshot をこの判定の根拠にしません。
-    fence 評価と宣言の間に review target または review surface の state が
-    変化した場合、その fence 評価は無効です。再評価してから宣言します。
-    この fence は、全 member が final target で completed であることを要求
-    しません。要求するのは、各 member の review obligation が Review stopping
-    rules に従って satisfied していることです。targeted closure で十分と
-    判定される bounded fix について、同じ reviewer による final target の
-    full re-review を強制しません。
+    `policy/core.md` の Merge-ready completion fence を評価します。
+    merge-ready の成立条件、review obligation の定義、および
+    review-relevant な state 変化による fence の無効化は `policy/core.md`
+    が定めます。
+    この skill で行う実務は次です。宣言の直前に expected review set を
+    fresh acquisition で閉じ直し、各 member の target completion state を
+    fresh に判定し、finding を安定 evidence 由来の reviewed target へ
+    帰属させ、triage されていない finding が review surface 上に残って
+    いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
+    しません。provider が thread の resolution 状態を持つ場合は、その
+    surface も未 triage finding の確認に使えます。
 
 ## Adapter boundary（manual pilot）
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -70,10 +70,12 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    ように `validity: valid` でない run であっても、そこで既に発見された finding は
    Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
    判定であり、finding を捨ててよい根拠ではありません。
-   ある reviewer をその target について `completed@target` とするには、その target
-   への resolvable な参照を持つ positive completion evidence が必要です。binding には
-   reviewed target を安定して表す field / surface を使い、review target の移動に
-   追随して値が変化するものを根拠にしません。
+   run record の `status` / `validity` とは別に、各 reviewer の target completion
+   state を判定します。positive completion evidence の target-bound 要件、binding へ
+   使う field / surface の安定性要件、および binding が成立しない場合の扱いは、
+   いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
+   この skill で行う実務は、どの surface item を positive completion evidence とし、
+   どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -25,8 +25,10 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    上で、markdown の形式チェック（lint / format / link 切れ等、repository
    が持つ機械的な check）を実行します。
 2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
-   range、target artifact set、reviewer / capability、required review 数を
-   確定します。
+   range、target artifact set、reviewer / capability、required review 数、
+   および expected review set を確定します。expected review set は自分が
+   trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
+   記録は Selection Contract（`policy/core.md`）に従います。
    手順 1 で記録した mechanical check 対象の target と、ここで確定する
    target が一致することを確認します。一致しない場合は、確定した target に
    対して手順 1 の mechanical check を再実行してから先へ進みます。
@@ -63,8 +65,15 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    な run が揃うまで triage へ進みません。
    揃わない run（invalid / unknown / failure）の扱いは Failure / retry
    （`policy/core.md`）に従います。
-   valid な run の finding だけを triage へ進めます。
-   invalid / unknown / failure な run の finding は triage に使用しません。
+   required 数の valid run が揃うことは triage へ進むための gate ですが、
+   finding の集約対象は valid な run に限りません。ancestor target に対する run の
+   ように `validity: valid` でない run であっても、そこで既に発見された finding は
+   Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
+   判定であり、finding を捨ててよい根拠ではありません。
+   ある reviewer をその target について `completed@target` とするには、その target
+   への resolvable な参照を持つ positive completion evidence が必要です。binding には
+   reviewed target を安定して表す field / surface を使い、review target の移動に
+   追随して値が変化するものを根拠にしません。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -106,6 +115,13 @@ Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 
    手順 7 の closure が行われなかった場合（accepted fix が無く target
    SHA / range も target artifact set も変更されていない場合）、この
    手順は不要です。
+9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
+   宣言する場合は、宣言の直前の最後の action として、Merge-ready completion
+   fence（`policy/core.md`）を評価します。会話内で既に見た snapshot をこの
+   判定の根拠にせず、expected review set と各 member の target completion
+   state を fresh acquisition で判定し直します。merge-ready の成立条件と、
+   review-relevant な state 変化による fence の無効化は `policy/core.md` に
+   従います。
 
 ## 停止条件
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -331,8 +331,12 @@ member とした根拠を記録すること**のみを要求し、provider 名�
 持ちません。
 
 reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、**expected / optional の member についてはその reviewer を blocker に
-しません**。
+表現してよく、**expected / optional の member については、その reviewer の target
+completion state を理由に blocker としません**。
+
+**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
+discharge しません。** ancestor target で出した finding についても同じです。非参加の
+宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
 
 **required member は非参加の宣言によって blocker から外れません。** required とした
 reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
@@ -439,7 +443,9 @@ parser 0 件、status success のみを `no findings` へ変換してはいけ�
 completion evidence のない empty output は `unknown` として扱います。
 
 **run record state と target completion state は別の対象です。** 上記の record schema の
-`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
+`status` / `validity` は、**個々の review run** の状態を表します。`unknown` / `failure`
+の語は本 Contract 内で複数の対象について現れるため、どちらの対象について述べているかを
+必ず明示します。これとは別に、
 **ある reviewer が、確定した review target について現在どこまで完了しているか**を
 **target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
 `failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
@@ -460,6 +466,12 @@ target を安定して表す field / surface** を使います。review target �
 が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
 **binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
 場合、その binding は成立しておらず、target completion state は `unknown` です。**
+
+本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
+membership class とその根拠、target completion state とその binding の根拠、および
+current target の clean / discovery evidence として採用した run——は、個々の run record
+schema ではなく、その review stage の Selection / fence 記録として persist します。
+これらは run 単位ではなく reviewer 単位・stage 単位の情報であるためです。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -536,17 +548,24 @@ stopping rules を置き換えず、参照します。
 判定対象です。
 
 - **required member**: Selection Contract の required review 数を満たす valid な run が
-  揃っていること、およびその finding の Resolution が完了していること。非参加の宣言では
+  揃っていること、およびその finding の Resolution が完了していること。ここでの
+  `validity` は、**その run が属する review stage の expected target** に対して判定
+  します。必ずしも final target に対して判定するのではありません。非参加の宣言では
   この obligation は解除されません（Selection Contract 参照）。
 - **expected member**: 次の両方。
   1. その member が既に出した finding の Resolution が完了していること（target
-     completion state が `not-bound` でも同じ）。
-  2. その member の**不在または沈黙を、current target の `0 findings` / discovery
-     evidence として使っていない**こと。使う場合は target completion state が
-     `completed@target` である必要があります。使わない場合、target completion state が
-     `unknown` であること自体は blocker ではありません。
+     completion state が `not-bound` / `declined` でも同じ）。
+  2. target completion state が `completed@target` または `declined` であること。
+     **ただし、accepted fix による target 変更の後、Review stopping rules に従って
+     targeted closure で十分と判定され、その member について追加の discovery が不要と
+     判断される場合、この条件を要求しません。** この例外に依拠する場合は、どの
+     stopping rules 判断に基づくかを記録します。
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
+
+expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
+いない」等）で満たしたことにしてはいけません。判定は observable な target completion
+state と、上記の記録された stopping rules 判断に基づきます。
 
 手順 7 は、**全 member が final target で completed であることを要求するものでは
 ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
@@ -557,9 +576,10 @@ stopping rules に従います。targeted closure で十分と判定される bo
 あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化
 とは、review target の変化、および expected review set の membership・target completion
 state・finding・Resolution 状態のいずれかを変えうる surface の変化です。review 意味を
-持たない surface の変化（通常の human comment 等）や、**agent 自身が本 Contract に従って
-persist する durable evidence の記録そのもの**は、review-relevant な変化に当たらず、
-fence を無効化しません。
+持たない surface の変化（通常の human comment 等）や、**agent 自身が Review Protocol の
+各 Contract および本 fence に従って persist する durable evidence（acquisition record、
+triage / Resolution の記録、merge-ready report を含む）の記録そのもの**は、
+review-relevant な変化に当たらず、fence を無効化しません。
 
 この再評価は無制限に繰り返しません。review-relevant な変化が繰り返し発生して fence が
 収束しない場合、その繰り返し自体を停止条件として扱い、Review stopping rules と同様に

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -302,7 +302,10 @@ Resolution が完了している必要があります。discovery Resolution を
    review completion の blocker です。
    - consumer が configured automatic reviewer として明示している
    - 取得済み evidence が、その actor による review 行為をその review target 上で
-     識別させる
+     識別させる。**この判定は current target に限りません。** 同じ review flow の
+     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
+     actor は、以降の target でも expected member として残ります。target が移動
+     しただけで member から外してはいけません
 3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
    completion state が `unknown` であること自体は blocker にしません。ただし actual
    finding が観測された場合、その finding は Resolution Contract の対象です。
@@ -541,8 +544,8 @@ stopping rules を置き換えず、参照します。
 5. finding を Resolution Contract に従って triage する。ancestor target で発見された
    finding も対象とする。
 6. triage されていない finding が review surface 上に残っていないことを確認する。
-7. merge-ready は、**required ∪ expected の各 member の review obligation が
-   satisfied している**ことをもって成立する。
+7. merge-ready は、**expected review set の各 member（optional / advisory を含む）の
+   review obligation が satisfied している**ことをもって成立する。
 
 **review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
 判定対象です。
@@ -556,21 +559,35 @@ stopping rules を置き換えず、参照します。
   1. その member が既に出した finding の Resolution が完了していること（target
      completion state が `not-bound` / `declined` でも同じ）。
   2. target completion state が `completed@target` または `declined` であること。
-     **ただし、accepted fix による target 変更の後、Review stopping rules に従って
-     targeted closure で十分と判定され、その member について追加の discovery が不要と
-     判断される場合、この条件を要求しません。** この例外に依拠する場合は、どの
-     stopping rules 判断に基づくかを記録します。
+     **ただし、次をすべて満たす場合に限り、この条件を要求しません。**
+     - その member が、accepted fix の直前の target では `completed@target` であり、
+       target が移動したことだけによって `not-bound` になった
+     - その target 移動について、Review stopping rules に従い targeted closure で
+       十分と判定されている
+     - その member について、current target に対する run が in-flight でない
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
+
+この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
+義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
+義務は免除しません。** current target に対する run が observed で in-flight なら、
+terminal state（completed / failed / declined）に達するまで待ちます。一度も
+`completed@target` になっていない member へこの例外を適用してはいけません。
+この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
 state と、上記の記録された stopping rules 判断に基づきます。
 
-手順 7 は、**全 member が final target で completed であることを要求するものでは
-ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
-stopping rules に従います。targeted closure で十分と判定される bounded fix について、
-同じ reviewer による final target の full re-review を強制しません。
+expected member の target completion state が `failed`、または Failure / retry の
+bounded retry でも解消しない恒久的な `unknown` である場合、条件 2 の成立を無期限に
+待ちません。Failure / retry に従って escalate するか、Selection Contract を明示的に
+変更してその member の class を確定し直し、その判断と根拠を記録します。いずれの場合
+も、条件 1（既に出した finding の Resolution）は残ります。
+
+手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
+full re-review を新たに要求するものではありません。どこまで再 review が必要かは
+Review stopping rules に従い、上記の例外がその範囲を定めます。
 
 この fence の評価後、merge-ready を宣言する前に **review-relevant な state 変化**が
 あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -303,9 +303,19 @@ Resolution が完了している必要があります。discovery Resolution を
    - consumer が configured automatic reviewer として明示している
    - 取得済み evidence が、その actor による review 行為をその review target 上で
      識別させる
-3. **optional / advisory** — consumer が advisory と宣言した reviewer。completion
-   state が `unknown` であること自体は blocker にしません。ただし actual finding が
-   観測された場合、その finding は Resolution Contract の対象です。
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
+   completion state が `unknown` であること自体は blocker にしません。ただし actual
+   finding が観測された場合、その finding は Resolution Contract の対象です。
+
+一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
+observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
+review 行為を行っても optional のままです（その finding は Resolution Contract の対象
+です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
+
+consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
+するかは、その consumer の product rules、または当該 Task の Selection 記録に置きます。
+Kernel はこの宣言の置き場所を要求しますが、宣言のための schema / field / template を
+規定しません。
 
 2 の後者について、actor を expected member とする根拠は、その surface item 自体が
 **review participation として識別できる**ことです。review target 上に presence が
@@ -321,7 +331,14 @@ member とした根拠を記録すること**のみを要求し、provider 名�
 持ちません。
 
 reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、その reviewer を blocker にしません。
+表現してよく、**expected / optional の member についてはその reviewer を blocker に
+しません**。
+
+**required member は非参加の宣言によって blocker から外れません。** required とした
+reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
+代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
+まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
+gate を迂回する経路にしてはいけません。
 
 expected review set は、consumer が明示しておらず、かつその review target 上へまだ
 review participation evidence を出していない reviewer を含められません。この residual
@@ -421,20 +438,32 @@ recoverable な evidence として扱いません。record schema 自体（特�
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。
 
-**positive completion evidence は target-bound です。** ある reviewer の、確定した
-review target に対する completion state を `completed` とできるのは、取得済み surface
-item のうち、その target への resolvable な参照を持つ positive completion evidence が
-存在する場合に限ります。そのような evidence が無い場合、その reviewer のその target に
-対する state は `unknown` であり、`0 findings` へ変換してはいけません。
+**run record state と target completion state は別の対象です。** 上記の record schema の
+`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
+**ある reviewer が、確定した review target について現在どこまで完了しているか**を
+**target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
+`failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
+ancestor target に対する run は、run record としては `status: completed` かつ
+`validity: invalid` であり、同時にその reviewer の current target に対する target
+completion state は `not-bound` です。この 2 つは矛盾しません。
+
+**positive completion evidence は target-bound です。** ある reviewer の target
+completion state を `completed@target` とできるのは、取得済み surface item のうち、
+その target への resolvable な参照を持つ positive completion evidence が存在する場合に
+限ります。そのような evidence が無い場合、その state は `unknown`（または、reviewed
+target を確定できた上で一致しない場合は `not-bound`）であり、`0 findings` へ変換しては
+いけません。
 
 reviewed target を確定させる evidence には、**その review run が実際に review した
 target を安定して表す field / surface** を使います。review target の移動に追随して
 値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
 が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
-**binding の根拠を記録すること**のみを定めます。
+**binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
+場合、その binding は成立しておらず、target completion state は `unknown` です。**
 
-確定した reviewed target が expected target と一致しない completed run は、次の 2 軸で
-扱いを分けます。両者を混同してはいけません。
+target completion state が `not-bound` である reviewer（reviewed target が expected
+target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
+両者を混同してはいけません。
 
 - **evidence 軸**: その run を、current target の `0 findings` 主張や discovery
   evidence の根拠として使えません。
@@ -493,23 +522,48 @@ stopping rules を置き換えず、参照します。
 1. 確定した final candidate target を freeze する。
 2. Selection Contract に従って expected review set を閉じる。observed review
    participation は、この評価時点の fresh acquisition で判定する。
-3. set の各 member について、fresh acquisition で completion state を判定する。
+3. set の各 member について、fresh acquisition で target completion state を判定する。
    positive completion evidence が無い member を `0 findings` へ変換しない。
 4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
    帰属させる。
 5. finding を Resolution Contract に従って triage する。ancestor target で発見された
    finding も対象とする。
-6. unresolved review thread が 0 であることを確認する。
-7. merge-ready は、**required ∪ expected の各 member に課された review obligation が
-   Review stopping rules に従って satisfied している**ことをもって成立する。
+6. triage されていない finding が review surface 上に残っていないことを確認する。
+7. merge-ready は、**required ∪ expected の各 member の review obligation が
+   satisfied している**ことをもって成立する。
+
+**review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
+判定対象です。
+
+- **required member**: Selection Contract の required review 数を満たす valid な run が
+  揃っていること、およびその finding の Resolution が完了していること。非参加の宣言では
+  この obligation は解除されません（Selection Contract 参照）。
+- **expected member**: 次の両方。
+  1. その member が既に出した finding の Resolution が完了していること（target
+     completion state が `not-bound` でも同じ）。
+  2. その member の**不在または沈黙を、current target の `0 findings` / discovery
+     evidence として使っていない**こと。使う場合は target completion state が
+     `completed@target` である必要があります。使わない場合、target completion state が
+     `unknown` であること自体は blocker ではありません。
+- **optional / advisory member**: その member が既に出した finding の Resolution が
+  完了していること。target completion state は blocker ではありません。
 
 手順 7 は、**全 member が final target で completed であることを要求するものでは
 ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
 stopping rules に従います。targeted closure で十分と判定される bounded fix について、
 同じ reviewer による final target の full re-review を強制しません。
 
-この fence の評価後、merge-ready を宣言する前に review target または review surface の
-state が変化した場合、その fence 評価は無効となり、再評価します。
+この fence の評価後、merge-ready を宣言する前に **review-relevant な state 変化**が
+あった場合、その fence 評価は無効となり、再評価します。review-relevant な state 変化
+とは、review target の変化、および expected review set の membership・target completion
+state・finding・Resolution 状態のいずれかを変えうる surface の変化です。review 意味を
+持たない surface の変化（通常の human comment 等）や、**agent 自身が本 Contract に従って
+persist する durable evidence の記録そのもの**は、review-relevant な変化に当たらず、
+fence を無効化しません。
+
+この再評価は無制限に繰り返しません。review-relevant な変化が繰り返し発生して fence が
+収束しない場合、その繰り返し自体を停止条件として扱い、Review stopping rules と同様に
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
 
 この fence は merge-ready の成立条件であり、merge を実行してよいという判断とは同義では
 ありません。merge execution authority は本節冒頭の分離に従います。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -286,8 +286,47 @@ Resolution が完了している必要があります。discovery Resolution を
 - artifact classification
 - reviewer / capability の選択
 - required review 数
+- expected review set（下記）
 - target artifact set
 - expected target SHA / commit range
+
+**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
+選択していなくても、その repository / review target に対して review を行う reviewer が
+存在し得ます。Selection では次の和集合を expected review set として確定します。
+
+1. **required** — Selection Contract で明示的に required とした reviewer。
+   required review 数を満たす対象であり、その review obligation は merge /
+   review completion の blocker です。
+2. **expected** — required ではないが、次のいずれかに該当する reviewer。
+   required review 数には算入しませんが、その review obligation は merge /
+   review completion の blocker です。
+   - consumer が configured automatic reviewer として明示している
+   - 取得済み evidence が、その actor による review 行為をその review target 上で
+     識別させる
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。completion
+   state が `unknown` であること自体は blocker にしません。ただし actual finding が
+   観測された場合、その finding は Resolution Contract の対象です。
+
+2 の後者について、actor を expected member とする根拠は、その surface item 自体が
+**review participation として識別できる**ことです。review target 上に presence が
+あるだけでは足りず、次は単独では expected member 化の根拠になりません。
+
+- 通常の human comment（議論・質問・進捗報告等）
+- CI actor（workflow / status / check の author であること）
+- review 以外の目的で投稿する bot
+
+どの surface item が review participation を構成するかの識別は Review Adapter
+boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
+member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
+持ちません。
+
+reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
+表現してよく、その reviewer を blocker にしません。
+
+expected review set は、consumer が明示しておらず、かつその review target 上へまだ
+review participation evidence を出していない reviewer を含められません。この residual
+limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
+configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
 
 #### Execution Contract
 
@@ -382,6 +421,26 @@ recoverable な evidence として扱いません。record schema 自体（特�
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
 completion evidence のない empty output は `unknown` として扱います。
 
+**positive completion evidence は target-bound です。** ある reviewer の、確定した
+review target に対する completion state を `completed` とできるのは、取得済み surface
+item のうち、その target への resolvable な参照を持つ positive completion evidence が
+存在する場合に限ります。そのような evidence が無い場合、その reviewer のその target に
+対する state は `unknown` であり、`0 findings` へ変換してはいけません。
+
+reviewed target を確定させる evidence には、**その review run が実際に review した
+target を安定して表す field / surface** を使います。review target の移動に追随して
+値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
+が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
+**binding の根拠を記録すること**のみを定めます。
+
+確定した reviewed target が expected target と一致しない completed run は、次の 2 軸で
+扱いを分けます。両者を混同してはいけません。
+
+- **evidence 軸**: その run を、current target の `0 findings` 主張や discovery
+  evidence の根拠として使えません。
+- **finding 軸**: その run で既に発見された finding は Resolution obligation として
+  残ります。review target が移動したことだけを理由に discharge されません。
+
 review run の状態は少なくとも `none` / `unknown` / `failure` を区別し、混同してはいけません。
 
 #### Resolution Contract
@@ -402,6 +461,9 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
   の finding（未解決の needs-verification / technical-dispute /
   intent-question 等を含む）が残る間は、その review stage の Resolution
   は完了せず、merge / review completion の根拠にしない
+- 確定した review target より前の target（ancestor）で発見された finding も
+  Resolution Contract の対象である。review target が移動したことだけを理由に
+  discharge されない
 
 ### Merge readiness and merge authority
 
@@ -423,6 +485,35 @@ merge authority が明示されていない場合、または別 authority の�
 ことを意味しません。GitHub の required approval 数を増やす rule でも
 ありません。provider や model 固有の rule にもしません。
 
+#### Merge-ready completion fence
+
+merge-ready を宣言する前に、次を最後の action として評価します。この fence は Review
+stopping rules を置き換えず、参照します。
+
+1. 確定した final candidate target を freeze する。
+2. Selection Contract に従って expected review set を閉じる。observed review
+   participation は、この評価時点の fresh acquisition で判定する。
+3. set の各 member について、fresh acquisition で completion state を判定する。
+   positive completion evidence が無い member を `0 findings` へ変換しない。
+4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
+   帰属させる。
+5. finding を Resolution Contract に従って triage する。ancestor target で発見された
+   finding も対象とする。
+6. unresolved review thread が 0 であることを確認する。
+7. merge-ready は、**required ∪ expected の各 member に課された review obligation が
+   Review stopping rules に従って satisfied している**ことをもって成立する。
+
+手順 7 は、**全 member が final target で completed であることを要求するものでは
+ありません**。accepted fix による target 変更後にどこまで再 review が必要かは Review
+stopping rules に従います。targeted closure で十分と判定される bounded fix について、
+同じ reviewer による final target の full re-review を強制しません。
+
+この fence の評価後、merge-ready を宣言する前に review target または review surface の
+state が変化した場合、その fence 評価は無効となり、再評価します。
+
+この fence は merge-ready の成立条件であり、merge を実行してよいという判断とは同義では
+ありません。merge execution authority は本節冒頭の分離に従います。
+
 ### Review Adapter boundary
 
 provider 差分は次の 4 つの責務として扱います。Kernel はこの boundary の**形**のみを
@@ -442,6 +533,16 @@ capability/profile の更新時に再検証可能にします。
 
 収集した evidence は、comment ID / review ID / run ID / timestamp / target SHA
 または commit range を可能な範囲で保持します。
+
+次の 2 つの識別も adapter の責務です。Kernel は要求だけを定め、判定材料を持ちません。
+
+- どの surface item が **review participation** を構成するか（Selection Contract の
+  expected review set 参照）
+- どの field / surface が **reviewed target を安定して表す**か、および、どれが review
+  target の移動に追随して値が変化するか（Acquisition & Validity Contract 参照）
+
+これらの判定材料は、恒久仕様ではなく再検証可能な observed evidence として
+capability/profile 側に置きます。
 
 ### Failure / retry
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -347,8 +347,10 @@ reviewer が非参加を宣言した場合、その required review obligation �
 まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
 gate を迂回する経路にしてはいけません。
 
-expected review set は、consumer が明示しておらず、かつその review target 上へまだ
-review participation evidence を出していない reviewer を含められません。この residual
+expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
+target 上にも**まだ review participation evidence を出していない reviewer を含め
+られません。ancestor target で participation evidence を出している reviewer は、
+上記の carry-over により member です。この residual
 limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
 configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
 
@@ -560,10 +562,11 @@ stopping rules を置き換えず、参照します。
      completion state が `not-bound` / `declined` でも同じ）。
   2. target completion state が `completed@target` または `declined` であること。
      **ただし、次をすべて満たす場合に限り、この条件を要求しません。**
-     - その member が、accepted fix の直前の target では `completed@target` であり、
-       target が移動したことだけによって `not-bound` になった
-     - その target 移動について、Review stopping rules に従い targeted closure で
-       十分と判定されている
+     - その member が、この review flow のいずれかの target で `completed@target`
+       になっている
+     - その completion 以降の target 移動がすべて accepted fix によるものであり、
+       いずれも Review stopping rules に従い targeted closure で十分と判定されて
+       いる（連続する targeted closure を跨いでこの条件を辿れます）
      - その member について、current target に対する run が in-flight でない
 - **optional / advisory member**: その member が既に出した finding の Resolution が
   完了していること。target completion state は blocker ではありません。
@@ -571,9 +574,11 @@ stopping rules を置き換えず、参照します。
 この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
 義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
 義務は免除しません。** current target に対する run が observed で in-flight なら、
-terminal state（completed / failed / declined）に達するまで待ちます。一度も
-`completed@target` になっていない member へこの例外を適用してはいけません。
-この例外に依拠する場合、上記 3 点の充足を記録します。
+その run が terminate する（run record が `status` の終端値として確定する）まで
+待ちます。ここで待つ対象は run record state であり、target completion state では
+ありません。run が終端した結果 `validity: invalid` であっても、待機義務としては
+充足です。一度も `completed@target` になっていない member へこの例外を適用しては
+いけません。この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
@@ -584,6 +589,9 @@ bounded retry でも解消しない恒久的な `unknown` である場合、条�
 待ちません。Failure / retry に従って escalate するか、Selection Contract を明示的に
 変更してその member の class を確定し直し、その判断と根拠を記録します。いずれの場合
 も、条件 1（既に出した finding の Resolution）は残ります。
+この route を、条件 2 の gate を迂回する経路にしてはいけません。bounded retry を
+形だけ行って恒久 failure と宣言したり、待機を避けるために class を再宣言したりする
+ことは、この route の用途ではありません。
 
 手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
 full re-review を新たに要求するものではありません。どこまで再 review が必要かは

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -33,9 +33,11 @@ function containsText(haystack, needle) {
 //   R3 two axes. A run whose reviewed target != final target is unusable as
 //      clean/discovery evidence (evidence axis) but its findings survive
 //      (finding axis).
-//   R4 merge-ready = every required|expected member's review obligation is
-//      satisfied, where the obligation is the one policy/core.md defines per
-//      class. NOT "every member completed at the final target".
+//   R4 merge-ready = EVERY member of the expected review set — including
+//      optional/advisory — has its review obligation satisfied, where the
+//      obligation is the one policy/core.md defines per class. This does not
+//      demand a fresh full re-review at every accepted fix; the narrow
+//      post-fix exception defines that boundary.
 //   R5 optional members: `unknown` alone does not block; observed findings do.
 //   R6 a required member cannot be exempted by declaring non-participation.
 // ---------------------------------------------------------------------------
@@ -90,12 +92,18 @@ function outstandingFindings(member, runs, finalTarget) {
 /**
  * Evaluate the fence. Returns { mergeReady, blockers[] }.
  *
- * Every gate below is derived from observable inputs (runs, findings, declared
- * class, declared non-participation). The one judgement input,
- * `boundedClosureSufficient`, mirrors the single exception policy/core.md
- * grants: a Review stopping rules decision that targeted closure suffices after
- * an accepted fix moved the target. Policy requires that decision to be
- * recorded, so it is an input rather than an unstated agent intention.
+ * Gates are derived from observable inputs (runs, findings, declared class,
+ * declared non-participation) wherever the state is representable. Two inputs
+ * remain judgements rather than derivations, and both are ones policy/core.md
+ * requires the agent to RECORD, so neither is an unstated intention:
+ *   - `boundedClosureSufficient` — the Review stopping rules decision that
+ *     targeted closure suffices for every target move since the member's
+ *     completion.
+ *   - `runInFlightAtCurrentTarget` — whether a run is still running; not
+ *     derivable from a terminal-run list.
+ * `completedAtPreFixTarget` is NOT an input: whether the member ever reached
+ * `completed@target` is derivable from its runs, and deriving it is what makes
+ * the precondition falsifiable.
  */
 function evaluateFence({ finalTarget, actors, runs, findingsRequireTriage = true }) {
   const blockers = [];
@@ -114,12 +122,18 @@ function evaluateFence({ finalTarget, actors, runs, findingsRequireTriage = true
       if (untriaged.length > 0) blockers.push(`untriaged-finding:${member.name}:${untriaged.length}`);
     }
 
-    const bound = runs.filter((r) => r.actor === member.name).some((r) => isTargetBoundEvidence(r, finalTarget));
+    const memberRuns = runs.filter((r) => r.actor === member.name);
+    const bound = memberRuns.some((r) => isTargetBoundEvidence(r, finalTarget));
 
     if (member.cls === "required") {
-      // R6: non-participation does not exempt a required member. Only a valid
-      // run, or an explicit Selection change, discharges the obligation.
-      if (!bound && !member.selectionChangedToDropRequired) {
+      // A required run's validity is judged against the expected target of the
+      // review STAGE it belongs to — not against the final target. Comparing
+      // to finalTarget here would demand a re-review at every accepted fix,
+      // the opposite of what the stopping rules allow.
+      const validForItsStage = memberRuns.some((r) =>
+        isTargetBoundEvidence(r, r.stageTarget ?? finalTarget),
+      );
+      if (!validForItsStage && !member.selectionChangedToDropRequired) {
         blockers.push(`required-run-missing:${member.name}`);
       }
       continue;
@@ -132,9 +146,14 @@ function evaluateFence({ finalTarget, actors, runs, findingsRequireTriage = true
     // requires ALL of its preconditions — it is not a free pass. Note this
     // branch is reached only for `expected`; `required` returned above, so the
     // exception can never discharge a required obligation.
+    // Derived, not supplied: did this member ever reach `completed@target` at
+    // some target in this flow? A member that never completed can never claim
+    // the exception, however the stopping-rules decision was recorded.
+    const everCompleted = memberRuns.some((r) => isTargetBoundEvidence(r, r.reviewedTarget));
+
     const exceptionApplies =
       member.boundedClosureSufficient === true &&
-      member.completedAtPreFixTarget === true && // never completed => no exception
+      everCompleted && // never completed => no exception
       member.runInFlightAtCurrentTarget !== true; // must await a terminal state
 
     if (!bound && !member.declinedParticipation && !exceptionApplies) {
@@ -283,13 +302,12 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
         name: "auto-reviewer",
         participation: "review",
         boundedClosureSufficient: true,
-        completedAtPreFixTarget: true, // it HAD completed at 354187da
       },
     ],
     runs: [
       {
         actor: "auto-reviewer",
-        reviewedTarget: "354187da", // never re-ran at the final head
+        reviewedTarget: "354187da", // completed here; never re-ran at the head
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
         findings: [{ id: "P1", resolved: true }],
@@ -313,34 +331,69 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
 });
 
 test("the post-fix exception requires every one of its preconditions", () => {
-  // Closure round found the exception was over-broad in two independent ways:
-  // it could exempt a member that had never completed at all, and it could
-  // exempt waiting for a run already in flight at the current target.
-  const base = {
-    finalTarget: "6800b796",
-    actors: [
-      {
-        name: "auto-reviewer",
-        participation: "review",
-        boundedClosureSufficient: true,
-        completedAtPreFixTarget: true,
-      },
-    ],
-    runs: [],
-  };
-  assert.equal(evaluateFence(base).mergeReady, true, "all preconditions met");
+  // The exception was over-broad in two independent ways: it could exempt a
+  // member that had never completed at all, and it could exempt waiting for a
+  // run already in flight at the current target.
+  //
+  // Both routes into the `expected` class are exercised. Keying only on
+  // observed participation left per-precondition mutations scoped to
+  // `declaredAutomatic` members alive — and a declared automatic reviewer is
+  // exactly the actor shape of the PR #51 incident.
+  for (const route of [{ participation: "review" }, { declaredAutomatic: true }]) {
+    const label = JSON.stringify(route);
+    const priorCompletion = {
+      actor: "auto-reviewer",
+      reviewedTarget: "354187da", // completed at an earlier target in this flow
+      reviewedTargetIsStable: true,
+      positiveCompletionEvidence: true,
+      findings: [],
+    };
+    const base = {
+      finalTarget: "6800b796",
+      actors: [{ name: "auto-reviewer", ...route, boundedClosureSufficient: true }],
+      runs: [priorCompletion],
+    };
+    assert.equal(evaluateFence(base).mergeReady, true, `all preconditions met ${label}`);
 
-  // (a) never completed before the fix => the exception must not apply, or the
-  // member's initial completion obligation is bypassed entirely.
-  const neverCompleted = structuredClone(base);
-  neverCompleted.actors[0].completedAtPreFixTarget = false;
-  assert.deepEqual(evaluateFence(neverCompleted).blockers, ["unknown-completion:auto-reviewer"]);
+    // (a) never completed anywhere in this flow => the exception must not
+    // apply, or the member's initial completion obligation is bypassed.
+    const neverCompleted = structuredClone(base);
+    neverCompleted.runs = [];
+    assert.deepEqual(
+      evaluateFence(neverCompleted).blockers,
+      ["unknown-completion:auto-reviewer"],
+      `never-completed must not get the exception ${label}`,
+    );
 
-  // (b) a run is in flight at the current target => must await a terminal
-  // state. Exempting here is exactly the PR #51 late-arrival failure mode.
-  const inFlight = structuredClone(base);
-  inFlight.actors[0].runInFlightAtCurrentTarget = true;
-  assert.deepEqual(evaluateFence(inFlight).blockers, ["unknown-completion:auto-reviewer"]);
+    // (a') completed, but only per an unstable (head-following) field => the
+    // completion was never established, so the exception must not apply.
+    const unstable = structuredClone(base);
+    unstable.runs[0].reviewedTargetIsStable = false;
+    assert.deepEqual(
+      evaluateFence(unstable).blockers,
+      ["unknown-completion:auto-reviewer"],
+      `unstable binding must not establish the prior completion ${label}`,
+    );
+
+    // (b) a run is in flight at the current target => must await it. Exempting
+    // here is exactly the PR #51 late-arrival failure mode.
+    const inFlight = structuredClone(base);
+    inFlight.actors[0].runInFlightAtCurrentTarget = true;
+    assert.deepEqual(
+      evaluateFence(inFlight).blockers,
+      ["unknown-completion:auto-reviewer"],
+      `in-flight run must be awaited ${label}`,
+    );
+
+    // (c) no recorded stopping-rules decision => not the default.
+    const noDecision = structuredClone(base);
+    delete noDecision.actors[0].boundedClosureSufficient;
+    assert.deepEqual(
+      evaluateFence(noDecision).blockers,
+      ["unknown-completion:auto-reviewer"],
+      `the exception must be claimed explicitly ${label}`,
+    );
+  }
 });
 
 test("the post-fix exception can never discharge a required member", () => {
@@ -354,12 +407,45 @@ test("the post-fix exception can never discharge a required member", () => {
         name: "required-reviewer",
         declaredRequired: true,
         boundedClosureSufficient: true,
-        completedAtPreFixTarget: true,
       },
     ],
     runs: [],
   };
   assert.deepEqual(evaluateFence(scenario).blockers, ["required-run-missing:required-reviewer"]);
+});
+
+test("a required run stays valid against its own stage target after the head moves", () => {
+  // policy/core.md judges a required run's validity against the expected
+  // target of the stage it belongs to, NOT the final target. Comparing to the
+  // final target would demand a fresh required run at every accepted fix —
+  // the opposite of what the stopping rules allow, and the shape of this very
+  // PR (independent discovery at an earlier target, closure at the head).
+  const scenario = {
+    finalTarget: "46fc0ea",
+    actors: [{ name: "independent-reviewer", declaredRequired: true }],
+    runs: [
+      {
+        actor: "independent-reviewer",
+        reviewedTarget: "e11ee55",
+        stageTarget: "e11ee55", // the discovery stage's expected target
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "F1", resolved: true, triage: "fix" }],
+      },
+    ],
+  };
+  assert.deepEqual(
+    evaluateFence(scenario).blockers,
+    [],
+    "a discovery-stage run must not be invalidated by a later closure target",
+  );
+
+  // But a run that was not valid even for its own stage still blocks.
+  const invalidForStage = structuredClone(scenario);
+  invalidForStage.runs[0].stageTarget = "some-other-target";
+  assert.deepEqual(evaluateFence(invalidForStage).blockers, [
+    "required-run-missing:independent-reviewer",
+  ]);
 });
 
 test("an optional member's unresolved finding blocks merge-ready via step 7", () => {
@@ -771,19 +857,40 @@ test("core policy defines the merge-ready completion fence without overriding st
   // The exception must be narrow: all three preconditions, and it must not
   // exempt awaiting an in-flight run or a member's first completion.
   assert.ok(containsText(core, "**ただし、次をすべて満たす場合に限り、この条件を要求しません。**"));
+  // The exception must compose across successive bounded target moves, or a
+  // second targeted closure silently loses it and forces a full re-review.
   assert.ok(
-    containsText(core, "target が移動したことだけによって `not-bound` になった"),
+    containsText(core, "その member が、この review flow のいずれかの target で `completed@target` になっている"),
   );
+  assert.ok(
+    containsText(core, "その completion 以降の target 移動がすべて accepted fix によるものであり"),
+  );
+  assert.ok(containsText(core, "連続する targeted closure を跨いでこの条件を辿れます"));
   assert.ok(containsText(core, "current target に対する run が in-flight でない"));
   assert.ok(
     containsText(core, "**既に走っている run の終端を待つ義務と、その member の初回 completion 義務は免除しません。**"),
   );
   assert.ok(containsText(core, "一度も `completed@target` になっていない member へこの例外を適用してはいけません"));
 
-  // A permanently failed/unknown expected member must have a stated exit.
+  // A permanently failed/unknown expected member must have a stated exit —
+  // carrying the same anti-bypass guard its required-member sibling has.
   assert.ok(containsText(core, "条件 2 の成立を無期限に待ちません"));
   assert.ok(
     containsText(core, "Selection Contract を明示的に変更してその member の class を確定し直し"),
+  );
+  assert.ok(containsText(core, "この route を、条件 2 の gate を迂回する経路にしてはいけません"));
+
+  // The wait is on run-record state, not target completion state — the policy
+  // forbids using one vocabulary for both objects.
+  assert.ok(containsText(core, "ここで待つ対象は run record state であり、target completion state ではありません"));
+
+  // The residual-limitation sentence must not re-assert current-target-only
+  // membership after the carry-over rule above it.
+  assert.ok(
+    containsText(core, "**この review flow のいずれの target 上にも**まだ review participation evidence を出していない reviewer"),
+  );
+  assert.ok(
+    containsText(core, "ancestor target で participation evidence を出している reviewer は、上記の carry-over により member です"),
   );
   assert.ok(
     containsText(core, "agent の内心の申告（「この member の沈黙には依拠していない」等）で満たしたことにしてはいけません"),

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -128,9 +128,16 @@ function evaluateFence({ finalTarget, actors, runs, findingsRequireTriage = true
     if (member.cls === "optional") continue; // R5: state is never a blocker
 
     // expected (R4): the target completion state must be `completed@target` or
-    // `declined`. The sole exception is a recorded stopping-rules decision that
-    // targeted closure suffices after an accepted fix moved the target.
-    if (!bound && !member.declinedParticipation && !member.boundedClosureSufficient) {
+    // `declined`. The sole exception is the narrow post-fix carry-over, and it
+    // requires ALL of its preconditions — it is not a free pass. Note this
+    // branch is reached only for `expected`; `required` returned above, so the
+    // exception can never discharge a required obligation.
+    const exceptionApplies =
+      member.boundedClosureSufficient === true &&
+      member.completedAtPreFixTarget === true && // never completed => no exception
+      member.runInFlightAtCurrentTarget !== true; // must await a terminal state
+
+    if (!bound && !member.declinedParticipation && !exceptionApplies) {
       blockers.push(`unknown-completion:${member.name}`);
     }
   }
@@ -271,7 +278,14 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
   // its silence is not being used as clean evidence for the new head.
   const scenario = {
     finalTarget: "6800b796", // post-fix head
-    actors: [{ name: "auto-reviewer", participation: "review", boundedClosureSufficient: true }],
+    actors: [
+      {
+        name: "auto-reviewer",
+        participation: "review",
+        boundedClosureSufficient: true,
+        completedAtPreFixTarget: true, // it HAD completed at 354187da
+      },
+    ],
     runs: [
       {
         actor: "auto-reviewer",
@@ -296,6 +310,112 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
   const noDecision = structuredClone(scenario);
   delete noDecision.actors[0].boundedClosureSufficient;
   assert.deepEqual(evaluateFence(noDecision).blockers, ["unknown-completion:auto-reviewer"]);
+});
+
+test("the post-fix exception requires every one of its preconditions", () => {
+  // Closure round found the exception was over-broad in two independent ways:
+  // it could exempt a member that had never completed at all, and it could
+  // exempt waiting for a run already in flight at the current target.
+  const base = {
+    finalTarget: "6800b796",
+    actors: [
+      {
+        name: "auto-reviewer",
+        participation: "review",
+        boundedClosureSufficient: true,
+        completedAtPreFixTarget: true,
+      },
+    ],
+    runs: [],
+  };
+  assert.equal(evaluateFence(base).mergeReady, true, "all preconditions met");
+
+  // (a) never completed before the fix => the exception must not apply, or the
+  // member's initial completion obligation is bypassed entirely.
+  const neverCompleted = structuredClone(base);
+  neverCompleted.actors[0].completedAtPreFixTarget = false;
+  assert.deepEqual(evaluateFence(neverCompleted).blockers, ["unknown-completion:auto-reviewer"]);
+
+  // (b) a run is in flight at the current target => must await a terminal
+  // state. Exempting here is exactly the PR #51 late-arrival failure mode.
+  const inFlight = structuredClone(base);
+  inFlight.actors[0].runInFlightAtCurrentTarget = true;
+  assert.deepEqual(evaluateFence(inFlight).blockers, ["unknown-completion:auto-reviewer"]);
+});
+
+test("the post-fix exception can never discharge a required member", () => {
+  // The exception lives in the `expected` bullet only. An implementation that
+  // honoured it in the required branch would let a required reviewer be
+  // exempted without a valid run or an explicit Selection change.
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [
+      {
+        name: "required-reviewer",
+        declaredRequired: true,
+        boundedClosureSufficient: true,
+        completedAtPreFixTarget: true,
+      },
+    ],
+    runs: [],
+  };
+  assert.deepEqual(evaluateFence(scenario).blockers, ["required-run-missing:required-reviewer"]);
+});
+
+test("an optional member's unresolved finding blocks merge-ready via step 7", () => {
+  // Step 7 must evaluate the whole expected review set. Scoping it to
+  // `required ∪ expected` would leave the optional member's Resolution
+  // obligation defined but never applied.
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [{ name: "advisory-bot", declaredAdvisory: true }],
+    runs: [
+      {
+        actor: "advisory-bot",
+        reviewedTarget: "abc1234",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "P3", resolved: false, triage: "needs-verification" }],
+      },
+    ],
+  };
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "a triaged-but-unresolved optional finding still blocks");
+  assert.deepEqual(blockers, ["unresolved-finding:advisory-bot:1"]);
+});
+
+test("expected membership survives a target move (ancestor-only participation)", () => {
+  // Closure round: keying membership off the *current* target would drop a
+  // reviewer that only ever participated on an ancestor, and its ancestor
+  // findings would escape collection — reopening the PR #42 failure mode.
+  const ancestorOnly = {
+    name: "auto-reviewer",
+    participation: "review",
+    participationTargets: ["354187da"], // never reappeared at the final target
+  };
+  assert.equal(
+    classifyActor(ancestorOnly),
+    "expected",
+    "an ancestor-only participant remains an expected member",
+  );
+
+  const scenario = {
+    finalTarget: "6800b796",
+    actors: [ancestorOnly],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "354187da",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "P1", resolved: false, triage: "fix" }],
+      },
+    ],
+  };
+  assert.ok(
+    evaluateFence(scenario).blockers.includes("unresolved-finding:auto-reviewer:1"),
+    "the ancestor finding must still be collected after the target moved",
+  );
 });
 
 test("regression 4: optional reviewer — unknown does not block, findings do", () => {
@@ -486,6 +606,13 @@ test("core policy states the expected review set closure rule", async () => {
   assert.ok(
     containsText(core, "取得済み evidence が、その actor による review 行為をその review target 上で識別させる"),
   );
+  // Membership must carry across target moves within the same review flow,
+  // or an ancestor-only participant silently leaves the set.
+  assert.ok(containsText(core, "**この判定は current target に限りません。**"));
+  assert.ok(
+    containsText(core, "ancestor target を含むいずれかの target 上で review 行為を識別できた actor は、以降の target でも expected member として残ります"),
+  );
+  assert.ok(containsText(core, "target が移動しただけで member から外してはいけません"));
 
   // Presence alone must not promote an actor.
   assert.ok(containsText(core, "review participation として識別できる"));
@@ -613,10 +740,22 @@ test("core policy defines the merge-ready completion fence without overriding st
   assert.ok(containsText(core, "triage されていない finding が review surface 上に残っていないことを確認する"));
   assert.ok(!core.includes("unresolved review thread"), "the Kernel must not name a provider thread concept");
 
-  // R4: obligation satisfaction, NOT universal completion at the final target.
-  assert.ok(containsText(core, "各 member の review obligation が satisfied している"));
-  assert.ok(containsText(core, "全 member が final target で completed であることを要求するものではありません"));
-  assert.ok(containsText(core, "同じ reviewer による final target の full re-review を強制しません"));
+  // R4: obligation satisfaction. Step 7 must span the WHOLE expected review
+  // set — scoping it to `required ∪ expected` would leave the optional
+  // member's Resolution obligation defined but never evaluated.
+  assert.ok(
+    containsText(core, "**expected review set の各 member（optional / advisory を含む）の review obligation が satisfied している**"),
+  );
+  // The R2 carve-out must remain true when read standalone: it is about not
+  // demanding a NEW full re-review per target move, not about waiving the
+  // default condition.
+  assert.ok(
+    containsText(
+      core,
+      "accepted fix による target 変更のたびに、全 member へ final target の full re-review を新たに要求するものではありません",
+    ),
+  );
+  assert.ok(containsText(core, "上記の例外がその範囲を定めます"));
 
   // The obligation must actually be defined, per class — otherwise step 7 is
   // circular and two agents can read it opposite ways.
@@ -629,11 +768,22 @@ test("core policy defines the merge-ready completion fence without overriding st
   assert.ok(
     containsText(core, "target completion state が `completed@target` または `declined` であること"),
   );
+  // The exception must be narrow: all three preconditions, and it must not
+  // exempt awaiting an in-flight run or a member's first completion.
+  assert.ok(containsText(core, "**ただし、次をすべて満たす場合に限り、この条件を要求しません。**"));
   assert.ok(
-    containsText(
-      core,
-      "targeted closure で十分と判定され、その member について追加の discovery が不要と判断される場合、この条件を要求しません",
-    ),
+    containsText(core, "target が移動したことだけによって `not-bound` になった"),
+  );
+  assert.ok(containsText(core, "current target に対する run が in-flight でない"));
+  assert.ok(
+    containsText(core, "**既に走っている run の終端を待つ義務と、その member の初回 completion 義務は免除しません。**"),
+  );
+  assert.ok(containsText(core, "一度も `completed@target` になっていない member へこの例外を適用してはいけません"));
+
+  // A permanently failed/unknown expected member must have a stated exit.
+  assert.ok(containsText(core, "条件 2 の成立を無期限に待ちません"));
+  assert.ok(
+    containsText(core, "Selection Contract を明示的に変更してその member の class を確定し直し"),
   );
   assert.ok(
     containsText(core, "agent の内心の申告（「この member の沈黙には依拠していない」等）で満たしたことにしてはいけません"),

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -1,0 +1,487 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+// ---------------------------------------------------------------------------
+// Decision model
+//
+// This is a TEST-ONLY executable encoding of the Merge-ready completion fence
+// (policy/core.md, Merge readiness and merge authority). It is not a production
+// mechanism and nothing in tooling/ depends on it. Its purpose is to prove that
+// the normative rules, as written, produce the intended verdict for the failure
+// modes recorded in Issue #45 — rather than asserting only that certain prose
+// exists.
+//
+// The rules encoded here, and only these:
+//   R1 expected review set = required | expected(declared or observed review
+//      participation) | optional. Presence alone never promotes an actor.
+//   R2 positive completion evidence is target-bound; absent it, state is
+//      `unknown` and never `0 findings`.
+//   R3 a run whose reviewed target != final target is unusable as clean/discovery
+//      evidence (evidence axis) but its findings survive (finding axis).
+//   R4 merge-ready = every required|expected member's review obligation is
+//      satisfied per Review stopping rules. NOT "every member completed at the
+//      final target".
+//   R5 optional members: `unknown` alone does not block; observed findings do.
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify an actor observed on the review target.
+ * `participation` is what the adapter identified the surface item as.
+ */
+function classifyActor(actor) {
+  if (actor.declaredRequired) return "required";
+  if (actor.declaredAutomatic) return "expected";
+  if (actor.declaredAdvisory) return "optional";
+  // Observed-participant closure: only review participation promotes an actor.
+  if (actor.participation === "review") return "expected";
+  return "not-a-member";
+}
+
+/** Is this run usable as clean/discovery evidence for `finalTarget`? (R2, R3) */
+function isTargetBoundEvidence(run, finalTarget) {
+  if (!run.positiveCompletionEvidence) return false;
+  // Binding must come from a field that stably represents the reviewed target.
+  if (!run.reviewedTargetIsStable) return false;
+  return run.reviewedTarget === finalTarget;
+}
+
+/**
+ * Evaluate the fence.
+ * Returns { mergeReady, blockers[] }.
+ */
+function evaluateFence({ finalTarget, actors, runs, findings, unresolvedThreads = 0 }) {
+  const blockers = [];
+  const members = [];
+
+  for (const actor of actors) {
+    const cls = classifyActor(actor);
+    if (cls !== "not-a-member") members.push({ ...actor, cls });
+  }
+
+  for (const member of members) {
+    const memberRuns = runs.filter((r) => r.actor === member.name);
+    const bound = memberRuns.find((r) => isTargetBoundEvidence(r, finalTarget));
+
+    // Finding axis (R3): findings survive regardless of which target produced
+    // them, and regardless of the run's validity.
+    const openFindings = findings.filter((f) => f.actor === member.name && !f.resolved);
+    if (openFindings.length > 0) {
+      blockers.push(`unresolved-finding:${member.name}:${openFindings.length}`);
+    }
+
+    if (member.cls === "optional") continue; // R5: unknown alone does not block
+
+    // Evidence axis (R2/R3): only a target-bound run may back a `0 findings`
+    // claim. Absent one, the member's state is `unknown`.
+    if (!bound) {
+      // R4: an unknown state only blocks where the obligation actually requires
+      // fresh evidence at the final target. Review stopping rules say a bounded
+      // accepted-fix closure does not re-require full discovery at the head.
+      if (member.obligationSatisfiedByStoppingRules) continue;
+      blockers.push(`unknown-completion:${member.name}`);
+    }
+  }
+
+  if (unresolvedThreads > 0) blockers.push(`unresolved-threads:${unresolvedThreads}`);
+
+  return { mergeReady: blockers.length === 0, blockers };
+}
+
+// ---------------------------------------------------------------------------
+// Regression proofs — the five scenarios required by Issue #45.
+// ---------------------------------------------------------------------------
+
+// Shapes taken from the real incident recorded in Issue #45: an automatic
+// reviewer produced a P1 on 354187da while the frozen final target was c2b99f69.
+test("regression 1: PR #42 type — ancestor-target finding blocks merge-ready", () => {
+  const scenario = {
+    finalTarget: "c2b99f69",
+    actors: [{ name: "auto-reviewer", participation: "review" }],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "354187da", // ancestor, not the final target
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+      },
+    ],
+    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: false }],
+  };
+
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "ancestor finding must block merge-ready");
+  assert.ok(
+    blockers.includes("unresolved-finding:auto-reviewer:1"),
+    `finding axis must survive the target move: ${blockers.join(", ")}`,
+  );
+
+  // The evidence axis must ALSO reject the ancestor run as clean evidence.
+  assert.equal(
+    isTargetBoundEvidence(scenario.runs[0], scenario.finalTarget),
+    false,
+    "a run on an ancestor target is not clean evidence for the final target",
+  );
+
+  // Resolving the finding is what clears it — not the head having moved.
+  const resolved = {
+    ...scenario,
+    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: true }],
+    actors: [{ name: "auto-reviewer", participation: "review", obligationSatisfiedByStoppingRules: true }],
+  };
+  assert.equal(evaluateFence(resolved).mergeReady, true);
+});
+
+// Shape taken from the real incident: the automatic reviewer had completed on
+// exactly the frozen target, and its finding was simply never collected because
+// the reviewer was never in the review set.
+test("regression 2: PR #51 type — finding at the final target blocks merge-ready", () => {
+  const scenario = {
+    finalTarget: "29447ce3",
+    actors: [{ name: "auto-reviewer", participation: "review" }],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "29447ce3",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+      },
+    ],
+    findings: [{ actor: "auto-reviewer", reviewedTarget: "29447ce3", resolved: false }],
+  };
+
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "a finding on the final target must block merge-ready");
+  assert.ok(blockers.includes("unresolved-finding:auto-reviewer:1"));
+
+  // The load-bearing part: the reviewer entered the set purely through observed
+  // review participation, with no consumer declaration. Without that closure the
+  // finding is never collected and the fence is vacuous.
+  assert.equal(classifyActor(scenario.actors[0]), "expected");
+
+  // Guard against binding on a head-following field: had the model trusted a
+  // field that drifts to the head, this ancestor run would be misread as clean
+  // evidence for the current head.
+  const drifted = {
+    actor: "auto-reviewer",
+    reviewedTarget: "29447ce3",
+    reviewedTargetIsStable: false,
+    positiveCompletionEvidence: true,
+  };
+  assert.equal(
+    isTargetBoundEvidence(drifted, "29447ce3"),
+    false,
+    "an unstable (head-following) field must not establish binding",
+  );
+});
+
+test("regression 3: bounded accepted-fix does not re-require full discovery at the head", () => {
+  // Review stopping rules: a bounded fix is handled by targeted closure. The
+  // fence must not escalate that into "the automatic reviewer must complete
+  // again at the final head".
+  const scenario = {
+    finalTarget: "6800b796", // post-fix head
+    actors: [
+      {
+        name: "auto-reviewer",
+        participation: "review",
+        // targeted closure was judged sufficient per Review stopping rules
+        obligationSatisfiedByStoppingRules: true,
+      },
+    ],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "354187da", // never re-ran at the final head
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+      },
+    ],
+    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: true }],
+  };
+
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(
+    mergeReady,
+    true,
+    `bounded closure must not be blocked on a head re-review: ${blockers.join(", ")}`,
+  );
+
+  // Contrast: without the stopping-rules satisfaction, the same shape blocks.
+  const notSatisfied = {
+    ...scenario,
+    actors: [{ name: "auto-reviewer", participation: "review" }],
+  };
+  assert.deepEqual(evaluateFence(notSatisfied).blockers, ["unknown-completion:auto-reviewer"]);
+});
+
+test("regression 4: optional reviewer — unknown does not block, findings do", () => {
+  const unknownOnly = {
+    finalTarget: "abc1234",
+    actors: [{ name: "advisory-bot", declaredAdvisory: true }],
+    runs: [], // no completion evidence at all
+    findings: [],
+  };
+  assert.equal(
+    evaluateFence(unknownOnly).mergeReady,
+    true,
+    "an optional reviewer being unknown must not block merge-ready",
+  );
+
+  const withFinding = {
+    ...unknownOnly,
+    findings: [{ actor: "advisory-bot", reviewedTarget: "abc1234", resolved: false }],
+  };
+  const result = evaluateFence(withFinding);
+  assert.equal(result.mergeReady, false, "an optional reviewer's actual finding is in scope");
+  assert.ok(result.blockers.includes("unresolved-finding:advisory-bot:1"));
+});
+
+test("regression 5: ordinary non-review actors are not promoted to expected reviewers", () => {
+  for (const actor of [
+    { name: "human-collaborator", participation: "comment" },
+    { name: "ci", participation: "status" },
+    { name: "release-notes-bot", participation: "comment" },
+  ]) {
+    assert.equal(
+      classifyActor(actor),
+      "not-a-member",
+      `${actor.name} must not become an expected reviewer through presence alone`,
+    );
+  }
+
+  // A PR full of ordinary chatter and a green CI status is still merge-ready.
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [
+      { name: "human-collaborator", participation: "comment" },
+      { name: "ci", participation: "status" },
+      { name: "auto-reviewer", participation: "review" },
+    ],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "abc1234",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+      },
+    ],
+    findings: [],
+  };
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, true, `non-review actors must not create blockers: ${blockers.join(", ")}`);
+});
+
+test("regression 2b: absence of positive completion evidence is `unknown`, never 0 findings", () => {
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [{ name: "declared-auto", declaredAutomatic: true }],
+    runs: [
+      {
+        actor: "declared-auto",
+        reviewedTarget: "abc1234",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: false, // silence, not a clean result
+      },
+    ],
+    findings: [],
+  };
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "silence must not be converted into `0 findings`");
+  assert.deepEqual(blockers, ["unknown-completion:declared-auto"]);
+});
+
+test("fence blocks while review threads are unresolved", () => {
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [{ name: "auto-reviewer", participation: "review" }],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "abc1234",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+      },
+    ],
+    findings: [],
+    unresolvedThreads: 1,
+  };
+  assert.equal(evaluateFence(scenario).mergeReady, false);
+});
+
+// ---------------------------------------------------------------------------
+// The decision model above is only meaningful if the normative source actually
+// states these rules. These assertions bind the model to policy/core.md and
+// skills/review-code.md so the two cannot drift apart silently.
+// ---------------------------------------------------------------------------
+
+test("core policy states the expected review set closure rule", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(containsText(core, "expected review set は、agent が選択した reviewer だけでは閉じません"));
+  assert.ok(containsText(core, "consumer が configured automatic reviewer として明示している"));
+  assert.ok(
+    containsText(core, "取得済み evidence が、その actor による review 行為をその review target 上で識別させる"),
+  );
+
+  // Presence alone must not promote an actor.
+  assert.ok(containsText(core, "review participation として識別できる"));
+  assert.ok(containsText(core, "review target 上に presence があるだけでは足りず"));
+  for (const negative of [
+    "通常の human comment",
+    "CI actor（workflow / status / check の author であること）",
+    "review 以外の目的で投稿する bot",
+  ]) {
+    assert.ok(containsText(core, negative), `missing negative constraint: ${negative}`);
+  }
+
+  // Provider-neutrality: identification is the adapter's job, not the Kernel's.
+  assert.ok(containsText(core, "どの surface item が review participation を構成するかの識別は Review Adapter"));
+  assert.ok(containsText(core, "その actor を expected member とした根拠"));
+
+  // Residual limitation is stated rather than papered over.
+  assert.ok(
+    containsText(
+      core,
+      "review participation evidence を出していない reviewer を含められません",
+    ),
+  );
+
+  // optional/advisory stays non-blocking, but its findings do not.
+  assert.ok(containsText(core, "completion state が `unknown` であること自体は blocker にしません"));
+  assert.ok(containsText(core, "actual finding が観測された場合、その finding は Resolution Contract の対象です"));
+});
+
+test("core policy requires target-bound positive completion evidence on stable fields", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(containsText(core, "positive completion evidence は target-bound です"));
+  assert.ok(containsText(core, "その target への resolvable な参照を持つ positive completion evidence"));
+  assert.ok(containsText(core, "state は `unknown` であり、`0 findings` へ変換してはいけません"));
+
+  assert.ok(containsText(core, "target を安定して表す field / surface"));
+  assert.ok(
+    containsText(core, "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません"),
+  );
+  assert.ok(containsText(core, "binding の根拠を記録すること"));
+
+  // The two axes must be stated, and stated as non-interchangeable.
+  assert.ok(containsText(core, "次の 2 軸で扱いを分けます。両者を混同してはいけません"));
+  assert.ok(containsText(core, "**evidence 軸**"));
+  assert.ok(containsText(core, "**finding 軸**"));
+  assert.ok(containsText(core, "review target が移動したことだけを理由に discharge されません"));
+});
+
+test("core policy defines the merge-ready completion fence without overriding stopping rules", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("#### Merge-ready completion fence"));
+
+  // The fence must live in the always-on merge-readiness section, not inside
+  // `Review stopping rules` (which #36 Phase 1 migrates out of the Kernel).
+  const fenceIndex = core.indexOf("#### Merge-ready completion fence");
+  const mergeReadinessIndex = core.indexOf("### Merge readiness and merge authority");
+  const stoppingRulesIndex = core.indexOf("### Review stopping rules");
+  assert.ok(mergeReadinessIndex !== -1 && stoppingRulesIndex !== -1);
+  assert.ok(
+    fenceIndex > mergeReadinessIndex && fenceIndex < stoppingRulesIndex,
+    "the fence must sit inside Merge readiness and merge authority",
+  );
+
+  assert.ok(containsText(core, "merge-ready を宣言する前に、次を最後の action として評価します"));
+  assert.ok(containsText(core, "この fence は Review stopping rules を置き換えず、参照します"));
+  assert.ok(containsText(core, "Selection Contract に従って expected review set を閉じる"));
+  assert.ok(containsText(core, "positive completion evidence が無い member を `0 findings` へ変換しない"));
+  assert.ok(containsText(core, "安定 evidence 由来の reviewed target へ帰属させる"));
+  assert.ok(containsText(core, "ancestor target で発見された finding も対象とする"));
+  assert.ok(containsText(core, "unresolved review thread が 0 であることを確認する"));
+
+  // R4: obligation satisfaction, NOT universal completion at the final target.
+  assert.ok(
+    containsText(core, "review obligation が Review stopping rules に従って satisfied している"),
+  );
+  assert.ok(containsText(core, "全 member が final target で completed であることを要求するものではありません"));
+  assert.ok(
+    containsText(core, "同じ reviewer による final target の full re-review を強制しません"),
+  );
+
+  // Ordering property: the fence is invalidated by later state changes.
+  assert.ok(
+    containsText(core, "state が変化した場合、その fence 評価は無効となり、再評価します"),
+  );
+
+  // merge-ready still is not merge authority.
+  assert.ok(containsText(core, "merge を実行してよいという判断とは同義ではありません"));
+});
+
+test("Resolution Contract keeps ancestor-target findings in scope", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  assert.ok(
+    containsText(
+      core,
+      "確定した review target より前の target（ancestor）で発見された finding も Resolution Contract の対象である",
+    ),
+  );
+});
+
+test("review-code skill carries the procedural detail for the fence", async () => {
+  const skill = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  // Selection: close the set, record the basis, do not promote by presence.
+  assert.ok(containsText(skill, "expected review set を閉じます"));
+  assert.ok(containsText(skill, "自分が trigger した reviewer だけを set に入れて終わりにせず"));
+  assert.ok(containsText(skill, "presence だけを理由に expected member 化しません"));
+
+  // Acquisition: target-bound, stable field, record the binding basis.
+  assert.ok(containsText(skill, "resolvable な参照を持つ positive completion evidence が必要です"));
+  assert.ok(containsText(skill, "安定して表す field / surface を使います"));
+  assert.ok(containsText(skill, "binding の根拠にしてはいけません"));
+  assert.ok(containsText(skill, "どちらが安定かを確認できない場合、その binding は成立しておらず `unknown` です"));
+
+  // Aggregation must not drop findings from non-valid runs.
+  assert.ok(containsText(skill, "finding の集約対象は valid な run に限りません"));
+  assert.ok(containsText(skill, "`validity` は evidence 軸の判定であり、finding を捨ててよい根拠ではありません"));
+
+  // Merge-ready: fence evaluated last, invalidated by later change.
+  assert.ok(containsText(skill, "merge-ready を宣言する直前の最後の action として"));
+  assert.ok(containsText(skill, "会話内で既に見た snapshot をこの判定の根拠にしません"));
+  assert.ok(containsText(skill, "fence 評価は無効です。再評価してから宣言します"));
+  assert.ok(containsText(skill, "全 member が final target で completed であることを要求しません"));
+
+  // Provider observations stay observations.
+  assert.ok(containsText(skill, "check/status surface を一切生成しませんでした"));
+  assert.ok(containsText(skill, "green な status が review 完了ではなく **review 未実施**を意味する"));
+  assert.ok(containsText(skill, "capability/profile 側で再検証可能な observed evidence として扱います"));
+});
+
+test("the Kernel states the fence without hard-coding provider specifics", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const added = core.slice(core.indexOf("#### Selection Contract"));
+
+  for (const providerToken of [
+    "Codex",
+    "CodeRabbit",
+    "chatgpt",
+    "original_commit_id",
+    "commit_id",
+    "pulls/",
+    "github.com",
+  ]) {
+    assert.ok(
+      !added.includes(providerToken),
+      `Kernel must not hard-code provider specifics, found: ${providerToken}`,
+    );
+  }
+});

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -17,40 +17,44 @@ function containsText(haystack, needle) {
 // ---------------------------------------------------------------------------
 // Decision model
 //
-// This is a TEST-ONLY executable encoding of the Merge-ready completion fence
-// (policy/core.md, Merge readiness and merge authority). It is not a production
-// mechanism and nothing in tooling/ depends on it. Its purpose is to prove that
-// the normative rules, as written, produce the intended verdict for the failure
-// modes recorded in Issue #45 — rather than asserting only that certain prose
-// exists.
+// TEST-ONLY executable encoding of the Merge-ready completion fence
+// (policy/core.md, Merge readiness and merge authority). Not a production
+// mechanism; nothing in tooling/ depends on it. Its purpose is to prove that
+// the normative rules, as written, yield the intended verdict for the failure
+// modes recorded in Issue #45 — rather than only asserting that prose exists.
 //
-// The rules encoded here, and only these:
-//   R1 expected review set = required | expected(declared or observed review
-//      participation) | optional. Presence alone never promotes an actor.
-//   R2 positive completion evidence is target-bound; absent it, state is
-//      `unknown` and never `0 findings`.
-//   R3 a run whose reviewed target != final target is unusable as clean/discovery
-//      evidence (evidence axis) but its findings survive (finding axis).
+// Encoded rules, and only these:
+//   R1 expected review set = required | expected(declared automatic, or observed
+//      review participation) | optional. Presence alone never promotes an actor.
+//      An explicit consumer declaration outranks observed evidence.
+//   R2 positive completion evidence is target-bound, and binding must rest on a
+//      field that stably represents the reviewed target. Absent either, the
+//      member's target completion state is `unknown` — never `0 findings`.
+//   R3 two axes. A run whose reviewed target != final target is unusable as
+//      clean/discovery evidence (evidence axis) but its findings survive
+//      (finding axis).
 //   R4 merge-ready = every required|expected member's review obligation is
-//      satisfied per Review stopping rules. NOT "every member completed at the
-//      final target".
+//      satisfied, where the obligation is the one policy/core.md defines per
+//      class. NOT "every member completed at the final target".
 //   R5 optional members: `unknown` alone does not block; observed findings do.
+//   R6 a required member cannot be exempted by declaring non-participation.
 // ---------------------------------------------------------------------------
 
 /**
  * Classify an actor observed on the review target.
  * `participation` is what the adapter identified the surface item as.
+ * Explicit consumer declarations take precedence over observed evidence.
  */
 function classifyActor(actor) {
   if (actor.declaredRequired) return "required";
-  if (actor.declaredAutomatic) return "expected";
   if (actor.declaredAdvisory) return "optional";
+  if (actor.declaredAutomatic) return "expected";
   // Observed-participant closure: only review participation promotes an actor.
   if (actor.participation === "review") return "expected";
   return "not-a-member";
 }
 
-/** Is this run usable as clean/discovery evidence for `finalTarget`? (R2, R3) */
+/** Is this run usable as clean/discovery evidence for `finalTarget`? (R2) */
 function isTargetBoundEvidence(run, finalTarget) {
   if (!run.positiveCompletionEvidence) return false;
   // Binding must come from a field that stably represents the reviewed target.
@@ -59,43 +63,71 @@ function isTargetBoundEvidence(run, finalTarget) {
 }
 
 /**
- * Evaluate the fence.
- * Returns { mergeReady, blockers[] }.
+ * Findings owed by a member (finding axis, R3).
+ *
+ * Deliberately DERIVED from the member's runs rather than taken as a free
+ * input. The finding axis claims a finding's fate does not depend on whether
+ * its producing run is target-bound; deriving it here is what makes that claim
+ * falsifiable. An implementation that discharged findings on a target move
+ * would filter on `isTargetBoundEvidence` at this exact spot — and
+ * `finding axis is falsifiable` below would catch it.
  */
-function evaluateFence({ finalTarget, actors, runs, findings, unresolvedThreads = 0 }) {
-  const blockers = [];
-  const members = [];
-
-  for (const actor of actors) {
-    const cls = classifyActor(actor);
-    if (cls !== "not-a-member") members.push({ ...actor, cls });
+function outstandingFindings(member, runs, finalTarget) {
+  const owed = [];
+  for (const run of runs.filter((r) => r.actor === member.name)) {
+    for (const finding of run.findings ?? []) {
+      if (finding.resolved) continue;
+      owed.push({
+        ...finding,
+        reviewedTarget: run.reviewedTarget,
+        bound: run.reviewedTarget === finalTarget,
+      });
+    }
   }
+  return owed;
+}
+
+/**
+ * Evaluate the fence. Returns { mergeReady, blockers[] }.
+ *
+ * `reliedOnForCleanEvidence` encodes the Selection decision described by
+ * policy/core.md: whether this member's silence is being used as the current
+ * target's `0 findings` / discovery evidence. It is a Selection input, not an
+ * oracle for the verdict.
+ */
+function evaluateFence({ finalTarget, actors, runs, unresolvedFindingSurfaces = 0 }) {
+  const blockers = [];
+  const members = actors
+    .map((actor) => ({ ...actor, cls: classifyActor(actor) }))
+    .filter((m) => m.cls !== "not-a-member");
 
   for (const member of members) {
-    const memberRuns = runs.filter((r) => r.actor === member.name);
-    const bound = memberRuns.find((r) => isTargetBoundEvidence(r, finalTarget));
+    // Finding axis (R3): applies to every class, regardless of the producing
+    // run's validity or target.
+    const owed = outstandingFindings(member, runs, finalTarget);
+    if (owed.length > 0) blockers.push(`unresolved-finding:${member.name}:${owed.length}`);
 
-    // Finding axis (R3): findings survive regardless of which target produced
-    // them, and regardless of the run's validity.
-    const openFindings = findings.filter((f) => f.actor === member.name && !f.resolved);
-    if (openFindings.length > 0) {
-      blockers.push(`unresolved-finding:${member.name}:${openFindings.length}`);
+    const bound = runs.filter((r) => r.actor === member.name).some((r) => isTargetBoundEvidence(r, finalTarget));
+
+    if (member.cls === "required") {
+      // R6: non-participation does not exempt a required member. Only a valid
+      // run, or an explicit Selection change, discharges the obligation.
+      if (!bound && !member.selectionChangedToDropRequired) {
+        blockers.push(`required-run-missing:${member.name}`);
+      }
+      continue;
     }
 
-    if (member.cls === "optional") continue; // R5: unknown alone does not block
+    if (member.cls === "optional") continue; // R5
 
-    // Evidence axis (R2/R3): only a target-bound run may back a `0 findings`
-    // claim. Absent one, the member's state is `unknown`.
-    if (!bound) {
-      // R4: an unknown state only blocks where the obligation actually requires
-      // fresh evidence at the final target. Review stopping rules say a bounded
-      // accepted-fix closure does not re-require full discovery at the head.
-      if (member.obligationSatisfiedByStoppingRules) continue;
+    // expected (R4): unknown blocks only where its silence is being used as the
+    // current target's clean/discovery evidence.
+    if (member.reliedOnForCleanEvidence && !bound) {
       blockers.push(`unknown-completion:${member.name}`);
     }
   }
 
-  if (unresolvedThreads > 0) blockers.push(`unresolved-threads:${unresolvedThreads}`);
+  if (unresolvedFindingSurfaces > 0) blockers.push(`untriaged-findings:${unresolvedFindingSurfaces}`);
 
   return { mergeReady: blockers.length === 0, blockers };
 }
@@ -104,7 +136,7 @@ function evaluateFence({ finalTarget, actors, runs, findings, unresolvedThreads 
 // Regression proofs — the five scenarios required by Issue #45.
 // ---------------------------------------------------------------------------
 
-// Shapes taken from the real incident recorded in Issue #45: an automatic
+// Shape taken from the real incident recorded in Issue #45: an automatic
 // reviewer produced a P1 on 354187da while the frozen final target was c2b99f69.
 test("regression 1: PR #42 type — ancestor-target finding blocks merge-ready", () => {
   const scenario = {
@@ -116,9 +148,9 @@ test("regression 1: PR #42 type — ancestor-target finding blocks merge-ready",
         reviewedTarget: "354187da", // ancestor, not the final target
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
+        findings: [{ id: "P1", resolved: false }],
       },
     ],
-    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: false }],
   };
 
   const { mergeReady, blockers } = evaluateFence(scenario);
@@ -135,18 +167,59 @@ test("regression 1: PR #42 type — ancestor-target finding blocks merge-ready",
     "a run on an ancestor target is not clean evidence for the final target",
   );
 
-  // Resolving the finding is what clears it — not the head having moved.
-  const resolved = {
-    ...scenario,
-    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: true }],
-    actors: [{ name: "auto-reviewer", participation: "review", obligationSatisfiedByStoppingRules: true }],
-  };
-  assert.equal(evaluateFence(resolved).mergeReady, true);
+  // Resolving the finding is what clears it — and nothing else changes here,
+  // so the assertion isolates the finding axis (one variable, not two).
+  const resolved = structuredClone(scenario);
+  resolved.runs[0].findings[0].resolved = true;
+  assert.deepEqual(evaluateFence(resolved).blockers, []);
+});
+
+test("finding axis is falsifiable: a target move alone must not discharge a finding", () => {
+  // Same ancestor finding, but the head has moved on twice more. If the model
+  // discharged findings whose run is no longer target-bound, this would pass as
+  // merge-ready. It must not.
+  for (const finalTarget of ["c2b99f69", "6800b796", "deadbeef"]) {
+    const scenario = {
+      finalTarget,
+      actors: [{ name: "auto-reviewer", participation: "review" }],
+      runs: [
+        {
+          actor: "auto-reviewer",
+          reviewedTarget: "354187da",
+          reviewedTargetIsStable: true,
+          positiveCompletionEvidence: true,
+          findings: [{ id: "P1", resolved: false }],
+        },
+      ],
+    };
+    assert.equal(
+      evaluateFence(scenario).mergeReady,
+      false,
+      `finding must survive the move to ${finalTarget}`,
+    );
+  }
+
+  // And the converse: the finding is owed even though its run is not bound.
+  const owed = outstandingFindings(
+    { name: "auto-reviewer" },
+    [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "354187da",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "P1", resolved: false }],
+      },
+    ],
+    "c2b99f69",
+  );
+  assert.equal(owed.length, 1);
+  assert.equal(owed[0].bound, false, "the owed finding is explicitly not target-bound");
 });
 
 // Shape taken from the real incident: the automatic reviewer had completed on
-// exactly the frozen target, and its finding was simply never collected because
-// the reviewer was never in the review set.
+// exactly the frozen target, and its finding was never collected because the
+// reviewer was never in the review set.
 test("regression 2: PR #51 type — finding at the final target blocks merge-ready", () => {
   const scenario = {
     finalTarget: "29447ce3",
@@ -157,9 +230,9 @@ test("regression 2: PR #51 type — finding at the final target blocks merge-rea
         reviewedTarget: "29447ce3",
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
+        findings: [{ id: "P2", resolved: false }],
       },
     ],
-    findings: [{ actor: "auto-reviewer", reviewedTarget: "29447ce3", resolved: false }],
   };
 
   const { mergeReady, blockers } = evaluateFence(scenario);
@@ -172,16 +245,13 @@ test("regression 2: PR #51 type — finding at the final target blocks merge-rea
   assert.equal(classifyActor(scenario.actors[0]), "expected");
 
   // Guard against binding on a head-following field: had the model trusted a
-  // field that drifts to the head, this ancestor run would be misread as clean
+  // field that drifts to the head, an ancestor run would be misread as clean
   // evidence for the current head.
-  const drifted = {
-    actor: "auto-reviewer",
-    reviewedTarget: "29447ce3",
-    reviewedTargetIsStable: false,
-    positiveCompletionEvidence: true,
-  };
   assert.equal(
-    isTargetBoundEvidence(drifted, "29447ce3"),
+    isTargetBoundEvidence(
+      { reviewedTarget: "29447ce3", reviewedTargetIsStable: false, positiveCompletionEvidence: true },
+      "29447ce3",
+    ),
     false,
     "an unstable (head-following) field must not establish binding",
   );
@@ -190,26 +260,20 @@ test("regression 2: PR #51 type — finding at the final target blocks merge-rea
 test("regression 3: bounded accepted-fix does not re-require full discovery at the head", () => {
   // Review stopping rules: a bounded fix is handled by targeted closure. The
   // fence must not escalate that into "the automatic reviewer must complete
-  // again at the final head".
+  // again at the final head". The member's ancestor finding is resolved, and
+  // its silence is not being used as clean evidence for the new head.
   const scenario = {
     finalTarget: "6800b796", // post-fix head
-    actors: [
-      {
-        name: "auto-reviewer",
-        participation: "review",
-        // targeted closure was judged sufficient per Review stopping rules
-        obligationSatisfiedByStoppingRules: true,
-      },
-    ],
+    actors: [{ name: "auto-reviewer", participation: "review", reliedOnForCleanEvidence: false }],
     runs: [
       {
         actor: "auto-reviewer",
         reviewedTarget: "354187da", // never re-ran at the final head
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
+        findings: [{ id: "P1", resolved: true }],
       },
     ],
-    findings: [{ actor: "auto-reviewer", reviewedTarget: "354187da", resolved: true }],
   };
 
   const { mergeReady, blockers } = evaluateFence(scenario);
@@ -219,12 +283,11 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
     `bounded closure must not be blocked on a head re-review: ${blockers.join(", ")}`,
   );
 
-  // Contrast: without the stopping-rules satisfaction, the same shape blocks.
-  const notSatisfied = {
-    ...scenario,
-    actors: [{ name: "auto-reviewer", participation: "review" }],
-  };
-  assert.deepEqual(evaluateFence(notSatisfied).blockers, ["unknown-completion:auto-reviewer"]);
+  // Contrast: if the agent DOES lean on that member's silence as the new head's
+  // clean evidence, the missing target-bound run blocks.
+  const relied = structuredClone(scenario);
+  relied.actors[0].reliedOnForCleanEvidence = true;
+  assert.deepEqual(evaluateFence(relied).blockers, ["unknown-completion:auto-reviewer"]);
 });
 
 test("regression 4: optional reviewer — unknown does not block, findings do", () => {
@@ -232,7 +295,6 @@ test("regression 4: optional reviewer — unknown does not block, findings do", 
     finalTarget: "abc1234",
     actors: [{ name: "advisory-bot", declaredAdvisory: true }],
     runs: [], // no completion evidence at all
-    findings: [],
   };
   assert.equal(
     evaluateFence(unknownOnly).mergeReady,
@@ -242,11 +304,23 @@ test("regression 4: optional reviewer — unknown does not block, findings do", 
 
   const withFinding = {
     ...unknownOnly,
-    findings: [{ actor: "advisory-bot", reviewedTarget: "abc1234", resolved: false }],
+    runs: [
+      {
+        actor: "advisory-bot",
+        reviewedTarget: "abc1234",
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "P3", resolved: false }],
+      },
+    ],
   };
   const result = evaluateFence(withFinding);
   assert.equal(result.mergeReady, false, "an optional reviewer's actual finding is in scope");
   assert.ok(result.blockers.includes("unresolved-finding:advisory-bot:1"));
+
+  // Precedence: an explicit advisory declaration outranks an observed review
+  // act, so performing a review does not silently promote it to a blocker.
+  assert.equal(classifyActor({ name: "advisory-bot", declaredAdvisory: true, participation: "review" }), "optional");
 });
 
 test("regression 5: ordinary non-review actors are not promoted to expected reviewers", () => {
@@ -268,7 +342,7 @@ test("regression 5: ordinary non-review actors are not promoted to expected revi
     actors: [
       { name: "human-collaborator", participation: "comment" },
       { name: "ci", participation: "status" },
-      { name: "auto-reviewer", participation: "review" },
+      { name: "auto-reviewer", participation: "review", reliedOnForCleanEvidence: true },
     ],
     runs: [
       {
@@ -276,34 +350,60 @@ test("regression 5: ordinary non-review actors are not promoted to expected revi
         reviewedTarget: "abc1234",
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
+        findings: [],
       },
     ],
-    findings: [],
   };
   const { mergeReady, blockers } = evaluateFence(scenario);
   assert.equal(mergeReady, true, `non-review actors must not create blockers: ${blockers.join(", ")}`);
 });
 
-test("regression 2b: absence of positive completion evidence is `unknown`, never 0 findings", () => {
+test("regression 6: a required member is not exempted by declaring non-participation", () => {
   const scenario = {
     finalTarget: "abc1234",
-    actors: [{ name: "declared-auto", declaredAutomatic: true }],
+    actors: [{ name: "required-reviewer", declaredRequired: true, declinedParticipation: true }],
+    runs: [], // declined, so no run
+  };
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "a required reviewer cannot self-exempt by declining");
+  assert.deepEqual(blockers, ["required-run-missing:required-reviewer"]);
+
+  // Only an explicit Selection change (or a valid run) discharges it.
+  const reselected = structuredClone(scenario);
+  reselected.actors[0].selectionChangedToDropRequired = true;
+  assert.equal(evaluateFence(reselected).mergeReady, true);
+
+  // An expected member, by contrast, may be discharged by declining.
+  assert.equal(
+    evaluateFence({
+      finalTarget: "abc1234",
+      actors: [{ name: "auto", declaredAutomatic: true, declinedParticipation: true }],
+      runs: [],
+    }).mergeReady,
+    true,
+  );
+});
+
+test("silence is `unknown`, never 0 findings, when relied on as clean evidence", () => {
+  const scenario = {
+    finalTarget: "abc1234",
+    actors: [{ name: "declared-auto", declaredAutomatic: true, reliedOnForCleanEvidence: true }],
     runs: [
       {
         actor: "declared-auto",
         reviewedTarget: "abc1234",
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: false, // silence, not a clean result
+        findings: [],
       },
     ],
-    findings: [],
   };
   const { mergeReady, blockers } = evaluateFence(scenario);
   assert.equal(mergeReady, false, "silence must not be converted into `0 findings`");
   assert.deepEqual(blockers, ["unknown-completion:declared-auto"]);
 });
 
-test("fence blocks while review threads are unresolved", () => {
+test("fence blocks while untriaged findings remain on a review surface", () => {
   const scenario = {
     finalTarget: "abc1234",
     actors: [{ name: "auto-reviewer", participation: "review" }],
@@ -313,18 +413,18 @@ test("fence blocks while review threads are unresolved", () => {
         reviewedTarget: "abc1234",
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
+        findings: [],
       },
     ],
-    findings: [],
-    unresolvedThreads: 1,
+    unresolvedFindingSurfaces: 1,
   };
   assert.equal(evaluateFence(scenario).mergeReady, false);
 });
 
 // ---------------------------------------------------------------------------
 // The decision model above is only meaningful if the normative source actually
-// states these rules. These assertions bind the model to policy/core.md and
-// skills/review-code.md so the two cannot drift apart silently.
+// states these rules. These assertions bind the model to policy/core.md and the
+// review skills so the two cannot drift apart silently.
 // ---------------------------------------------------------------------------
 
 test("core policy states the expected review set closure rule", async () => {
@@ -347,21 +447,51 @@ test("core policy states the expected review set closure rule", async () => {
     assert.ok(containsText(core, negative), `missing negative constraint: ${negative}`);
   }
 
+  // Precedence between overlapping classes must be stated.
+  assert.ok(containsText(core, "consumer による明示的な宣言が observed evidence に優先します"));
+  assert.ok(containsText(core, "consumer が advisory と宣言した reviewer は、実際に review 行為を行っても optional のまま"));
+
+  // The declaration must have a stated home, so agents do not diverge on where
+  // to look for it.
+  assert.ok(containsText(core, "その consumer の product rules、または当該 Task の Selection 記録に置きます"));
+
   // Provider-neutrality: identification is the adapter's job, not the Kernel's.
   assert.ok(containsText(core, "どの surface item が review participation を構成するかの識別は Review Adapter"));
   assert.ok(containsText(core, "その actor を expected member とした根拠"));
 
   // Residual limitation is stated rather than papered over.
+  assert.ok(containsText(core, "review participation evidence を出していない reviewer を含められません"));
+
+  // optional/advisory stays non-blocking, but its findings do not.
+  assert.ok(containsText(core, "target completion state が `unknown` であること自体は blocker にしません"));
+  assert.ok(containsText(core, "actual finding が観測された場合、その finding は Resolution Contract の対象です"));
+});
+
+test("a required member cannot be exempted by declaring non-participation", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(containsText(core, "expected / optional の member についてはその reviewer を blocker にしません"));
+  assert.ok(containsText(core, "required member は非参加の宣言によって blocker から外れません"));
+  assert.ok(
+    containsText(core, "valid な代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す"),
+  );
+  assert.ok(containsText(core, "required review 数の gate を迂回する経路にしてはいけません"));
+});
+
+test("core policy separates run record state from target completion state", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(containsText(core, "run record state と target completion state は別の対象です"));
+  assert.ok(containsText(core, "両者は同じ語で呼ばず、混同してはいけません"));
+  // The pre-existing record vocabulary must be reconciled explicitly, not left
+  // to collide with the new reviewer-level vocabulary.
   assert.ok(
     containsText(
       core,
-      "review participation evidence を出していない reviewer を含められません",
+      "run record としては `status: completed` かつ `validity: invalid` であり、同時にその reviewer の current target に対する target completion state は `not-bound` です",
     ),
   );
-
-  // optional/advisory stays non-blocking, but its findings do not.
-  assert.ok(containsText(core, "completion state が `unknown` であること自体は blocker にしません"));
-  assert.ok(containsText(core, "actual finding が観測された場合、その finding は Resolution Contract の対象です"));
+  assert.ok(containsText(core, "この 2 つは矛盾しません"));
 });
 
 test("core policy requires target-bound positive completion evidence on stable fields", async () => {
@@ -369,13 +499,22 @@ test("core policy requires target-bound positive completion evidence on stable f
 
   assert.ok(containsText(core, "positive completion evidence は target-bound です"));
   assert.ok(containsText(core, "その target への resolvable な参照を持つ positive completion evidence"));
-  assert.ok(containsText(core, "state は `unknown` であり、`0 findings` へ変換してはいけません"));
+  assert.ok(containsText(core, "`0 findings` へ変換してはいけません"));
 
   assert.ok(containsText(core, "target を安定して表す field / surface"));
   assert.ok(
     containsText(core, "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません"),
   );
   assert.ok(containsText(core, "binding の根拠を記録すること"));
+
+  // The fallback when stability cannot be confirmed is normative and must live
+  // in the Kernel, not only in the Executable-only skill.
+  assert.ok(
+    containsText(
+      core,
+      "どちらが安定かを必要な精度で確認できない場合、その binding は成立しておらず、target completion state は `unknown` です",
+    ),
+  );
 
   // The two axes must be stated, and stated as non-interchangeable.
   assert.ok(containsText(core, "次の 2 軸で扱いを分けます。両者を混同してはいけません"));
@@ -406,21 +545,38 @@ test("core policy defines the merge-ready completion fence without overriding st
   assert.ok(containsText(core, "positive completion evidence が無い member を `0 findings` へ変換しない"));
   assert.ok(containsText(core, "安定 evidence 由来の reviewed target へ帰属させる"));
   assert.ok(containsText(core, "ancestor target で発見された finding も対象とする"));
-  assert.ok(containsText(core, "unresolved review thread が 0 であることを確認する"));
+
+  // Step 6 must be provider-neutral: tied to triage, not to a provider's thread
+  // concept, and not stricter than the Resolution Contract.
+  assert.ok(containsText(core, "triage されていない finding が review surface 上に残っていないことを確認する"));
+  assert.ok(!core.includes("unresolved review thread"), "the Kernel must not name a provider thread concept");
 
   // R4: obligation satisfaction, NOT universal completion at the final target.
-  assert.ok(
-    containsText(core, "review obligation が Review stopping rules に従って satisfied している"),
-  );
+  assert.ok(containsText(core, "各 member の review obligation が satisfied している"));
   assert.ok(containsText(core, "全 member が final target で completed であることを要求するものではありません"));
+  assert.ok(containsText(core, "同じ reviewer による final target の full re-review を強制しません"));
+
+  // The obligation must actually be defined, per class — otherwise step 7 is
+  // circular and two agents can read it opposite ways.
+  assert.ok(containsText(core, "**review obligation** は、member の class ごとに次を指します"));
+  assert.ok(containsText(core, "**required member**:"));
+  assert.ok(containsText(core, "**expected member**:"));
+  assert.ok(containsText(core, "**optional / advisory member**:"));
   assert.ok(
-    containsText(core, "同じ reviewer による final target の full re-review を強制しません"),
+    containsText(core, "その member の**不在または沈黙を、current target の `0 findings` / discovery evidence として使っていない**こと"),
+  );
+  assert.ok(
+    containsText(core, "使わない場合、target completion state が `unknown` であること自体は blocker ではありません"),
   );
 
-  // Ordering property: the fence is invalidated by later state changes.
+  // Ordering property: the fence is invalidated by later review-relevant state
+  // changes — bounded, and not self-triggering.
+  assert.ok(containsText(core, "**review-relevant な state 変化**があった場合、その fence 評価は無効となり、再評価します"));
   assert.ok(
-    containsText(core, "state が変化した場合、その fence 評価は無効となり、再評価します"),
+    containsText(core, "agent 自身が本 Contract に従って persist する durable evidence の記録そのもの"),
   );
+  assert.ok(containsText(core, "fence を無効化しません"));
+  assert.ok(containsText(core, "この再評価は無制限に繰り返しません"));
 
   // merge-ready still is not merge authority.
   assert.ok(containsText(core, "merge を実行してよいという判断とは同義ではありません"));
@@ -436,34 +592,100 @@ test("Resolution Contract keeps ancestor-target findings in scope", async () => 
   );
 });
 
+test("both review skills keep non-valid runs' findings in Resolution scope", async () => {
+  // The Kernel rule is only deterministic if every aggregation site in the
+  // procedures agrees. Issue #45's review found three such sites.
+  const code = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const doc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  for (const [name, text] of [
+    ["review-code.md", code],
+    ["review-doc.md", doc],
+  ]) {
+    assert.ok(
+      containsText(text, "finding の集約対象は valid な run に限りません") ||
+        containsText(text, "集約対象は valid な run に限りません"),
+      `${name} must not restrict finding aggregation to valid runs`,
+    );
+    assert.ok(
+      containsText(text, "`validity` は evidence 軸の判定であり、finding を捨ててよい根拠ではありません"),
+      `${name} must state that validity is not grounds for dropping findings`,
+    );
+    // The superseded instruction must be gone, not merely contradicted later.
+    assert.ok(
+      !containsText(text, "invalid / unknown / failure な run の finding は triage に使用しません"),
+      `${name} still contains the superseded discard instruction`,
+    );
+    assert.ok(
+      !containsText(text, "valid な run の finding だけを triage へ進めます"),
+      `${name} still contains the superseded valid-only triage instruction`,
+    );
+  }
+
+  // The second-discovery sub-step must not reintroduce the valid-only filter.
+  assert.ok(
+    !containsText(code, "valid な run の finding を Resolution Contract で triage します"),
+    "review-code.md second discovery still filters findings on validity",
+  );
+});
+
+test("the Normative review procedure reaches the fence and the expected review set", async () => {
+  // review-doc.md governs Normative artifacts. Issue #45's failure modes are
+  // reachable from Normative reviews too, so the procedure must close the set
+  // and evaluate the fence rather than ending at "procedure complete".
+  const doc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  assert.ok(containsText(doc, "expected review set を確定します"));
+  assert.ok(containsText(doc, "expected review set は自分が trigger した reviewer だけでは閉じません"));
+  assert.ok(containsText(doc, "Merge-ready completion fence"));
+  assert.ok(containsText(doc, "会話内で既に見た snapshot をこの判定の根拠にせず"));
+  assert.ok(containsText(doc, "target completion state"));
+});
+
 test("review-code skill carries the procedural detail for the fence", async () => {
   const skill = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
-  // Selection: close the set, record the basis, do not promote by presence.
-  assert.ok(containsText(skill, "expected review set を閉じます"));
-  assert.ok(containsText(skill, "自分が trigger した reviewer だけを set に入れて終わりにせず"));
-  assert.ok(containsText(skill, "presence だけを理由に expected member 化しません"));
+  // Selection: close the set and record the basis.
+  assert.ok(containsText(skill, "expected review set を確定します"));
+  assert.ok(containsText(skill, "自分が trigger した reviewer だけを set に入れて終わりにしません"));
+  assert.ok(containsText(skill, "どの surface item を review participation とみなしたか"));
 
-  // Acquisition: target-bound, stable field, record the binding basis.
-  assert.ok(containsText(skill, "resolvable な参照を持つ positive completion evidence が必要です"));
-  assert.ok(containsText(skill, "安定して表す field / surface を使います"));
-  assert.ok(containsText(skill, "binding の根拠にしてはいけません"));
-  assert.ok(containsText(skill, "どちらが安定かを確認できない場合、その binding は成立しておらず `unknown` です"));
+  // Acquisition: record which evidence and which field backed the binding.
+  assert.ok(containsText(skill, "どの field / surface を安定と判断して binding の根拠にしたか"));
+  assert.ok(containsText(skill, "安定性を必要な精度で確認できないまま binding が成立したものとして扱わないでください"));
 
-  // Aggregation must not drop findings from non-valid runs.
-  assert.ok(containsText(skill, "finding の集約対象は valid な run に限りません"));
-  assert.ok(containsText(skill, "`validity` は evidence 軸の判定であり、finding を捨ててよい根拠ではありません"));
-
-  // Merge-ready: fence evaluated last, invalidated by later change.
+  // Merge-ready: fence evaluated last, from fresh acquisition.
   assert.ok(containsText(skill, "merge-ready を宣言する直前の最後の action として"));
   assert.ok(containsText(skill, "会話内で既に見た snapshot をこの判定の根拠にしません"));
-  assert.ok(containsText(skill, "fence 評価は無効です。再評価してから宣言します"));
-  assert.ok(containsText(skill, "全 member が final target で completed であることを要求しません"));
+  assert.ok(containsText(skill, "triage されていない finding が review surface 上に残っていないことを確認します"));
 
   // Provider observations stay observations.
   assert.ok(containsText(skill, "check/status surface を一切生成しませんでした"));
   assert.ok(containsText(skill, "green な status が review 完了ではなく **review 未実施**を意味する"));
   assert.ok(containsText(skill, "capability/profile 側で再検証可能な observed evidence として扱います"));
+});
+
+test("the skills reference the Kernel rules rather than restating them", async () => {
+  // policy/core.md owns the normative rules; skills explain procedure. The
+  // sentences below are the Kernel's, and must not be duplicated verbatim into
+  // the skill, where the two copies could drift silently.
+  const skill = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  for (const kernelSentence of [
+    "全 member が final target で completed であることを要求するものではありません",
+    "同じ reviewer による final target の full re-review を強制しません",
+    "review target 上に presence があるだけでは足りず",
+    "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません",
+  ]) {
+    assert.ok(
+      !containsText(skill, kernelSentence),
+      `review-code.md restates a Kernel rule verbatim: ${kernelSentence}`,
+    );
+  }
+
+  // It must point at the owner instead.
+  assert.ok(containsText(skill, "は、いずれも `policy/core.md` が定めます"));
+  assert.ok(containsText(skill, "merge-ready の成立条件、review obligation の定義"));
 });
 
 test("the Kernel states the fence without hard-coding provider specifics", async () => {

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -90,12 +90,14 @@ function outstandingFindings(member, runs, finalTarget) {
 /**
  * Evaluate the fence. Returns { mergeReady, blockers[] }.
  *
- * `reliedOnForCleanEvidence` encodes the Selection decision described by
- * policy/core.md: whether this member's silence is being used as the current
- * target's `0 findings` / discovery evidence. It is a Selection input, not an
- * oracle for the verdict.
+ * Every gate below is derived from observable inputs (runs, findings, declared
+ * class, declared non-participation). The one judgement input,
+ * `boundedClosureSufficient`, mirrors the single exception policy/core.md
+ * grants: a Review stopping rules decision that targeted closure suffices after
+ * an accepted fix moved the target. Policy requires that decision to be
+ * recorded, so it is an input rather than an unstated agent intention.
  */
-function evaluateFence({ finalTarget, actors, runs, unresolvedFindingSurfaces = 0 }) {
+function evaluateFence({ finalTarget, actors, runs, findingsRequireTriage = true }) {
   const blockers = [];
   const members = actors
     .map((actor) => ({ ...actor, cls: classifyActor(actor) }))
@@ -103,9 +105,14 @@ function evaluateFence({ finalTarget, actors, runs, unresolvedFindingSurfaces = 
 
   for (const member of members) {
     // Finding axis (R3): applies to every class, regardless of the producing
-    // run's validity or target.
+    // run's validity or target, and regardless of non-participation. Declaring
+    // non-participation never discharges a finding already produced.
     const owed = outstandingFindings(member, runs, finalTarget);
     if (owed.length > 0) blockers.push(`unresolved-finding:${member.name}:${owed.length}`);
+    if (findingsRequireTriage) {
+      const untriaged = owed.filter((f) => !f.triage);
+      if (untriaged.length > 0) blockers.push(`untriaged-finding:${member.name}:${untriaged.length}`);
+    }
 
     const bound = runs.filter((r) => r.actor === member.name).some((r) => isTargetBoundEvidence(r, finalTarget));
 
@@ -118,16 +125,15 @@ function evaluateFence({ finalTarget, actors, runs, unresolvedFindingSurfaces = 
       continue;
     }
 
-    if (member.cls === "optional") continue; // R5
+    if (member.cls === "optional") continue; // R5: state is never a blocker
 
-    // expected (R4): unknown blocks only where its silence is being used as the
-    // current target's clean/discovery evidence.
-    if (member.reliedOnForCleanEvidence && !bound) {
+    // expected (R4): the target completion state must be `completed@target` or
+    // `declined`. The sole exception is a recorded stopping-rules decision that
+    // targeted closure suffices after an accepted fix moved the target.
+    if (!bound && !member.declinedParticipation && !member.boundedClosureSufficient) {
       blockers.push(`unknown-completion:${member.name}`);
     }
   }
-
-  if (unresolvedFindingSurfaces > 0) blockers.push(`untriaged-findings:${unresolvedFindingSurfaces}`);
 
   return { mergeReady: blockers.length === 0, blockers };
 }
@@ -167,11 +173,12 @@ test("regression 1: PR #42 type — ancestor-target finding blocks merge-ready",
     "a run on an ancestor target is not clean evidence for the final target",
   );
 
-  // Resolving the finding is what clears it — and nothing else changes here,
-  // so the assertion isolates the finding axis (one variable, not two).
+  // Resolving the finding is what clears the finding axis — and nothing else
+  // changes here, so the assertion isolates one variable. The member's own
+  // completion at the new target is a separate obligation, checked below.
   const resolved = structuredClone(scenario);
   resolved.runs[0].findings[0].resolved = true;
-  assert.deepEqual(evaluateFence(resolved).blockers, []);
+  assert.deepEqual(evaluateFence(resolved).blockers, ["unknown-completion:auto-reviewer"]);
 });
 
 test("finding axis is falsifiable: a target move alone must not discharge a finding", () => {
@@ -264,7 +271,7 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
   // its silence is not being used as clean evidence for the new head.
   const scenario = {
     finalTarget: "6800b796", // post-fix head
-    actors: [{ name: "auto-reviewer", participation: "review", reliedOnForCleanEvidence: false }],
+    actors: [{ name: "auto-reviewer", participation: "review", boundedClosureSufficient: true }],
     runs: [
       {
         actor: "auto-reviewer",
@@ -283,11 +290,12 @@ test("regression 3: bounded accepted-fix does not re-require full discovery at t
     `bounded closure must not be blocked on a head re-review: ${blockers.join(", ")}`,
   );
 
-  // Contrast: if the agent DOES lean on that member's silence as the new head's
-  // clean evidence, the missing target-bound run blocks.
-  const relied = structuredClone(scenario);
-  relied.actors[0].reliedOnForCleanEvidence = true;
-  assert.deepEqual(evaluateFence(relied).blockers, ["unknown-completion:auto-reviewer"]);
+  // Contrast: absent a recorded stopping-rules decision, an expected member
+  // that never completed at the final target blocks. The exception must be
+  // claimed explicitly — it is not the default.
+  const noDecision = structuredClone(scenario);
+  delete noDecision.actors[0].boundedClosureSufficient;
+  assert.deepEqual(evaluateFence(noDecision).blockers, ["unknown-completion:auto-reviewer"]);
 });
 
 test("regression 4: optional reviewer — unknown does not block, findings do", () => {
@@ -342,7 +350,7 @@ test("regression 5: ordinary non-review actors are not promoted to expected revi
     actors: [
       { name: "human-collaborator", participation: "comment" },
       { name: "ci", participation: "status" },
-      { name: "auto-reviewer", participation: "review", reliedOnForCleanEvidence: true },
+      { name: "auto-reviewer", participation: "review" },
     ],
     runs: [
       {
@@ -373,7 +381,7 @@ test("regression 6: a required member is not exempted by declaring non-participa
   reselected.actors[0].selectionChangedToDropRequired = true;
   assert.equal(evaluateFence(reselected).mergeReady, true);
 
-  // An expected member, by contrast, may be discharged by declining.
+  // An expected member's *completion* obligation may be discharged by declining.
   assert.equal(
     evaluateFence({
       finalTarget: "abc1234",
@@ -384,10 +392,41 @@ test("regression 6: a required member is not exempted by declaring non-participa
   );
 });
 
+test("declining non-participation never discharges a finding already produced", () => {
+  // The exemption covers the completion obligation only. A reviewer that filed
+  // a finding on an ancestor target and then declined at the new target still
+  // owes that finding's Resolution — otherwise the PR #42 failure mode reopens
+  // through the decline path.
+  const scenario = {
+    finalTarget: "6800b796",
+    actors: [{ name: "auto-reviewer", declaredAutomatic: true, declinedParticipation: true }],
+    runs: [
+      {
+        actor: "auto-reviewer",
+        reviewedTarget: "354187da", // ancestor
+        reviewedTargetIsStable: true,
+        positiveCompletionEvidence: true,
+        findings: [{ id: "P1", resolved: false, triage: "fix" }],
+      },
+    ],
+  };
+
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false, "a declined member still owes Resolution for findings it produced");
+  assert.deepEqual(blockers, ["unresolved-finding:auto-reviewer:1"]);
+
+  // A permissive implementation — `if (member.declinedParticipation) continue;`
+  // placed before the finding axis — would return merge-ready here. That is the
+  // specific wrong implementation this test exists to reject.
+  const resolvedNow = structuredClone(scenario);
+  resolvedNow.runs[0].findings[0].resolved = true;
+  assert.equal(evaluateFence(resolvedNow).mergeReady, true, "resolving it is what clears the block");
+});
+
 test("silence is `unknown`, never 0 findings, when relied on as clean evidence", () => {
   const scenario = {
     finalTarget: "abc1234",
-    actors: [{ name: "declared-auto", declaredAutomatic: true, reliedOnForCleanEvidence: true }],
+    actors: [{ name: "declared-auto", declaredAutomatic: true }],
     runs: [
       {
         actor: "declared-auto",
@@ -403,7 +442,10 @@ test("silence is `unknown`, never 0 findings, when relied on as clean evidence",
   assert.deepEqual(blockers, ["unknown-completion:declared-auto"]);
 });
 
-test("fence blocks while untriaged findings remain on a review surface", () => {
+test("fence blocks while a finding on a review surface has not been triaged", () => {
+  // Derived from the finding itself, not from a caller-supplied count: a
+  // finding with no triage category is untriaged, and blocks on that ground
+  // separately from being unresolved.
   const scenario = {
     finalTarget: "abc1234",
     actors: [{ name: "auto-reviewer", participation: "review" }],
@@ -413,12 +455,21 @@ test("fence blocks while untriaged findings remain on a review surface", () => {
         reviewedTarget: "abc1234",
         reviewedTargetIsStable: true,
         positiveCompletionEvidence: true,
-        findings: [],
+        findings: [{ id: "P2", resolved: false }], // no triage category
       },
     ],
-    unresolvedFindingSurfaces: 1,
   };
-  assert.equal(evaluateFence(scenario).mergeReady, false);
+  const { mergeReady, blockers } = evaluateFence(scenario);
+  assert.equal(mergeReady, false);
+  assert.ok(blockers.includes("untriaged-finding:auto-reviewer:1"));
+
+  // Assigning a triage category clears the triage blocker but not Resolution:
+  // policy states a triage category alone is not Resolution completion.
+  const triaged = structuredClone(scenario);
+  triaged.runs[0].findings[0].triage = "needs-verification";
+  const after = evaluateFence(triaged);
+  assert.ok(!after.blockers.some((b) => b.startsWith("untriaged-finding")));
+  assert.ok(after.blockers.includes("unresolved-finding:auto-reviewer:1"));
 });
 
 // ---------------------------------------------------------------------------
@@ -470,8 +521,19 @@ test("core policy states the expected review set closure rule", async () => {
 test("a required member cannot be exempted by declaring non-participation", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
-  assert.ok(containsText(core, "expected / optional の member についてはその reviewer を blocker にしません"));
+  assert.ok(
+    containsText(core, "expected / optional の member については、その reviewer の target completion state を理由に blocker としません"),
+  );
   assert.ok(containsText(core, "required member は非参加の宣言によって blocker から外れません"));
+
+  // The exemption must not leak into the finding axis (round-2 F2).
+  assert.ok(
+    containsText(core, "非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を discharge しません"),
+  );
+  assert.ok(containsText(core, "ancestor target で出した finding についても同じです"));
+  assert.ok(
+    containsText(core, "非参加の宣言が免除するのは、その target について新たな completion evidence を得ることだけです"),
+  );
   assert.ok(
     containsText(core, "valid な代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す"),
   );
@@ -562,18 +624,38 @@ test("core policy defines the merge-ready completion fence without overriding st
   assert.ok(containsText(core, "**required member**:"));
   assert.ok(containsText(core, "**expected member**:"));
   assert.ok(containsText(core, "**optional / advisory member**:"));
+  // The expected-member obligation must be decidable from observable state,
+  // not from an agent's unstated intention (round-2 F1).
   assert.ok(
-    containsText(core, "その member の**不在または沈黙を、current target の `0 findings` / discovery evidence として使っていない**こと"),
+    containsText(core, "target completion state が `completed@target` または `declined` であること"),
   );
   assert.ok(
-    containsText(core, "使わない場合、target completion state が `unknown` であること自体は blocker ではありません"),
+    containsText(
+      core,
+      "targeted closure で十分と判定され、その member について追加の discovery が不要と判断される場合、この条件を要求しません",
+    ),
   );
+  assert.ok(
+    containsText(core, "agent の内心の申告（「この member の沈黙には依拠していない」等）で満たしたことにしてはいけません"),
+  );
+  assert.ok(containsText(core, "判定は observable な target completion state と、上記の記録された stopping rules 判断に基づきます"));
+
+  // required-member validity is judged per review stage, not against the final
+  // target (round-2 F7).
+  assert.ok(
+    containsText(core, "その run が属する review stage の expected target"),
+  );
+  assert.ok(containsText(core, "必ずしも final target に対して判定するのではありません"));
 
   // Ordering property: the fence is invalidated by later review-relevant state
   // changes — bounded, and not self-triggering.
   assert.ok(containsText(core, "**review-relevant な state 変化**があった場合、その fence 評価は無効となり、再評価します"));
+  // The self-exemption must name the referent explicitly (round-2 F5).
   assert.ok(
-    containsText(core, "agent 自身が本 Contract に従って persist する durable evidence の記録そのもの"),
+    containsText(
+      core,
+      "agent 自身が Review Protocol の各 Contract および本 fence に従って persist する durable evidence（acquisition record、triage / Resolution の記録、merge-ready report を含む）の記録そのもの",
+    ),
   );
   assert.ok(containsText(core, "fence を無効化しません"));
   assert.ok(containsText(core, "この再評価は無制限に繰り返しません"));
@@ -665,27 +747,48 @@ test("review-code skill carries the procedural detail for the fence", async () =
   assert.ok(containsText(skill, "capability/profile 側で再検証可能な observed evidence として扱います"));
 });
 
-test("the skills reference the Kernel rules rather than restating them", async () => {
+test("both skills reference the Kernel rules rather than restating them", async () => {
   // policy/core.md owns the normative rules; skills explain procedure. The
-  // sentences below are the Kernel's, and must not be duplicated verbatim into
-  // the skill, where the two copies could drift silently.
-  const skill = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  // sentences below are the Kernel's and must not be duplicated into either
+  // skill, where the copies could drift silently. Round 2 found the guard had
+  // covered only review-code.md while review-doc.md gained a fresh (and
+  // incomplete) copy in the same commit — so both are checked here, and the
+  // paraphrase that slipped past the exact-match check is included.
+  const code = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const doc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
 
-  for (const kernelSentence of [
+  const kernelSentences = [
     "全 member が final target で completed であることを要求するものではありません",
     "同じ reviewer による final target の full re-review を強制しません",
     "review target 上に presence があるだけでは足りず",
     "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません",
+    // the review-doc paraphrase of the same rule
+    "review target の移動に追随して値が変化するものを根拠にしません",
+    "その target への resolvable な参照を持つ positive completion evidence が必要です",
+  ];
+
+  for (const [name, text] of [
+    ["review-code.md", code],
+    ["review-doc.md", doc],
   ]) {
+    for (const kernelSentence of kernelSentences) {
+      assert.ok(
+        !containsText(text, kernelSentence),
+        `${name} restates a Kernel rule: ${kernelSentence}`,
+      );
+    }
+    // Each must point at the owner instead of carrying its own copy.
     assert.ok(
-      !containsText(skill, kernelSentence),
-      `review-code.md restates a Kernel rule verbatim: ${kernelSentence}`,
+      containsText(text, "`policy/core.md`"),
+      `${name} must reference the owning policy`,
     );
   }
 
-  // It must point at the owner instead.
-  assert.ok(containsText(skill, "は、いずれも `policy/core.md` が定めます"));
-  assert.ok(containsText(skill, "merge-ready の成立条件、review obligation の定義"));
+  assert.ok(containsText(code, "は、いずれも `policy/core.md` が定めます"));
+  assert.ok(containsText(code, "merge-ready の成立条件、review obligation の定義"));
+  assert.ok(
+    containsText(doc, "いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます"),
+  );
 });
 
 test("the Kernel states the fence without hard-coding provider specifics", async () => {

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -1320,10 +1320,12 @@ test("review skills document procedure without duplicating normative rules", asy
   ]) {
     assert.ok(reviewDoc.includes(phrase), `review-doc.md missing: ${phrase}`);
   }
+  // Issue #45 extended this enumeration with the expected review set; the
+  // Selection step must still name every Selection Contract item it confirms.
   assert.ok(
     containsText(
       reviewDoc,
-      "target SHA / range、target artifact set、reviewer / capability、required review 数を確定します。",
+      "target SHA / range、target artifact set、reviewer / capability、required review 数、および expected review set を確定します。",
     ),
   );
 
@@ -1452,14 +1454,22 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // Only valid runs' findings may reach triage; invalid/unknown/failure runs must not,
-  // matching review-code.md's "valid な run から finding を集約し" gate (Fix, Codex P2).
+  // The required count of valid runs remains the gate for *entering* triage.
   assert.ok(
     !containsText(reviewDoc, "確認できない run の finding は triage へ進めず、"),
     "review-doc.md must gate on valid (not just 'confirmable'), since invalid is a determinate Validity outcome, not an inability to confirm",
   );
-  assert.ok(containsText(reviewDoc, "valid な run の finding だけを triage へ進めます。"));
-  assert.ok(containsText(reviewDoc, "invalid / unknown / failure な run の finding は triage に使用しません。"));
+  assert.ok(
+    containsText(reviewDoc, "required 数の valid run が揃うことは triage へ進むための gate ですが、"),
+  );
+
+  // Issue #45 superseded the earlier "only valid runs' findings reach triage"
+  // rule: `validity` is an evidence-axis judgement and is not grounds for
+  // dropping a finding that a non-valid run already produced. The superseded
+  // instructions must be absent, not merely contradicted further down.
+  assert.ok(!containsText(reviewDoc, "valid な run の finding だけを triage へ進めます。"));
+  assert.ok(!containsText(reviewDoc, "invalid / unknown / failure な run の finding は triage に使用しません。"));
+  assert.ok(containsText(reviewDoc, "finding の集約対象は valid な run に限りません。"));
 
   assert.ok(
     containsText(reviewDoc, "closure verification 自体の completion / acquisition / validity も"),


### PR DESCRIPTION
## Context

Canonical Task Contract: https://github.com/reitojike/ai-dev-foundation/issues/45

- Discovery / design checkpoint: https://github.com/reitojike/ai-dev-foundation/issues/45#issuecomment-5379916104
- Design refinement addendum（本PRのdesign正本）: https://github.com/reitojike/ai-dev-foundation/issues/45#issuecomment-5379973367

`expected review set` が agent の選択した reviewer だけで閉じていたため、repository が
自動実行する reviewer の finding が merge-ready 判定の評価対象に入らない gap があった。

#31 が定めた completion detection semantics（fresh multi-surface / CI green ≠ completion /
positive evidence なしに 0 findings へ進まない）は正しいが、**それらは expected review set
の member に対して評価される**ため、set に入っていない reviewer に対しては一度も適用されず
空振りしていた。これが AF PR #42 と stage-tracker PR #51 の共通 root cause。

## Fix

### `policy/core.md`

- **Selection Contract** — expected review set の closure を追加。
  `required` / `expected` / `optional` の分類、observed review participation による
  membership、および **presence だけでは昇格させない** negative constraint（通常の human
  comment / CI actor / review 以外の bot）。未宣言かつ未観測の reviewer を set へ含められない
  **residual limitation** も明記する。
- **Acquisition & Validity Contract** — positive completion evidence が **target-bound** で
  あること、および reviewed target の確定に **安定 field / surface** を使い、review target の
  移動に追随する field を binding 根拠にしないことを追加。reviewed target が一致しない
  completed run を **evidence 軸 / finding 軸**へ分離する。
- **Resolution Contract** — ancestor target で発見された finding も対象であり、review target
  が移動したことだけでは discharge されないことを追加。
- **Merge readiness and merge authority** — `#### Merge-ready completion fence` を追加。
  Review stopping rules を**置き換えず参照**し、merge-ready を「各 member の review
  obligation が Review stopping rules に従って satisfied していること」で定義する。
  **全 member の final target completion は要求しない。**
- **Review Adapter boundary** — review participation の識別と、安定 field / head 追随 field の
  識別が adapter 責務であることを追加。

### `skills/review-code.md`

- Selection で expected review set を閉じる手順と、member とした根拠の記録
- Acquisition で target-bound / 安定 field / binding 根拠の記録
- **集約対象を valid な run に限定しない**（`validity` は evidence 軸の判定であり、finding を
  捨ててよい根拠ではない）
- merge-ready 宣言の**直前の最後の action** として fence を評価し、以降の state 変化で無効化
- head 追随 field / check-status を生成しない reviewer / `success` かつ "review skipped" な
  status を、**再検証可能な observed evidence** として記録

## Design decisions

- **fence の配置**: `Review stopping rules` ではなく `Merge readiness and merge authority` へ
  置いた。#36 Phase 1 が `Review stopping rules` を skill へ migrate するため、**gate 条件を
  always-on Kernel 側へ残す**という addendum の設計制約に沿う。この配置は test で assert 済み。
- **provider-neutrality**: Kernel には provider 名も API field 名も入れない。`Codex` /
  `CodeRabbit` / `original_commit_id` / `pulls/` 等が Kernel へ混入していないことを test で
  assert している。
- **stopping rules を上書きしない**: targeted closure で十分と判定される bounded fix について、
  同じ reviewer による final target の full re-review を強制しない。

## Regression coverage

`test/merge-ready-fence.test.mjs` — fence の **test-only decision model**（production
mechanism ではない）と regression proof。

1. **PR #42 型** — ancestor SHA（`354187da`）に finding があり final target が別 SHA
   （`c2b99f69`）の場合、finding Resolution なしに merge-ready にならない。ancestor run が
   clean evidence として使えないことも同時に assert。
2. **PR #51 型** — final target（`29447ce3`）に finding があるのに set / acquisition から
   漏れた場合、merge-ready にならない。reviewer が **observed review participation のみ**で
   set へ入ること、および head 追随 field では binding が成立しないことを assert。
3. **bounded accepted-fix** — targeted closure で十分な場合、automatic reviewer 自身の
   final-head full discovery を無条件に再要求しない（対照として、stopping rules 上
   satisfied でない場合は block することも assert）。
4. **optional / advisory** — `unknown` だけでは blocker にならないが、actual finding が
   観測された場合は Resolution 対象。
5. **ordinary non-review actor** — human commenter / CI actor / 非 review bot が
   observed-participant closure だけでは expected reviewer へ昇格しない。

加えて `2b`（silence を `0 findings` へ変換しない）と unresolved thread の block を assert。

decision model が vacuous でないことは negative control で確認済み: `classifyActor` を
「presence があれば昇格」へ変異させると regression 5 が
`AssertionError: human-collaborator promoted` で fail する。

## Verification

- `npm test`: **47 pass / 0 fail**
- `npm run test:guardrails`: **8 fixture green**
- `npm run check:fixture`: generated adapters / quality profile / skill bundle すべて current
- `git diff --check`: clean
- diff は **322 insertions / 0 deletions** — 既存 normative content の削除なし

## Out of scope（addendum に従い本PRから分離）

- **read-only fence helper は実装しない。** Kernel normative fix + repository backstop 適用後
  にも再発が観測された場合にのみ再評価する
- **`required_review_thread_resolution: true`** は採用方向だが、**独立した ops action** として
  扱い、本 PR の code / normative change へ混ぜない
- AF PR #42 / stage-tracker PR #51 の finding そのものの fix（各 lane で対応済み）
- #36 Phase 1 の着手（本 PR の land が prerequisite）

## Authority

本 session に **merge / Issue #45 close / release・tag** の authority はありません。
merge-ready で停止し、判断は別 authority へ委ねます。
