### PR TITLE
Review routing: formal Claude reviewでGitHub-native acquisitionを確実に選択する (Issue #49)

### DIFF
--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -300,18 +300,22 @@ GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は�
 ### Claude formal acquisition routing（Issue #22 決定の execution routing、Issue #49）
 
 Claude が Selection Contract 上 reviewer / capability として selection された
-場合、この repository には GitHub-native な `@claude` mention trigger workflow
-（`.github/workflows/claude-review.yml`）が存在します。この trigger が利用可能
-（workflow が repository に存在し、trigger する権限がある）かつ target/context に
-適している場合、Execution はこれを preferred/default route として使います。
+場合、review 対象の repository に GitHub-native な `@claude` mention trigger
+workflow が存在するかを確認します（この Foundation リポジトリ自身では
+`.github/workflows/claude-review.yml` がその実例です）。この workflow は
+Foundation が consumer へ配布するものではなく、review 対象の repository が
+個別に用意している必要があります。この trigger が利用可能（当該 repository に
+workflow が存在し、trigger する権限がある）かつ target/context に適している
+場合、Execution はこれを preferred/default route として使います。
 
-GitHub-native route が unavailable（workflow が存在しない、trigger 権限がない等）
-または unsuitable（target が workflow の扱える範囲を超える等）な場合に限り、
-in-session/subagent review を Claude の formal acquisition として使ってよく、その
-場合は上記 `collectOutputs()` の no-surface persistence 手順に従い、
-`policy/core.md` の Acquisition & Validity Contract が要求する durable evidence を
-PR/Issue へ明示的に persist します。この fallback は durable evidence requirement
-を免除しません。
+GitHub-native route が unavailable（review 対象の repository にそもそも
+該当 workflow が存在しない——多くの consumer repository はこれに該当します——、
+trigger 権限がない等）または unsuitable（target が workflow の扱える範囲を
+超える等）な場合に限り、in-session/subagent review を Claude の formal
+acquisition として使ってよく、その場合は上記 `collectOutputs()` の
+no-surface persistence 手順に従い、`policy/core.md` の Acquisition &
+Validity Contract が要求する durable evidence を PR/Issue へ明示的に
+persist します。この fallback は durable evidence requirement を免除しません。
 
 この節は Claude という provider に固有な運用手順であり、`policy/core.md` Kernel
 には Claude 固有の rule を追加しません。この節は Claude を全 PR mandatory にする

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -21,6 +21,21 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
 
+## Formal review と preflight/local 利用の境界（Issue #49）
+
+実装 session 中に Claude Code 本体や subagent を使った critique / self-check /
+design sanity check は自由に行ってよく、この skill の対象外です。これらは
+Selection Contract で reviewer / capability として selection されたものではなく、
+Acquisition & Validity Contract の record も持たないため、required review 数にも
+expected review set にも算入しません。
+
+Claude が Selection Contract 上 reviewer / capability として明示的に selection
+された場合にのみ、以降の手順および下記「Claude formal acquisition routing」が
+適用されます。selection されていない preflight/local 利用を、事後的に
+「Claude review を実施した」として required/expected review の消化根拠にしては
+いけません。この区別は Claude に限らず、他 provider の local/preflight 利用にも
+同様に適用します。
+
 ## 手順
 
 1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
@@ -280,6 +295,29 @@ Acquisition & Validity Contract の recoverability 要件を満たしやすい�
 capability record 側で再検証可能な observed evidence として扱ってください。
 GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は、上記の
 `collectOutputs()` の persist 手順を必ず行います。
+
+### Claude formal acquisition routing（Issue #22 決定の execution routing、Issue #49）
+
+Claude が Selection Contract 上 reviewer / capability として selection された
+場合、この repository には GitHub-native な `@claude` mention trigger workflow
+（`.github/workflows/claude-review.yml`）が存在します。この trigger が利用可能
+（workflow が repository に存在し、trigger する権限がある）かつ target/context に
+適している場合、Execution はこれを preferred/default route として使います。
+
+GitHub-native route が unavailable（workflow が存在しない、trigger 権限がない等）
+または unsuitable（target が workflow の扱える範囲を超える等）な場合に限り、
+in-session/subagent review を Claude の formal acquisition として使ってよく、その
+場合は上記 `collectOutputs()` の no-surface persistence 手順に従い、
+`policy/core.md` の Acquisition & Validity Contract が要求する durable evidence を
+PR/Issue へ明示的に persist します。この fallback は durable evidence requirement
+を免除しません。
+
+この節は Claude という provider に固有な運用手順であり、`policy/core.md` Kernel
+には Claude 固有の rule を追加しません。この節は Claude を全 PR mandatory にする
+ものでも、automatic required CI check にするものでもなく、Selection で Claude が
+選ばれた場合の acquisition route の優先順位のみを扱います。他 provider の
+acquisition policy（Codex automatic review trigger、CodeRabbit manual trigger 等）
+を変更するものではありません。
 
 さらに別の観測として、GitHub Actions 経由で PR comment を投稿・編集する reviewer では、
 その reviewer を起動した Actions job/step 自身の conclusion（success/failure）が、同じ

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -29,12 +29,13 @@ Selection Contract で reviewer / capability として selection されたもの
 Acquisition & Validity Contract の record も持たないため、required review 数にも
 expected review set にも算入しません。
 
-Claude が Selection Contract 上 reviewer / capability として明示的に selection
-された場合にのみ、以降の手順および下記「Claude formal acquisition routing」が
-適用されます。selection されていない preflight/local 利用を、事後的に
-「Claude review を実施した」として required/expected review の消化根拠にしては
-いけません。この区別は Claude に限らず、他 provider の local/preflight 利用にも
-同様に適用します。
+直後の `## 手順`（Deterministic verify 以降）は、reviewer / capability の選択に
+かかわらず共通に適用します。Claude が Selection Contract 上 reviewer /
+capability として明示的に selection された場合にのみ、下記「Claude formal
+acquisition routing」が追加で適用されます。selection されていない
+preflight/local 利用を、事後的に「Claude review を実施した」として
+required/expected review の消化根拠にしてはいけません。この区別は Claude に
+限らず、他 provider の local/preflight 利用にも同様に適用します。
 
 ## 手順
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -31,9 +31,10 @@ expected review set にも算入しません。selection されていない pref
 
 Claude が formal reviewer として selection された場合の GitHub-native
 acquisition routing（preferred/default route と fallback 時の durable
-evidence 要件）は artifact classification に関わらず共通であり、
-`skills/review-code.md` の「Claude formal acquisition routing」節に従います。
-この skill では重複定義しません。
+evidence 要件）は artifact classification に関わらず共通であり、Foundation
+リポジトリの `skills/review-code.md`（consumer には
+`.ai-dev-foundation/skills/review-code.md` として配布）の「Claude formal
+acquisition routing」節に従います。この skill では重複定義しません。
 
 ## 手順
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -29,6 +29,12 @@ expected review set にも算入しません。selection されていない pref
 してはいけません。この区別は Claude に限らず、他 provider の local/preflight
 利用にも同様に適用します。
 
+Claude が formal reviewer として selection された場合の GitHub-native
+acquisition routing（preferred/default route と fallback 時の durable
+evidence 要件）は artifact classification に関わらず共通であり、
+`skills/review-code.md` の「Claude formal acquisition routing」節に従います。
+この skill では重複定義しません。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -18,6 +18,17 @@ Normative、Review contracts、Review stopping rules）を使った実行手順�
 Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 agent や
 実装を拘束する文書）の review。
 
+## Formal review と preflight/local 利用の境界（Issue #49）
+
+実装 session 中に Claude Code 本体や subagent を使った critique / self-check /
+design sanity check は自由に行ってよく、この skill の対象外です。これらは
+Selection Contract で reviewer / capability として selection されたものではなく、
+Acquisition & Validity Contract の record も持たないため、required review 数にも
+expected review set にも算入しません。selection されていない preflight/local
+利用を、事後的に「review を実施した」として required/expected review の消化根拠に
+してはいけません。この区別は Claude に限らず、他 provider の local/preflight
+利用にも同様に適用します。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -73,6 +73,21 @@ test("review-code.md gives Claude formal-reviewer selection an execution-reachab
 test("review-code.md excludes local/preflight Claude usage from formal required review counting", async () => {
   const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
+  // Closure round (Codex P1 + Claude closure review on PR #50): the boundary
+  // section's phrasing must not read as conditioning the entire common
+  // `## 手順` procedure (Deterministic verify / Selection / Execution /
+  // required review gate) on Claude being the selected reviewer — those
+  // steps apply regardless of which reviewer/capability was selected. Only
+  // the Claude-specific acquisition routing is conditioned on Claude
+  // selection.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "直後の `## 手順`（Deterministic verify 以降）は、reviewer / capability の選択にかかわらず共通に適用します。",
+    ),
+    "the boundary section must state that the common ## 手順 procedure applies regardless of reviewer selection",
+  );
+
   assert.ok(
     containsText(reviewCode, "## Formal review と preflight/local 利用の境界"),
     "review-code.md must have a dedicated section distinguishing preflight/local usage from formal review",

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -140,6 +140,31 @@ test("review-doc.md also excludes local/preflight usage from formal required rev
   );
 });
 
+test("review-doc.md points Normative Claude formal review at the same GitHub-native acquisition routing", async () => {
+  // Codex P2 on PR #50 closure round 2: the Claude acquisition routing section
+  // only existed in review-code.md (Executable), so a Normative artifact
+  // review following review-doc.md had no reachable path to the preferred
+  // GitHub-native route, leaving Issue #49's routing gap open for that
+  // classification. Fixed by a pointer, not a duplicated section, per this
+  // repo's "skill does not restate normative rules it doesn't own" convention.
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "Claude が formal reviewer として selection された場合の GitHub-native acquisition routing",
+    ) && containsText(reviewDoc, "`skills/review-code.md` の「Claude formal acquisition routing」節に従います。"),
+    "review-doc.md must point Claude formal reviewer selection at review-code.md's Claude acquisition routing section",
+  );
+
+  // Guard against the pointer regressing into a duplicated copy of the
+  // routing rule instead of a reference to the single owning section.
+  assert.ok(
+    !containsText(reviewDoc, ".github/workflows/claude-review.yml"),
+    "review-doc.md must not duplicate the workflow-file-specific routing rule; it must defer to review-code.md",
+  );
+});
+
 test("core policy is not amended with a Claude-specific Kernel rule by Issue #49", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -153,8 +153,11 @@ test("review-doc.md points Normative Claude formal review at the same GitHub-nat
     containsText(
       reviewDoc,
       "Claude が formal reviewer として selection された場合の GitHub-native acquisition routing",
-    ) && containsText(reviewDoc, "`skills/review-code.md` の「Claude formal acquisition routing」節に従います。"),
-    "review-doc.md must point Claude formal reviewer selection at review-code.md's Claude acquisition routing section",
+    ) && containsText(
+      reviewDoc,
+      "`skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md` として配布）の「Claude formal acquisition routing」節に従います。",
+    ),
+    "review-doc.md must point Claude formal reviewer selection at review-code.md's Claude acquisition routing section, in a form resolvable from consumer context too",
   );
 
   // Guard against the pointer regressing into a duplicated copy of the
@@ -162,6 +165,15 @@ test("review-doc.md points Normative Claude formal review at the same GitHub-nat
   assert.ok(
     !containsText(reviewDoc, ".github/workflows/claude-review.yml"),
     "review-doc.md must not duplicate the workflow-file-specific routing rule; it must defer to review-code.md",
+  );
+
+  // Codex P2 (closure round 3): the bare Foundation-repo-only path is not
+  // resolvable from a consumer's checkout, since sync.mjs materializes skills
+  // under .ai-dev-foundation/skills/ and consumers have no skills/ at repo
+  // root. The pointer must name the consumer-distributed path too.
+  assert.ok(
+    containsText(reviewDoc, ".ai-dev-foundation/skills/review-code.md"),
+    "review-doc.md's pointer must be resolvable from consumer context, naming the .ai-dev-foundation/skills/ distributed path",
   );
 });
 

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -40,6 +40,28 @@ test("review-code.md gives Claude formal-reviewer selection an execution-reachab
     "the Claude routing section must name Claude, the actual workflow file, and state it as the preferred/default route",
   );
 
+  // Codex P2 (closure round 4): the section must not read as if
+  // .github/workflows/claude-review.yml (or an equivalent) is something
+  // Foundation distributes to every consumer. sync.mjs does not materialize
+  // .github/ into consumers, and the reference consumer fixture has none, so
+  // most consumer repositories will hit the "workflow does not exist" branch
+  // of unavailable and correctly fall back — but only if the text says so
+  // explicitly instead of implying universal availability.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この workflow は Foundation が consumer へ配布するものではなく、review 対象の repository が個別に用意している必要があります。",
+    ),
+    "the Claude routing section must disclaim that the GitHub-native workflow is Foundation-distributed",
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "review 対象の repository にそもそも該当 workflow が存在しない",
+    ) && containsText(reviewCode, "多くの consumer repository はこれに該当します"),
+    "the unavailable branch must explicitly cover the common case of a consumer repository with no such workflow",
+  );
+
   // The preferred route must not be promoted to a mandatory/automatic gate —
   // that would violate the #22/#49 invariant against making Claude mandatory
   // on every PR or an automatic required CI check.

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+// Issue #49: the #22 decision ("Claude selected as formal reviewer -> prefer
+// the GitHub-native `@claude` route by default") existed only as an
+// anonymized narrative aside in review-code.md, never as an execution-reachable
+// instruction naming Claude or the actual workflow file. These guards protect
+// the dedicated, explicitly-named routing section added to close that gap,
+// without loosening the pre-existing anonymization guard on the unrelated
+// "Observed example" narrative (see the adjacent review-protocol.test.mjs
+// assertions, which this file intentionally does not duplicate).
+test("review-code.md gives Claude formal-reviewer selection an execution-reachable GitHub-native preferred route", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  assert.ok(
+    containsText(reviewCode, "### Claude formal acquisition routing"),
+    "review-code.md must have a dedicated, explicitly-named Claude acquisition routing section",
+  );
+
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Claude が Selection Contract 上 reviewer / capability として selection された場合",
+    ) &&
+      containsText(reviewCode, ".github/workflows/claude-review.yml") &&
+      containsText(reviewCode, "preferred/default route として使います"),
+    "the Claude routing section must name Claude, the actual workflow file, and state it as the preferred/default route",
+  );
+
+  // The preferred route must not be promoted to a mandatory/automatic gate —
+  // that would violate the #22/#49 invariant against making Claude mandatory
+  // on every PR or an automatic required CI check.
+  assert.ok(
+    containsText(reviewCode, "Claude を全 PR mandatory にするものでも、automatic required CI check にするものでもなく"),
+    "the Claude routing section must disclaim mandatory/automatic-CI status",
+  );
+
+  // Fallback to in-session/subagent acquisition must not silently drop the
+  // #22 durable evidence requirement.
+  assert.ok(
+    containsText(reviewCode, "in-session/subagent review を Claude の formal acquisition として使ってよく") &&
+      containsText(reviewCode, "durable evidence を") &&
+      containsText(reviewCode, "この fallback は durable evidence requirement を免除しません"),
+    "the fallback path must still require persisting #22 durable evidence",
+  );
+
+  // This is Claude-provider-specific operational guidance; it must not claim
+  // to add a rule to the provider-neutral Kernel, and must not touch other
+  // providers' acquisition policy.
+  assert.ok(
+    containsText(reviewCode, "`policy/core.md` Kernel には Claude 固有の rule を追加しません"),
+    "the Claude routing section must disclaim adding a Claude-specific Kernel rule",
+  );
+  assert.ok(
+    containsText(reviewCode, "他 provider の") && containsText(reviewCode, "acquisition policy"),
+    "the Claude routing section must disclaim changing other providers' acquisition policy",
+  );
+});
+
+test("review-code.md excludes local/preflight Claude usage from formal required review counting", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  assert.ok(
+    containsText(reviewCode, "## Formal review と preflight/local 利用の境界"),
+    "review-code.md must have a dedicated section distinguishing preflight/local usage from formal review",
+  );
+
+  assert.ok(
+    containsText(
+      reviewCode,
+      "実装 session 中に Claude Code 本体や subagent を使った critique / self-check / design sanity check は自由に行ってよく、この skill の対象外です。",
+    ),
+    "preflight/local critique must be explicitly declared out of this skill's scope",
+  );
+
+  assert.ok(
+    containsText(
+      reviewCode,
+      "required review 数にも expected review set にも算入しません。",
+    ),
+    "preflight/local usage must not count toward required/expected review membership",
+  );
+
+  assert.ok(
+    containsText(
+      reviewCode,
+      "selection されていない preflight/local 利用を、事後的に「Claude review を実施した」として required/expected review の消化根拠にしてはいけません。",
+    ),
+    "the boundary must explicitly forbid retroactively counting unselected local usage as formal review",
+  );
+});
+
+test("core policy is not amended with a Claude-specific Kernel rule by Issue #49", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(
+    !/\bClaude\b/.test(core),
+    "policy/core.md (the provider-neutral Kernel) must not name Claude specifically",
+  );
+});

--- a/test/claude-review-acquisition-routing.test.mjs
+++ b/test/claude-review-acquisition-routing.test.mjs
@@ -103,6 +103,28 @@ test("review-code.md excludes local/preflight Claude usage from formal required 
   );
 });
 
+test("review-doc.md also excludes local/preflight usage from formal required review counting", async () => {
+  // Claude review on PR #50 flagged that the review-code.md-only boundary left
+  // the same ambiguity possible for Normative artifact review, since the
+  // general "preflight/local doesn't count as formal review" principle isn't
+  // specific to Executable's provider-adapter routing gap that motivated
+  // Issue #49's review-code.md-focused root cause.
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  assert.ok(
+    containsText(reviewDoc, "## Formal review と preflight/local 利用の境界"),
+    "review-doc.md must have a dedicated section distinguishing preflight/local usage from formal review",
+  );
+
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "required review 数にも expected review set にも算入しません。",
+    ),
+    "preflight/local usage must not count toward required/expected review membership in review-doc.md",
+  );
+});
+
 test("core policy is not amended with a Claude-specific Kernel rule by Issue #49", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -300,18 +300,22 @@ GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は�
 ### Claude formal acquisition routing（Issue #22 決定の execution routing、Issue #49）
 
 Claude が Selection Contract 上 reviewer / capability として selection された
-場合、この repository には GitHub-native な `@claude` mention trigger workflow
-（`.github/workflows/claude-review.yml`）が存在します。この trigger が利用可能
-（workflow が repository に存在し、trigger する権限がある）かつ target/context に
-適している場合、Execution はこれを preferred/default route として使います。
+場合、review 対象の repository に GitHub-native な `@claude` mention trigger
+workflow が存在するかを確認します（この Foundation リポジトリ自身では
+`.github/workflows/claude-review.yml` がその実例です）。この workflow は
+Foundation が consumer へ配布するものではなく、review 対象の repository が
+個別に用意している必要があります。この trigger が利用可能（当該 repository に
+workflow が存在し、trigger する権限がある）かつ target/context に適している
+場合、Execution はこれを preferred/default route として使います。
 
-GitHub-native route が unavailable（workflow が存在しない、trigger 権限がない等）
-または unsuitable（target が workflow の扱える範囲を超える等）な場合に限り、
-in-session/subagent review を Claude の formal acquisition として使ってよく、その
-場合は上記 `collectOutputs()` の no-surface persistence 手順に従い、
-`policy/core.md` の Acquisition & Validity Contract が要求する durable evidence を
-PR/Issue へ明示的に persist します。この fallback は durable evidence requirement
-を免除しません。
+GitHub-native route が unavailable（review 対象の repository にそもそも
+該当 workflow が存在しない——多くの consumer repository はこれに該当します——、
+trigger 権限がない等）または unsuitable（target が workflow の扱える範囲を
+超える等）な場合に限り、in-session/subagent review を Claude の formal
+acquisition として使ってよく、その場合は上記 `collectOutputs()` の
+no-surface persistence 手順に従い、`policy/core.md` の Acquisition &
+Validity Contract が要求する durable evidence を PR/Issue へ明示的に
+persist します。この fallback は durable evidence requirement を免除しません。
 
 この節は Claude という provider に固有な運用手順であり、`policy/core.md` Kernel
 には Claude 固有の rule を追加しません。この節は Claude を全 PR mandatory にする

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -21,6 +21,21 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
 
+## Formal review と preflight/local 利用の境界（Issue #49）
+
+実装 session 中に Claude Code 本体や subagent を使った critique / self-check /
+design sanity check は自由に行ってよく、この skill の対象外です。これらは
+Selection Contract で reviewer / capability として selection されたものではなく、
+Acquisition & Validity Contract の record も持たないため、required review 数にも
+expected review set にも算入しません。
+
+Claude が Selection Contract 上 reviewer / capability として明示的に selection
+された場合にのみ、以降の手順および下記「Claude formal acquisition routing」が
+適用されます。selection されていない preflight/local 利用を、事後的に
+「Claude review を実施した」として required/expected review の消化根拠にしては
+いけません。この区別は Claude に限らず、他 provider の local/preflight 利用にも
+同様に適用します。
+
 ## 手順
 
 1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
@@ -280,6 +295,29 @@ Acquisition & Validity Contract の recoverability 要件を満たしやすい�
 capability record 側で再検証可能な observed evidence として扱ってください。
 GitHub-native 経路を使わず in-session/subagent review を選ぶ場合は、上記の
 `collectOutputs()` の persist 手順を必ず行います。
+
+### Claude formal acquisition routing（Issue #22 決定の execution routing、Issue #49）
+
+Claude が Selection Contract 上 reviewer / capability として selection された
+場合、この repository には GitHub-native な `@claude` mention trigger workflow
+（`.github/workflows/claude-review.yml`）が存在します。この trigger が利用可能
+（workflow が repository に存在し、trigger する権限がある）かつ target/context に
+適している場合、Execution はこれを preferred/default route として使います。
+
+GitHub-native route が unavailable（workflow が存在しない、trigger 権限がない等）
+または unsuitable（target が workflow の扱える範囲を超える等）な場合に限り、
+in-session/subagent review を Claude の formal acquisition として使ってよく、その
+場合は上記 `collectOutputs()` の no-surface persistence 手順に従い、
+`policy/core.md` の Acquisition & Validity Contract が要求する durable evidence を
+PR/Issue へ明示的に persist します。この fallback は durable evidence requirement
+を免除しません。
+
+この節は Claude という provider に固有な運用手順であり、`policy/core.md` Kernel
+には Claude 固有の rule を追加しません。この節は Claude を全 PR mandatory にする
+ものでも、automatic required CI check にするものでもなく、Selection で Claude が
+選ばれた場合の acquisition route の優先順位のみを扱います。他 provider の
+acquisition policy（Codex automatic review trigger、CodeRabbit manual trigger 等）
+を変更するものではありません。
 
 さらに別の観測として、GitHub Actions 経由で PR comment を投稿・編集する reviewer では、
 その reviewer を起動した Actions job/step 自身の conclusion（success/failure）が、同じ

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -29,12 +29,13 @@ Selection Contract で reviewer / capability として selection されたもの
 Acquisition & Validity Contract の record も持たないため、required review 数にも
 expected review set にも算入しません。
 
-Claude が Selection Contract 上 reviewer / capability として明示的に selection
-された場合にのみ、以降の手順および下記「Claude formal acquisition routing」が
-適用されます。selection されていない preflight/local 利用を、事後的に
-「Claude review を実施した」として required/expected review の消化根拠にしては
-いけません。この区別は Claude に限らず、他 provider の local/preflight 利用にも
-同様に適用します。
+直後の `## 手順`（Deterministic verify 以降）は、reviewer / capability の選択に
+かかわらず共通に適用します。Claude が Selection Contract 上 reviewer /
+capability として明示的に selection された場合にのみ、下記「Claude formal
+acquisition routing」が追加で適用されます。selection されていない
+preflight/local 利用を、事後的に「Claude review を実施した」として
+required/expected review の消化根拠にしてはいけません。この区別は Claude に
+限らず、他 provider の local/preflight 利用にも同様に適用します。
 
 ## 手順
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -31,9 +31,10 @@ expected review set にも算入しません。selection されていない pref
 
 Claude が formal reviewer として selection された場合の GitHub-native
 acquisition routing（preferred/default route と fallback 時の durable
-evidence 要件）は artifact classification に関わらず共通であり、
-`skills/review-code.md` の「Claude formal acquisition routing」節に従います。
-この skill では重複定義しません。
+evidence 要件）は artifact classification に関わらず共通であり、Foundation
+リポジトリの `skills/review-code.md`（consumer には
+`.ai-dev-foundation/skills/review-code.md` として配布）の「Claude formal
+acquisition routing」節に従います。この skill では重複定義しません。
 
 ## 手順
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -29,6 +29,12 @@ expected review set にも算入しません。selection されていない pref
 してはいけません。この区別は Claude に限らず、他 provider の local/preflight
 利用にも同様に適用します。
 
+Claude が formal reviewer として selection された場合の GitHub-native
+acquisition routing（preferred/default route と fallback 時の durable
+evidence 要件）は artifact classification に関わらず共通であり、
+`skills/review-code.md` の「Claude formal acquisition routing」節に従います。
+この skill では重複定義しません。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -18,6 +18,17 @@ Normative、Review contracts、Review stopping rules）を使った実行手順�
 Normative artifact（AGENTS / Skill / PRODUCT / ARCHITECTURE / ADR 等、後続 agent や
 実装を拘束する文書）の review。
 
+## Formal review と preflight/local 利用の境界（Issue #49）
+
+実装 session 中に Claude Code 本体や subagent を使った critique / self-check /
+design sanity check は自由に行ってよく、この skill の対象外です。これらは
+Selection Contract で reviewer / capability として selection されたものではなく、
+Acquisition & Validity Contract の record も持たないため、required review 数にも
+expected review set にも算入しません。selection されていない preflight/local
+利用を、事後的に「review を実施した」として required/expected review の消化根拠に
+してはいけません。この区別は Claude に限らず、他 provider の local/preflight
+利用にも同様に適用します。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical


### PR DESCRIPTION
Canonical Task Contract: #49

## Root cause（今回のfresh確認で特定）

#22でGitHub-native `@claude` route（`.github/workflows/claude-review.yml`）を
Claudeのpreferred acquisition pathとする決定は既にあり、実際にPR #24でも
`skills/review-code.md`の Adapter boundary「Observed example」節へ、この観測を
反映するテキストが追加されていた。

しかしfreshに追ってみると、その接続点には次の構造的な問題があった。

1. 当該テキストは意図的に**匿名化**されており（provider名を恒久ruleとして
   固定しないため）、Issue #24 PR #24自身が追加したregression test
   （`test/review-protocol.test.mjs`）が「`GitHub-native trigger`という語の
   直後にClaude/Codex/CodeRabbitのいずれかの名前が現れてはいけない」ことを
   明示的に禁止していた。
2. そのテキストは「Adapter boundary（manual pilot）」配下の「Observed example
   （provider固有の恒久ruleではない）」という**過去の観測の逸話**として
   書かれており、Selection/Executionの実行手順（`skills/review-code.md`の
   手順3・4）から参照されない、実行到達不能な位置にあった。
3. `.github/workflows/claude-review.yml`という実在のworkflow fileへの
   named referenceがどこにも存在せず、execution agentがClaudeをformal
   reviewerとしてselectionしても「どのrouteを使うべきか」を実行可能な形
   では特定できなかった。

つまり#22 decisionは**存在してはいたが、匿名化制約とnarrative配置によって
execution agentが実際に読む最小authority surfaceへ実行可能な形で接続されて
いなかった**（acquisition-routing gap）。

加えて、local/preflight Claude利用（実装session中のcritique/self-check）と
formal Discovery/Closureの境界を明文化したtextはFoundation上どこにも
存在しなかった（`skills/*.md`・`policy/core.md`をfresh grep で確認、0件）。

## 変更内容

- `skills/review-code.md`
  - 新設「Formal review と preflight/local 利用の境界（Issue #49）」節
    （`## 対象`直後）: 実装session中のClaude Code/subagent critiqueは
    自由に使えるがこのskillの対象外であり、required/expected review setに
    暗黙に算入しないことを明記。この区別はClaudeに限らず他providerの
    local/preflight利用にも同様に適用する旨を明記。直後の共通`## 手順`は
    reviewer/capabilityの選択にかかわらず適用されることも明記（Codex P1、
    後述closure round参照）。
  - 新設「Claude formal acquisition routing」節（既存の匿名化された
    Observed exampleとは別の、明示的にClaude名を持つ節）: Claudeが
    Selection Contract上reviewer/capabilityとしてselectionされた場合、
    review対象repositoryにGitHub-native `@claude` trigger workflowが
    存在するかを確認し、存在すればpreferred/default routeとする
    （この Foundation リポジトリでの実例が`.github/workflows/claude-review.yml`）。
    この workflow は Foundation が consumer へ配布するものではなく、review
    対象の repository が個別に用意する必要があること、多くの consumer
    repository では unavailable に該当し fallback へ進むことを明記
    （Codex P2、後述closure round参照）。unavailable/unsuitableな場合のみ
    in-session fallbackを許容し、その場合も既存`collectOutputs()`の
    durable evidence persist手順を必ず行うことを明記。Kernelへの
    Claude固有rule追加ではないこと、Claude mandatory化・automatic
    required CI check化ではないこと、他providerのacquisition policyを
    変更しないことを同節内で明示的に disclaim。
  - 既存の匿名化されたObserved example自体・regression testはそのまま維持
    （anonymization制約を弱めていない）。
- `skills/review-doc.md`
  - `skills/review-code.md`と同じ「Formal review と preflight/local 利用の
    境界」節を追加（artifact classificationに依存しない一般原則のため）。
  - Claude formal acquisition routingについては、routing自体を複製せず
    `skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md`
    として配布）の当該節へのpointerを追加（Codex P2、後述closure round参照）。
- `test/claude-review-acquisition-routing.test.mjs`（新規、8 test）
  - 上記各節の存在・内容・closure roundで修正した各箇所をassertするregression
    guard一式。mandatory/automatic-CI化のdisclaimer、durable evidence fallback
    要件、他provider不変更のdisclaimer、consumer解決可能性、Foundation非配布
    workflowであることの明記も含む。
  - `policy/core.md`（Kernel）へ`Claude`という語が一切現れないことを
    assertするguard（Kernel provider-neutral性の直接的な回帰保護）。
- `test/fixtures/consumer/.ai-dev-foundation/skills/{review-code.md,review-doc.md}`:
  `npm run sync:fixture`で再生成。

## Invariants遵守の確認

- Claude全PR mandatory化: していない（selection contractで選ばれた場合のみ
  適用される節として記述）
- automatic required CI check化: していない（既存`claude-review.yml`は
  `@claude` mentionのmanual trigger のまま、trigger機構自体は変更していない）
- provider-neutral Selection Contract: 維持（`policy/core.md`は無変更、
  `Claude`という語は0件のままであることをtestでguard）
- local Claude critique自体の禁止: していない（明示的に「自由に行ってよい」
  と記述）
- local/preflight critiqueのformal review暗黙算入: 明示的に禁止する文言を追加
  （review-code.md・review-doc.md 両方）
- Kernelへのprovider-specific hard-code: していない（review-code.md /
  review-doc.md側に配置）
- Issue #45との責務分離: #45（async review completion fence）のscope・
  実装には触れていない。矛盾がないことをfreshに確認済み（PR #48で
  merge済みのcompletion fenceはreviewer selectionそのものではなくfinal head
  に対するasync completion detectionを扱っており、本Issueのacquisition
  routing gapとは独立）
- Codex / CodeRabbit acquisition policy: 変更していない（`.coderabbit.yaml`・
  Codex関連の既存テキストは無変更）
- consumer側の重複policy: 追加していない（stage-tracker等は変更しておらず、
  既存のFoundation distribution経路 `.ai-dev-foundation/skills/`のsync/check
  機構でそのまま伝播する。review-doc.mdのpointerもconsumer解決可能なpathを
  明記済み）

## Final state（closure完了、final head `9ffc339790b3b23e17a94b96561eb796f1e45f21`）

本Issue自身が確立するGitHub-native `@claude` route（および既存のCodex
automatic review）を実際に使い、独立reviewer 2系統でclosureまで完了した。

- Claude（GitHub-native `@claude` mention trigger）: 5 round実施。round1で
  improvement提案2件（blockerなし）、round2でCodex P1 findingの独立確認・
  修正確認、round3〜5でCodex P2 finding 3件それぞれの修正確認。round5
  （final head）では新規findingなし。
- Codex（automatic review trigger）: 各headに対してreview submission。
  round1〜5でP1×1・P2×3を検出、都度同一PR内で修正・再検証。final head
  `9ffc339`のreviewでは "Didn't find any major issues. Delightful!"（0
  findings）。
- 過去4件のinline review thread（P1×1、P2×3）は、いずれも対応commitへの
  参照付きでreplyし、resolve済み（unresolved review thread = 0）。
- required review数（2、独立reviewer 2系統）ぶんの `validity: valid` な run
  が、同一 final head SHA `9ffc339` に対して揃っている。

durable evidenceの詳細（各roundのfinding内容とfix commit対応）は、本PR上の
`Merge-ready 報告（Review Protocol closure記録）` コメントに記録済み。

## Mechanical check（Normative precondition）

final head `9ffc339790b3b23e17a94b96561eb796f1e45f21` に対して実行。

| check | result |
| --- | --- |
| `npm test`（97 tests: 96 pass / 1 platform-skip[^1]、guardrails含む） | pass |
| `npm run check:fixture`（drift check） | pass（generated adapters/skill bundle are current） |
| `git diff --check` | pass |

[^1]: symlink migration testは本環境（Windows, non-admin）でシンボリックリンク
作成不可のためskip（`EPERM`）。本Issueの変更と無関係な既存の環境依存skip。

## Merge-ready

unresolved review thread なし。remaining blockers なし。merge-readyで停止
しています。merge / Issue #49 close / release / stage-tracker repin の
authorityはこのスレッドにもありません。
