### PR TITLE
Review stopping rulesのfinite flowをFoundation-owned review skillへ移行する (Issue #51 Phase 1)

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -506,9 +506,10 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 ### Merge readiness and merge authority
 
 本節における review completion（Resolution Contract の完了を含む）が
-成立した状態を **merge-ready** と呼びます。Review contracts および
-Review stopping rules で `merge` と記述する到達点は、merge-ready の
-成立を指し、merge を実行してよいという判断そのものとは同義ではありません。
+成立した状態を **merge-ready** と呼びます。Review contracts、Review stopping
+rules、および Skill routing contract が指す review skill の手順で `merge` と
+記述する到達点は、merge-ready の成立を指し、merge を実行してよいという判断
+そのものとは同義ではありません。
 
 merge execution authority は、Review Protocol とは別の contract /
 context として扱います。current Task、Execution Envelope、または
@@ -687,74 +688,6 @@ upstream task/design または policy/document 自体の instability を疑い�
 必要に応じて escalate します。これは Failure / retry の retry count とは
 別の stopping semantics です。
 
-Code review:
-
-```text
-deterministic verify
-  -> freeze candidate SHA
-  -> verify target と freeze target の consistency 確認
-  -> discovery（独立 reviewer）
-  -> completion / acquisition / validity 確認
-  -> aggregate / triage
-  -> accepted finding の batch fix で review target が変更された場合:
-       batch fix + root-cause sweep
-       -> deterministic verify
-       -> fix が behavior / blast radius を materially 変えた場合のみ:
-            second discovery target の Selection / Execution
-            -> full discovery（2nd round、独立 reviewer）
-            -> completion / acquisition / validity 確認
-            -> required review 数の valid run 確認
-            -> aggregate / triage
-            -> accepted finding があれば batch fix
-            -> target が変われば deterministic verify
-            -> この fix でさらに追加の full discovery が必要と判断される
-               場合: 3rd full discovery は起動せず、merge もせず、
-               upstream task/design の不安定さを疑い、必要に応じて
-               escalate する
-       -> closure target の Selection / Execution
-       -> targeted closure
-       -> closure completion / acquisition / validity 確認
-       -> closure finding の Resolution
-       -> accepted closure finding があれば:
-            batch fix
-            -> deterministic verify
-            -> Review stopping rules の再評価
-            -> 2nd full discovery 未使用かつ必要な場合:
-                 second discovery target の Selection / Execution から
-                 上記の full discovery route へ進み、完了後 targeted
-                 closure を再実行する
-            -> 2nd full discovery 使用済みでなお必要な場合:
-                 3rd full discovery は起動せず、merge もせず、
-                 upstream task/design の不安定さを疑い、必要に応じて
-                 escalate する
-            -> 追加の full discovery が不要な場合:
-                 targeted closure を再実行する
-       -> required discovery stage(s) の Resolution 完了
-       -> merge
-  -> accepted fix が無く review target が変更されていない場合:
-       required review 数の valid discovery と Resolution の完了
-       -> merge
-```
-
-accepted finding の batch fix によって review target が変更された場合のみ
-targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。targeted closure
-の finding も Resolution Contract の対象とし、Resolution が完了するまで
-merge しません。
-targeted closure の Resolution に加えて、この review flow で実行した
-discovery stage（2nd full discovery を含む）すべての Resolution が
-完了していることも merge の条件です。完了順序は問いません。
-targeted closure の finding に accepted fix がある場合も、fix 後の
-deterministic verify を経て Review stopping rules を再評価します。2nd
-full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
-に targeted closure をやり直します。2nd full discovery を使用済みでなお
-full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
-upstream task/design の不安定さを疑い、必要に応じて escalate します。
-追加の full discovery が不要なら、targeted closure をやり直します。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid discovery と Resolution の完了をもって、
-新たな closure run を要求せずに merge できます。
-
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
 upstream task/design の不安定さを疑います。
@@ -763,38 +696,11 @@ blast radius をさらに materially 変えた場合は、3rd full discovery を
 せず、targeted closure だけで merge へ進まず、upstream task/design の
 不安定さを疑い、必要に応じて escalate します。
 
-Normative document review:
-
-```text
-mechanical check
-  -> mechanical check target と Selection target の consistency 確認
-  -> semantic discovery（1 round）
-  -> triage / fix
-  -> accepted finding の fix で review target が変更された場合:
-       mechanical check
-       -> closure target の Selection / Execution
-       -> closure verification
-       -> closure completion / acquisition / validity 確認
-       -> closure finding の Resolution
-       -> semantic discovery の Resolution 完了
-       -> 完了
-  -> accepted fix が無く review target が変更されていない場合:
-       required review 数の valid semantic discovery と Resolution の完了
-       -> 完了
-```
-
-accepted finding の fix によって review target が変更された場合のみ、
-新しい target に対して mechanical check を再実行してから closure
-verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。closure
-verification の finding も Resolution Contract の対象とし、Resolution が
-完了するまで review を完了しません。
-closure verification の Resolution に加えて、semantic discovery（手順 3）
-の Resolution が完了していることも review completion の条件です。完了
-順序は問いません。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid semantic discovery と Resolution の完了をもって、
-新たな closure run を要求せずに review を完了できます。
+本節が定める stopping semantics（evidence の target 束縛、round / cycle の上限と
+escalate 判断）を、artifact classification ごとの具体的な review 手順のどこで評価
+するかは、その手順自体に属します。この review 手順の canonical source は
+Foundation-owned な review skill であり、本節には置きません。該当する review 手順
+へ入る前に、Skill routing contract に従って対応する skill を load します。
 
 ### Observed evidence is not a permanent provider rule
 

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -4,6 +4,8 @@
 Executable、Review contracts、Review Adapter boundary、Failure / retry、Review
 stopping rules）を使った実行手順です。規範的なルールはここで再定義せず、
 `policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先します。
+Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
+canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-code.md` です。consumer には `.ai-dev-foundation/skills/review-code.md`
@@ -245,6 +247,81 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
     しません。provider が thread の resolution 状態を持つ場合は、その
     surface も未 triage finding の確認に使えます。
+
+## 停止条件
+
+Executable artifact の review flow を、`policy/core.md` の Review stopping rules が
+定める stopping semantics（evidence の target 束縛、round / cycle の上限と escalate
+判断）を評価する分岐として表現した finite flow です。`## 手順` の各 step と同じ
+手続きを分岐構造として示したものであり、規範的なルール自体は `policy/core.md` が
+持ちます。round / cycle の上限判断そのものは Review stopping rules
+（`policy/core.md`）に従います。
+
+```text
+deterministic verify
+  -> freeze candidate SHA
+  -> verify target と freeze target の consistency 確認
+  -> discovery（独立 reviewer）
+  -> completion / acquisition / validity 確認
+  -> aggregate / triage
+  -> accepted finding の batch fix で review target が変更された場合:
+       batch fix + root-cause sweep
+       -> deterministic verify
+       -> Review stopping rules に従い 2nd full discovery が必要な場合のみ:
+            second discovery target の Selection / Execution
+            -> full discovery（2nd round、独立 reviewer）
+            -> completion / acquisition / validity 確認
+            -> required review 数の valid run 確認
+            -> aggregate / triage
+            -> accepted finding があれば batch fix
+            -> target が変われば deterministic verify
+            -> この fix でさらに追加の full discovery が必要と判断される
+               場合: 3rd full discovery は起動せず、merge もせず、
+               upstream task/design の不安定さを疑い、必要に応じて
+               escalate する
+       -> closure target の Selection / Execution
+       -> targeted closure
+       -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
+       -> accepted closure finding があれば:
+            batch fix
+            -> deterministic verify
+            -> Review stopping rules の再評価
+            -> 2nd full discovery 未使用かつ必要な場合:
+                 second discovery target の Selection / Execution から
+                 上記の full discovery route へ進み、完了後 targeted
+                 closure を再実行する
+            -> 2nd full discovery 使用済みでなお必要な場合:
+                 3rd full discovery は起動せず、merge もせず、
+                 upstream task/design の不安定さを疑い、必要に応じて
+                 escalate する
+            -> 追加の full discovery が不要な場合:
+                 targeted closure を再実行する
+       -> required discovery stage(s) の Resolution 完了
+       -> merge
+  -> accepted fix が無く review target が変更されていない場合:
+       required review 数の valid discovery と Resolution の完了
+       -> merge
+```
+
+accepted finding の batch fix によって review target が変更された場合のみ
+targeted closure を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。targeted closure
+の finding も Resolution Contract の対象とし、Resolution が完了するまで
+merge しません。
+targeted closure の Resolution に加えて、この review flow で実行した
+discovery stage（2nd full discovery を含む）すべての Resolution が
+完了していることも merge の条件です。完了順序は問いません。
+targeted closure の finding に accepted fix がある場合も、fix 後の
+deterministic verify を経て Review stopping rules を再評価します。2nd
+full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
+に targeted closure を再実行します。2nd full discovery を使用済みでなお
+full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
+追加の full discovery が不要なら、targeted closure を再実行します。
+accepted fix が無く review target が変更されていない場合は、
+required review 数の valid discovery と Resolution の完了をもって、
+新たな closure run を要求せずに merge できます。
 
 ## Adapter boundary（manual pilot）
 

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -4,6 +4,8 @@
 Normative、Review contracts、Review stopping rules）を使った実行手順です。規範的な
 ルールはここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
 矛盾する場合は policy が優先します。
+Normative artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
+canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-doc.md` です。consumer には `.ai-dev-foundation/skills/review-doc.md`
@@ -149,3 +151,40 @@ acquisition routing」節に従います。この skill では重複定義しま
 を増やすのではなく、上流の policy / document 自体に defect がある兆候として扱い、
 escalate します。round 数の扱いは Review stopping rules（`policy/core.md`）に
 従います。
+
+Normative artifact の review flow を、`policy/core.md` の Review stopping rules が
+定める stopping semantics（evidence の target 束縛、round / cycle の上限と escalate
+判断）を評価する分岐として表現した finite flow です。`## 手順` の各 step と同じ
+手続きを分岐構造として示したものであり、規範的なルール自体は `policy/core.md` が
+持ちます。
+
+```text
+mechanical check
+  -> mechanical check target と Selection target の consistency 確認
+  -> semantic discovery（1 round）
+  -> triage / fix
+  -> accepted finding の fix で review target が変更された場合:
+       mechanical check
+       -> closure target の Selection / Execution
+       -> closure verification
+       -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
+       -> semantic discovery の Resolution 完了
+       -> 完了
+  -> accepted fix が無く review target が変更されていない場合:
+       required review 数の valid semantic discovery と Resolution の完了
+       -> 完了
+```
+
+accepted finding の fix によって review target が変更された場合のみ、
+新しい target に対して mechanical check を再実行してから closure
+verification を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。closure
+verification の finding も Resolution Contract の対象とし、Resolution が
+完了するまで review を完了しません。
+closure verification の Resolution に加えて、semantic discovery（手順 3）
+の Resolution が完了していることも review completion の条件です。完了
+順序は問いません。
+accepted fix が無く review target が変更されていない場合は、
+required review 数の valid semantic discovery と Resolution の完了をもって、
+新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -4,6 +4,8 @@
 Executable、Review contracts、Review Adapter boundary、Failure / retry、Review
 stopping rules）を使った実行手順です。規範的なルールはここで再定義せず、
 `policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先します。
+Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
+canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-code.md` です。consumer には `.ai-dev-foundation/skills/review-code.md`
@@ -245,6 +247,81 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
     しません。provider が thread の resolution 状態を持つ場合は、その
     surface も未 triage finding の確認に使えます。
+
+## 停止条件
+
+Executable artifact の review flow を、`policy/core.md` の Review stopping rules が
+定める stopping semantics（evidence の target 束縛、round / cycle の上限と escalate
+判断）を評価する分岐として表現した finite flow です。`## 手順` の各 step と同じ
+手続きを分岐構造として示したものであり、規範的なルール自体は `policy/core.md` が
+持ちます。round / cycle の上限判断そのものは Review stopping rules
+（`policy/core.md`）に従います。
+
+```text
+deterministic verify
+  -> freeze candidate SHA
+  -> verify target と freeze target の consistency 確認
+  -> discovery（独立 reviewer）
+  -> completion / acquisition / validity 確認
+  -> aggregate / triage
+  -> accepted finding の batch fix で review target が変更された場合:
+       batch fix + root-cause sweep
+       -> deterministic verify
+       -> Review stopping rules に従い 2nd full discovery が必要な場合のみ:
+            second discovery target の Selection / Execution
+            -> full discovery（2nd round、独立 reviewer）
+            -> completion / acquisition / validity 確認
+            -> required review 数の valid run 確認
+            -> aggregate / triage
+            -> accepted finding があれば batch fix
+            -> target が変われば deterministic verify
+            -> この fix でさらに追加の full discovery が必要と判断される
+               場合: 3rd full discovery は起動せず、merge もせず、
+               upstream task/design の不安定さを疑い、必要に応じて
+               escalate する
+       -> closure target の Selection / Execution
+       -> targeted closure
+       -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
+       -> accepted closure finding があれば:
+            batch fix
+            -> deterministic verify
+            -> Review stopping rules の再評価
+            -> 2nd full discovery 未使用かつ必要な場合:
+                 second discovery target の Selection / Execution から
+                 上記の full discovery route へ進み、完了後 targeted
+                 closure を再実行する
+            -> 2nd full discovery 使用済みでなお必要な場合:
+                 3rd full discovery は起動せず、merge もせず、
+                 upstream task/design の不安定さを疑い、必要に応じて
+                 escalate する
+            -> 追加の full discovery が不要な場合:
+                 targeted closure を再実行する
+       -> required discovery stage(s) の Resolution 完了
+       -> merge
+  -> accepted fix が無く review target が変更されていない場合:
+       required review 数の valid discovery と Resolution の完了
+       -> merge
+```
+
+accepted finding の batch fix によって review target が変更された場合のみ
+targeted closure を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。targeted closure
+の finding も Resolution Contract の対象とし、Resolution が完了するまで
+merge しません。
+targeted closure の Resolution に加えて、この review flow で実行した
+discovery stage（2nd full discovery を含む）すべての Resolution が
+完了していることも merge の条件です。完了順序は問いません。
+targeted closure の finding に accepted fix がある場合も、fix 後の
+deterministic verify を経て Review stopping rules を再評価します。2nd
+full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
+に targeted closure を再実行します。2nd full discovery を使用済みでなお
+full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
+upstream task/design の不安定さを疑い、必要に応じて escalate します。
+追加の full discovery が不要なら、targeted closure を再実行します。
+accepted fix が無く review target が変更されていない場合は、
+required review 数の valid discovery と Resolution の完了をもって、
+新たな closure run を要求せずに merge できます。
 
 ## Adapter boundary（manual pilot）
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -4,6 +4,8 @@
 Normative、Review contracts、Review stopping rules）を使った実行手順です。規範的な
 ルールはここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
 矛盾する場合は policy が優先します。
+Normative artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
+canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-doc.md` です。consumer には `.ai-dev-foundation/skills/review-doc.md`
@@ -149,3 +151,40 @@ acquisition routing」節に従います。この skill では重複定義しま
 を増やすのではなく、上流の policy / document 自体に defect がある兆候として扱い、
 escalate します。round 数の扱いは Review stopping rules（`policy/core.md`）に
 従います。
+
+Normative artifact の review flow を、`policy/core.md` の Review stopping rules が
+定める stopping semantics（evidence の target 束縛、round / cycle の上限と escalate
+判断）を評価する分岐として表現した finite flow です。`## 手順` の各 step と同じ
+手続きを分岐構造として示したものであり、規範的なルール自体は `policy/core.md` が
+持ちます。
+
+```text
+mechanical check
+  -> mechanical check target と Selection target の consistency 確認
+  -> semantic discovery（1 round）
+  -> triage / fix
+  -> accepted finding の fix で review target が変更された場合:
+       mechanical check
+       -> closure target の Selection / Execution
+       -> closure verification
+       -> closure completion / acquisition / validity 確認
+       -> closure finding の Resolution
+       -> semantic discovery の Resolution 完了
+       -> 完了
+  -> accepted fix が無く review target が変更されていない場合:
+       required review 数の valid semantic discovery と Resolution の完了
+       -> 完了
+```
+
+accepted finding の fix によって review target が変更された場合のみ、
+新しい target に対して mechanical check を再実行してから closure
+verification を行い、その review run も Acquisition & Validity Contract
+に従って completion / acquisition / validity を確認します。closure
+verification の finding も Resolution Contract の対象とし、Resolution が
+完了するまで review を完了しません。
+closure verification の Resolution に加えて、semantic discovery（手順 3）
+の Resolution が完了していることも review completion の条件です。完了
+順序は問いません。
+accepted fix が無く review target が変更されていない場合は、
+required review 数の valid semantic discovery と Resolution の完了をもって、
+新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -514,9 +514,10 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 ### Merge readiness and merge authority
 
 本節における review completion（Resolution Contract の完了を含む）が
-成立した状態を **merge-ready** と呼びます。Review contracts および
-Review stopping rules で `merge` と記述する到達点は、merge-ready の
-成立を指し、merge を実行してよいという判断そのものとは同義ではありません。
+成立した状態を **merge-ready** と呼びます。Review contracts、Review stopping
+rules、および Skill routing contract が指す review skill の手順で `merge` と
+記述する到達点は、merge-ready の成立を指し、merge を実行してよいという判断
+そのものとは同義ではありません。
 
 merge execution authority は、Review Protocol とは別の contract /
 context として扱います。current Task、Execution Envelope、または
@@ -695,74 +696,6 @@ upstream task/design または policy/document 自体の instability を疑い�
 必要に応じて escalate します。これは Failure / retry の retry count とは
 別の stopping semantics です。
 
-Code review:
-
-```text
-deterministic verify
-  -> freeze candidate SHA
-  -> verify target と freeze target の consistency 確認
-  -> discovery（独立 reviewer）
-  -> completion / acquisition / validity 確認
-  -> aggregate / triage
-  -> accepted finding の batch fix で review target が変更された場合:
-       batch fix + root-cause sweep
-       -> deterministic verify
-       -> fix が behavior / blast radius を materially 変えた場合のみ:
-            second discovery target の Selection / Execution
-            -> full discovery（2nd round、独立 reviewer）
-            -> completion / acquisition / validity 確認
-            -> required review 数の valid run 確認
-            -> aggregate / triage
-            -> accepted finding があれば batch fix
-            -> target が変われば deterministic verify
-            -> この fix でさらに追加の full discovery が必要と判断される
-               場合: 3rd full discovery は起動せず、merge もせず、
-               upstream task/design の不安定さを疑い、必要に応じて
-               escalate する
-       -> closure target の Selection / Execution
-       -> targeted closure
-       -> closure completion / acquisition / validity 確認
-       -> closure finding の Resolution
-       -> accepted closure finding があれば:
-            batch fix
-            -> deterministic verify
-            -> Review stopping rules の再評価
-            -> 2nd full discovery 未使用かつ必要な場合:
-                 second discovery target の Selection / Execution から
-                 上記の full discovery route へ進み、完了後 targeted
-                 closure を再実行する
-            -> 2nd full discovery 使用済みでなお必要な場合:
-                 3rd full discovery は起動せず、merge もせず、
-                 upstream task/design の不安定さを疑い、必要に応じて
-                 escalate する
-            -> 追加の full discovery が不要な場合:
-                 targeted closure を再実行する
-       -> required discovery stage(s) の Resolution 完了
-       -> merge
-  -> accepted fix が無く review target が変更されていない場合:
-       required review 数の valid discovery と Resolution の完了
-       -> merge
-```
-
-accepted finding の batch fix によって review target が変更された場合のみ
-targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。targeted closure
-の finding も Resolution Contract の対象とし、Resolution が完了するまで
-merge しません。
-targeted closure の Resolution に加えて、この review flow で実行した
-discovery stage（2nd full discovery を含む）すべての Resolution が
-完了していることも merge の条件です。完了順序は問いません。
-targeted closure の finding に accepted fix がある場合も、fix 後の
-deterministic verify を経て Review stopping rules を再評価します。2nd
-full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
-に targeted closure をやり直します。2nd full discovery を使用済みでなお
-full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
-upstream task/design の不安定さを疑い、必要に応じて escalate します。
-追加の full discovery が不要なら、targeted closure をやり直します。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid discovery と Resolution の完了をもって、
-新たな closure run を要求せずに merge できます。
-
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
 upstream task/design の不安定さを疑います。
@@ -771,38 +704,11 @@ blast radius をさらに materially 変えた場合は、3rd full discovery を
 せず、targeted closure だけで merge へ進まず、upstream task/design の
 不安定さを疑い、必要に応じて escalate します。
 
-Normative document review:
-
-```text
-mechanical check
-  -> mechanical check target と Selection target の consistency 確認
-  -> semantic discovery（1 round）
-  -> triage / fix
-  -> accepted finding の fix で review target が変更された場合:
-       mechanical check
-       -> closure target の Selection / Execution
-       -> closure verification
-       -> closure completion / acquisition / validity 確認
-       -> closure finding の Resolution
-       -> semantic discovery の Resolution 完了
-       -> 完了
-  -> accepted fix が無く review target が変更されていない場合:
-       required review 数の valid semantic discovery と Resolution の完了
-       -> 完了
-```
-
-accepted finding の fix によって review target が変更された場合のみ、
-新しい target に対して mechanical check を再実行してから closure
-verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。closure
-verification の finding も Resolution Contract の対象とし、Resolution が
-完了するまで review を完了しません。
-closure verification の Resolution に加えて、semantic discovery（手順 3）
-の Resolution が完了していることも review completion の条件です。完了
-順序は問いません。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid semantic discovery と Resolution の完了をもって、
-新たな closure run を要求せずに review を完了できます。
+本節が定める stopping semantics（evidence の target 束縛、round / cycle の上限と
+escalate 判断）を、artifact classification ごとの具体的な review 手順のどこで評価
+するかは、その手順自体に属します。この review 手順の canonical source は
+Foundation-owned な review skill であり、本節には置きません。該当する review 手順
+へ入る前に、Skill routing contract に従って対応する skill を load します。
 
 ### Observed evidence is not a permanent provider rule
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -359,56 +359,12 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   );
   assert.ok(containsText(core, "empty output: positive completion evidence がなければ `unknown`"));
 
-  // Stopping rules, including the closure Acquisition & Validity gate before merge
-  assert.ok(core.includes("closure completion / acquisition / validity 確認"));
-  // Finding 1: the Code accepted-fix branch re-applies Selection/Execution to the
-  // closure target before targeted closure runs.
-  assert.ok(core.includes("closure target の Selection / Execution"));
-  assert.ok(core.includes("-> targeted closure"));
-
-  // Codex P2 (route a material fix through a full 2nd discovery): an optional 2nd
-  // full discovery, gated by the same material-fix condition Review stopping
-  // rules already define, sits between the post-fix deterministic verify and
-  // closure target Selection/Execution — reusing the same discovery Contracts,
-  // not a new Second Discovery Contract or round-counter schema.
-  assert.ok(
-    containsText(
-      core,
-      "deterministic verify -> fix が behavior / blast radius を materially 変えた場合のみ:",
-    ),
-  );
-  assert.ok(core.includes("second discovery target の Selection / Execution"));
-  assert.ok(core.includes("full discovery（2nd round、独立 reviewer）"));
-  assert.ok(
-    containsText(
-      core,
-      "required review 数の valid run 確認 -> aggregate / triage -> accepted finding があれば batch fix -> target が変われば deterministic verify",
-    ),
-  );
-  assert.doesNotMatch(
-    core,
-    /discovery_round|round counter|Second Discovery Contract/,
-    "policy/core.md must not introduce a new round-counter schema or a Second Discovery Contract",
-  );
-  assert.ok(
-    containsText(
-      core,
-      "accepted finding の batch fix によって review target が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
-    ),
-  );
-
-  // Codex P2 (unify closure-entry predicates with the canonical review target
-  // definition): the Code review diagram's accepted-fix branch condition is
-  // "review target changed", not a stage-local "candidate SHA changed" that
-  // drifts from the review target definition established just above.
-  assert.ok(
-    containsText(core, "-> accepted finding の batch fix で review target が変更された場合:"),
-  );
-  assert.doesNotMatch(
-    core,
-    /accepted finding の batch fix で candidate SHA が変更された場合/,
-    "the Code review diagram's closure-entry condition must not regress to a bare candidate-SHA predicate",
-  );
+  // Review stopping rules (Kernel-retained always-on semantics, #51 Phase 1).
+  // The artifact-class finite flow itself moved to the Foundation-owned review
+  // skills; what stays here is the target-bound evidence invariant, the
+  // closure-cycle stopping semantics, and the discovery round limit — all of
+  // which can be violated at any time, including at the merge-ready fence,
+  // without ever entering the skill's procedure.
 
   // Root cause A (closure findings need Resolution too): completed + valid closure
   // runs still gate on Resolution before merge/completion, in both artifacts, using
@@ -427,102 +383,6 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     containsText(
       core,
       "unresolved の finding（未解決の needs-verification / technical-dispute / intent-question 等を含む）が残る間は、その review stage の Resolution は完了せず、merge / review completion の根拠にしない",
-    ),
-  );
-  assert.ok(core.includes("closure finding の Resolution"));
-  assert.ok(
-    containsText(
-      core,
-      "targeted closure の finding も Resolution Contract の対象とし、Resolution が完了するまで merge しません。",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "closure verification の finding も Resolution Contract の対象とし、Resolution が完了するまで review を完了しません。",
-    ),
-  );
-
-  // Codex P1 (resolve discovery findings before merge, Code flow): the
-  // accepted-fix diagram branch now requires required discovery stage(s)'
-  // Resolution to complete, not just closure Resolution, before merge.
-  assert.ok(core.includes("required discovery stage(s) の Resolution 完了"));
-  assert.ok(
-    containsText(
-      core,
-      "closure finding の Resolution -> accepted closure finding があれば:",
-    ),
-  );
-
-  // Codex P1 (re-evaluate materiality of closure fixes): an accepted closure
-  // finding's fix re-enters Review stopping rules — routing to an unused 2nd
-  // discovery if needed, to escalation (no 3rd discovery, no merge) if 2nd was
-  // already used and still insufficient, or back to targeted closure if the
-  // fix wasn't material — instead of falling straight through to merge.
-  assert.ok(
-    containsText(
-      core,
-      "accepted closure finding があれば: batch fix -> deterministic verify -> Review stopping rules の再評価",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "2nd full discovery 未使用かつ必要な場合: second discovery target の Selection / Execution から上記の full discovery route へ進み、完了後 targeted closure を再実行する",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "2nd full discovery 使用済みでなお必要な場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "追加の full discovery が不要な場合: targeted closure を再実行する",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "targeted closure の finding に accepted fix がある場合も、fix 後の deterministic verify を経て Review stopping rules を再評価します。",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "2nd full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後に targeted closure をやり直します。",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "2nd full discovery を使用済みでなお full discovery が必要なら、3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
-    ),
-  );
-  assert.ok(
-    containsText(core, "追加の full discovery が不要なら、targeted closure をやり直します。"),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "targeted closure の Resolution に加えて、この review flow で実行した discovery stage（2nd full discovery を含む）すべての Resolution が完了していることも merge の条件です。完了順序は問いません。",
-    ),
-  );
-
-  // Codex P1 (resolve discovery findings before merge, Normative flow): same
-  // gate for semantic discovery Resolution before review completion.
-  assert.ok(
-    containsText(
-      core,
-      "-> closure finding の Resolution -> semantic discovery の Resolution 完了 -> 完了",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "closure verification の Resolution に加えて、semantic discovery（手順 3）の Resolution が完了していることも review completion の条件です。完了順序は問いません。",
     ),
   );
 
@@ -563,45 +423,20 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   // Range-only target change (Codex P1, commit range for Executable): a commit
   // range's endpoint moving counts as a target change even if head SHA is
   // unchanged, so old evidence isn't carried over just because the SHA looks the
-  // same; and the merge-without-closure branch is keyed on the review target
-  // (SHA-and-range), not head SHA alone, so an independent base/range move
-  // cannot slip through as "unchanged."
+  // same. The canonical review target definition the merge-ready fence and both
+  // skills key on stays in the Kernel.
   assert.ok(
     containsText(
       core,
       "head SHA が不変でも commit range の endpoint が変わった場合、また expected target SHA / commit range が不変でも target artifact set が変わった場合も、review target の変更として同じ scope です。",
     ),
   );
-  assert.ok(core.includes("-> accepted fix が無く review target が変更されていない場合:"));
-  assert.doesNotMatch(
-    core,
-    /accepted fix が無く candidate SHA が変更されていない場合/,
-    "the merge-without-closure branch must key on review target (SHA-and-range), not head SHA alone, or an independent range move could read as unchanged",
-  );
-  assert.ok(core.includes("verify target と freeze target の consistency 確認"));
-  assert.ok(core.includes("mechanical check target と Selection target の consistency 確認"));
-  // Canonical policy: no accepted fix + no SHA change completes via the required
-  // review count's valid discovery + Resolution, with no new closure run required
-  // (matches skills/review-code.md's existing Executable procedure).
-  assert.ok(
-    containsText(
-      core,
-      "accepted fix が無く review target が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
-    ),
-  );
+
+  // Discovery round limit stays always-on: the merge-ready completion fence's
+  // expected-member exception is defined in terms of "targeted closure で十分と
+  // 判定されて" per these rules, so the round limit cannot be skill-only.
   assert.ok(containsText(core, "full discovery は原則 1 round です。"));
   assert.ok(containsText(core, "materially 変えた場合のみ 2 round 目を許容します。"));
-
-  // Codex P1 (stop merge after a materially-changing 2nd discovery fix): the
-  // canonical Code review diagram now re-evaluates materiality after the 2nd
-  // discovery's own accepted-finding fix, not just before entering 2nd
-  // discovery — a further material change stops at escalation, not merge.
-  assert.ok(
-    containsText(
-      core,
-      "-> target が変われば deterministic verify -> この fix でさらに追加の full discovery が必要と判断される場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する -> closure target の Selection / Execution",
-    ),
-  );
   assert.ok(
     containsText(
       core,
@@ -613,45 +448,10 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     /4th full discovery|third full discovery|discovery_round|round counter|Materiality Contract|Closure Materiality Contract/i,
     "must not introduce a 3rd discovery phase, round counter, or a new Materiality Contract",
   );
-
-  // Normative must stay unchanged by this fix: no 2nd semantic discovery round.
-  assert.ok(core.includes("semantic discovery（1 round）"));
   assert.doesNotMatch(
     core,
-    /semantic discovery（2nd round）|2nd semantic discovery/,
-    "Normative document review must not gain a 2nd semantic discovery round",
-  );
-  // Canonical policy: Normative closure is likewise conditioned on an accepted-fix
-  // target change, not unconditional (matches skills/review-doc.md's procedure),
-  // and re-runs mechanical check against the post-fix target first (Finding 2).
-  assert.ok(
-    containsText(
-      core,
-      "accepted finding の fix によって review target が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "accepted fix が無く review target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
-    ),
-  );
-
-  // Codex P2 (unify closure-entry predicates with the canonical review target
-  // definition, Normative sibling): both diagram branches (accepted-fix and
-  // no-change) key on "review target", matching the Code review diagram and
-  // the review target definition established just above, not a stage-local
-  // "target SHA / range" partial predicate.
-  assert.ok(
-    containsText(core, "-> accepted finding の fix で review target が変更された場合:"),
-  );
-  assert.ok(
-    containsText(core, "-> accepted fix が無く review target が変更されていない場合:"),
-  );
-  assert.doesNotMatch(
-    core,
-    /accepted finding の fix で target SHA \/ range が変更された場合/,
-    "the Normative diagram's closure-entry condition must not regress to a bare SHA/range predicate",
+    /discovery_round|round counter|Second Discovery Contract/,
+    "policy/core.md must not introduce a new round-counter schema or a Second Discovery Contract",
   );
 
   // Codex P2 (stage-independent closure-cycle stopping semantics): a repeating
@@ -686,13 +486,13 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "precondition check（Executable の deterministic verify、Normative の mechanical check）を新しい target に対して再成立させます。",
     ),
   );
-  // The Normative accepted-fix branch re-runs mechanical check and re-applies
-  // Selection/Execution to the closure target before closure verification,
-  // without adding a 2nd semantic discovery round.
+
+  // #51 Phase 1: the Kernel keeps the routing pointer to the skill-owned
+  // procedure instead of the procedure itself.
   assert.ok(
     containsText(
       core,
-      "mechanical check -> closure target の Selection / Execution -> closure verification",
+      "この review 手順の canonical source は Foundation-owned な review skill であり、本節には置きません。該当する review 手順へ入る前に、Skill routing contract に従って対応する skill を load します。",
     ),
   );
 
@@ -707,6 +507,303 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(containsText(core, "実行手順（review skill）は Foundation リポジトリ側に別途保持し、"));
   assert.doesNotMatch(core, /(?<!\.ai-dev-foundation\/)skills\/review-code\.md/);
   assert.doesNotMatch(core, /(?<!\.ai-dev-foundation\/)skills\/review-doc\.md/);
+});
+
+// #51 Phase 1 (progressive disclosure canary): the artifact-class review finite
+// flow — the phase-specific part of the former Kernel `Review stopping rules`
+// section — is owned by the Foundation-owned review skills, not by the Kernel.
+// Every assertion below previously ran against `policy/core.md`; the semantics
+// are unchanged, only the canonical location moved.
+test("review skills own the artifact-class review finite flow (#51 Phase 1)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  // --- Executable finite flow (skills/review-code.md) ---
+
+  // Stopping rules, including the closure Acquisition & Validity gate before merge
+  assert.ok(reviewCode.includes("closure completion / acquisition / validity 確認"));
+  // Finding 1: the Code accepted-fix branch re-applies Selection/Execution to the
+  // closure target before targeted closure runs.
+  assert.ok(reviewCode.includes("closure target の Selection / Execution"));
+  assert.ok(reviewCode.includes("-> targeted closure"));
+
+  // Codex P2 (route a material fix through a full 2nd discovery): an optional 2nd
+  // full discovery sits between the post-fix deterministic verify and closure
+  // target Selection/Execution — reusing the same discovery Contracts, not a new
+  // Second Discovery Contract or round-counter schema. #51 Phase 1: the branch
+  // condition itself defers to the Kernel's Review stopping rules rather than
+  // restating the materiality criterion inside the skill.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "deterministic verify -> Review stopping rules に従い 2nd full discovery が必要な場合のみ:",
+    ),
+  );
+  assert.ok(reviewCode.includes("second discovery target の Selection / Execution"));
+  assert.ok(reviewCode.includes("full discovery（2nd round、独立 reviewer）"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "required review 数の valid run 確認 -> aggregate / triage -> accepted finding があれば batch fix -> target が変われば deterministic verify",
+    ),
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /discovery_round|round counter|Second Discovery Contract/,
+    "the skill must not introduce a new round-counter schema or a Second Discovery Contract",
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "accepted finding の batch fix によって review target が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+    ),
+  );
+
+  // Codex P2 (unify closure-entry predicates with the canonical review target
+  // definition): the Code review diagram's accepted-fix branch condition is
+  // "review target changed", not a stage-local "candidate SHA changed" that
+  // drifts from the review target definition the Kernel still owns.
+  assert.ok(
+    containsText(reviewCode, "-> accepted finding の batch fix で review target が変更された場合:"),
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /accepted finding の batch fix で candidate SHA が変更された場合/,
+    "the Code review diagram's closure-entry condition must not regress to a bare candidate-SHA predicate",
+  );
+
+  assert.ok(reviewCode.includes("closure finding の Resolution"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "targeted closure の finding も Resolution Contract の対象とし、Resolution が完了するまで merge しません。",
+    ),
+  );
+
+  // Codex P1 (resolve discovery findings before merge, Code flow): the
+  // accepted-fix diagram branch requires required discovery stage(s)'
+  // Resolution to complete, not just closure Resolution, before merge.
+  assert.ok(reviewCode.includes("required discovery stage(s) の Resolution 完了"));
+  assert.ok(
+    containsText(reviewCode, "closure finding の Resolution -> accepted closure finding があれば:"),
+  );
+
+  // Codex P1 (re-evaluate materiality of closure fixes): an accepted closure
+  // finding's fix re-enters Review stopping rules — routing to an unused 2nd
+  // discovery if needed, to escalation (no 3rd discovery, no merge) if 2nd was
+  // already used and still insufficient, or back to targeted closure if the
+  // fix wasn't material — instead of falling straight through to merge.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "accepted closure finding があれば: batch fix -> deterministic verify -> Review stopping rules の再評価",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "2nd full discovery 未使用かつ必要な場合: second discovery target の Selection / Execution から上記の full discovery route へ進み、完了後 targeted closure を再実行する",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "2nd full discovery 使用済みでなお必要な場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "追加の full discovery が不要な場合: targeted closure を再実行する"),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "targeted closure の finding に accepted fix がある場合も、fix 後の deterministic verify を経て Review stopping rules を再評価します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "2nd full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後に targeted closure を再実行します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "2nd full discovery を使用済みでなお full discovery が必要なら、3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+    ),
+  );
+  assert.ok(
+    containsText(reviewCode, "追加の full discovery が不要なら、targeted closure を再実行します。"),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "targeted closure の Resolution に加えて、この review flow で実行した discovery stage（2nd full discovery を含む）すべての Resolution が完了していることも merge の条件です。完了順序は問いません。",
+    ),
+  );
+  assert.ok(reviewCode.includes("verify target と freeze target の consistency 確認"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "accepted fix が無く review target が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
+    ),
+  );
+  assert.ok(reviewCode.includes("-> accepted fix が無く review target が変更されていない場合:"));
+  assert.doesNotMatch(
+    reviewCode,
+    /accepted fix が無く candidate SHA が変更されていない場合/,
+    "the merge-without-closure branch must key on review target (SHA-and-range), not head SHA alone, or an independent range move could read as unchanged",
+  );
+
+  // Codex P1 (stop merge after a materially-changing 2nd discovery fix): the
+  // canonical Code review diagram re-evaluates the need for more discovery after
+  // the 2nd discovery's own accepted-finding fix, not just before entering 2nd
+  // discovery — a further material change stops at escalation, not merge.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "-> target が変われば deterministic verify -> この fix でさらに追加の full discovery が必要と判断される場合: 3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate する -> closure target の Selection / Execution",
+    ),
+  );
+
+  // --- Normative finite flow (skills/review-doc.md) ---
+
+  assert.ok(reviewDoc.includes("closure completion / acquisition / validity 確認"));
+  assert.ok(reviewDoc.includes("closure target の Selection / Execution"));
+  assert.ok(reviewDoc.includes("closure finding の Resolution"));
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "closure verification の finding も Resolution Contract の対象とし、Resolution が完了するまで review を完了しません。",
+    ),
+  );
+  // Codex P1 (resolve discovery findings before merge, Normative flow): same
+  // gate for semantic discovery Resolution before review completion.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "-> closure finding の Resolution -> semantic discovery の Resolution 完了 -> 完了",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "closure verification の Resolution に加えて、semantic discovery（手順 3）の Resolution が完了していることも review completion の条件です。完了順序は問いません。",
+    ),
+  );
+  assert.ok(reviewDoc.includes("mechanical check target と Selection target の consistency 確認"));
+
+  // Normative keeps exactly one semantic discovery round.
+  assert.ok(reviewDoc.includes("semantic discovery（1 round）"));
+  assert.doesNotMatch(
+    reviewDoc,
+    /semantic discovery（2nd round）|2nd semantic discovery/,
+    "Normative document review must not gain a 2nd semantic discovery round",
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "accepted finding の fix によって review target が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "accepted fix が無く review target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
+    ),
+  );
+
+  // Codex P2 (unify closure-entry predicates with the canonical review target
+  // definition, Normative sibling): both diagram branches key on "review
+  // target", matching the Code review diagram and the Kernel's review target
+  // definition, not a stage-local "target SHA / range" partial predicate.
+  assert.ok(containsText(reviewDoc, "-> accepted finding の fix で review target が変更された場合:"));
+  assert.ok(containsText(reviewDoc, "-> accepted fix が無く review target が変更されていない場合:"));
+  assert.doesNotMatch(
+    reviewDoc,
+    /accepted finding の fix で target SHA \/ range が変更された場合/,
+    "the Normative diagram's closure-entry condition must not regress to a bare SHA/range predicate",
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "mechanical check -> closure target の Selection / Execution -> closure verification",
+    ),
+  );
+});
+
+// #51 Phase 1 contract: routing remains in the Kernel, procedure moved to the
+// skills. This guards both halves at once — a regression that copies the flow
+// back into the Kernel (or into the generated consumer adapter) fails here, and
+// so does a regression that drops the MUST skill-load routing.
+test("Phase 1 migration keeps routing in the Kernel and the procedure in the skills", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const generated = await readFile(
+    path.join(root, "test", "fixtures", "consumer", "AGENTS.md"),
+    "utf8",
+  );
+
+  // Distinctive finite-flow markers that must no longer live in always-on context.
+  const flowMarkers = [
+    "-> freeze candidate SHA",
+    "-> verify target と freeze target の consistency 確認",
+    "-> discovery（独立 reviewer）",
+    "-> accepted finding の batch fix で review target が変更された場合:",
+    "second discovery target の Selection / Execution",
+    "-> closure target の Selection / Execution -> targeted closure",
+    "-> closure finding の Resolution",
+    "required discovery stage(s) の Resolution 完了",
+    "mechanical check target と Selection target の consistency 確認",
+    "semantic discovery（1 round）",
+    "-> accepted finding の fix で review target が変更された場合:",
+  ];
+  for (const marker of flowMarkers) {
+    assert.ok(
+      !containsText(core, marker),
+      `Kernel must not carry the migrated finite-flow procedure: ${marker}`,
+    );
+    assert.ok(
+      !containsText(generated, marker),
+      `generated consumer AGENTS.md must not carry the migrated finite-flow procedure: ${marker}`,
+    );
+  }
+
+  // The Kernel keeps a `Review stopping rules` section: the always-on semantics
+  // the merge-ready completion fence and both skills reference by name.
+  assert.ok(core.includes("### Review stopping rules"));
+  assert.ok(generated.includes("### Review stopping rules"));
+
+  // The MUST skill-load routing stays discoverable from always-on context, in
+  // the Kernel and in the generated consumer adapter alike.
+  for (const text of [core, generated]) {
+    assert.ok(
+      containsText(
+        text,
+        "該当する artifact classification の review 手順に入る前に、対応する skill を load することは **MUST** です。",
+      ),
+    );
+    assert.ok(containsText(text, "`.ai-dev-foundation/skills/review-code.md`"));
+    assert.ok(containsText(text, "`.ai-dev-foundation/skills/review-doc.md`"));
+    assert.ok(
+      containsText(
+        text,
+        "この review 手順の canonical source は Foundation-owned な review skill であり、本節には置きません。該当する review 手順へ入る前に、Skill routing contract に従って対応する skill を load します。",
+      ),
+    );
+  }
+
+  // The migrated procedure is reachable from the distributed skill bundle, and
+  // the distributed copy is an exact match of the canonical skill.
+  for (const name of ["review-code.md", "review-doc.md"]) {
+    const canonical = await readFile(path.join(root, "skills", name), "utf8");
+    const distributed = await readFile(
+      path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "skills", name),
+      "utf8",
+    );
+    assert.equal(distributed, canonical, `distributed ${name} must match the canonical skill`);
+    assert.ok(canonical.includes("## 停止条件"), `${name} must own its stopping/finite-flow section`);
+    assert.ok(canonical.includes("```text"), `${name} must carry the migrated finite flow`);
+  }
 });
 
 test("core policy defines a provider-neutral skill routing contract", async () => {


### PR DESCRIPTION
## 概要

Issue #51（Progressive disclosure Phase 1）を canonical Task Contract として、
`policy/core.md` の `Review stopping rules` に含まれていた phase-specific な
finite flow を Foundation-owned review skill へ移行しました。

#36 D9 の phased decision に従い、今回移すのは `Review stopping rules` のみです。
`Review Adapter boundary` / `Failure / retry` / `Acquisition & Validity` /
Issue closure 等は移していません。

Refs #51

## Kernel / skill boundary（fresh classification 結果）

移行前の `Review stopping rules`（152 lines）を、以下の 6 unit に分類しました。

| unit | 内容 | 判定 | 移行後の所在 |
| --- | --- | --- | --- |
| A | precondition / discovery / closure evidence の target 束縛、review target の定義 | **always-on** | Kernel（verbatim） |
| B | closure cycle が繰り返す場合の停止 / escalate（Failure / retry とは別 semantics） | **always-on** | Kernel（verbatim） |
| C | Code review finite flow（```text block） | phase-specific | `skills/review-code.md` |
| D1–D5 | Code flow の targeted closure / discovery Resolution / closure 再評価の説明 prose | phase-specific | `skills/review-code.md` |
| D6 | full discovery の round 上限（原則 1 round、material change 時のみ 2nd、3rd は起動せず escalate） | **always-on** | Kernel（verbatim） |
| E, F | Normative document review finite flow と説明 prose | phase-specific | `skills/review-doc.md` |

### A / B / D6 を Kernel に残した理由

- **A** — 「確定した target と一致しない evidence を根拠にしない」は review 手順の
  内側だけで危険なわけではなく、merge-ready 宣言時・Task closure 時など任意の
  タイミングで誤りうる always-on guardrail です。さらに `Merge-ready completion
  fence`（#45）が「review target の変化」で fence を無効化する際、A が定義する
  review target（expected target SHA / commit range と target artifact set の組）
  に依存します。
- **B** — 「同根 finding の反復で無限に patch / re-review しない」は、skill を
  load していない時点でも保持していなければならない停止条件です。fence 自身も
  「その繰り返し自体を停止条件として扱い、Review stopping rules と同様に」と
  参照しています。
- **D6** — fence の expected member 例外が「いずれも Review stopping rules に従い
  targeted closure で十分と判定されている」という条件を持つため、round 上限の
  判断基準が Kernel から解決できないと fence が underdefined になります。

### C / D1–D5 / E / F を skill へ移した理由

いずれも「review phase へ入る直前に skill を load すれば十分」な手続きであり、
#36 discovery が指摘した「同じ手続きを Kernel 側にも並行表現したもの」
（[#36 discovery §1-4 / §4-4](https://github.com/reitojike/ai-dev-foundation/issues/36)）に
該当します。移行先の `skills/review-code.md` / `skills/review-doc.md` は既に
同じ手続きを `## 手順` として持っており、finite flow はその分岐構造表現です。

補足として、移行した Normative prose の `semantic discovery（手順 3）` は
`skills/review-doc.md` の step 番号を指す参照であり、Kernel に置かれていた
時点では skill を知らないと解決できない cross-document 参照でした。移行により
参照が自ファイル内で閉じています。

## Semantics を変更していないこと

Selection Contract / required・expected・optional reviewer semantics /
Acquisition & Validity semantics / Resolution categories / #45 completion fence /
#49 Claude acquisition routing / merge-ready・merge authority semantics /
reviewer 数 default / provider selection policy は **material に変更していません**。

移行に伴い既存文を書き換えた文言調整は次の 2 箇所で、いずれも canonical-source
discipline を維持するための調整です。意味は同一です。これとは別に、canonical
source の所在を示す pointer / provenance 文を skill へ追加しています（後述）。

1. **flow の 2nd discovery 分岐条件**
   `-> fix が behavior / blast radius を materially 変えた場合のみ:`
   → `-> Review stopping rules に従い 2nd full discovery が必要な場合のみ:`

   round 上限の判断基準（D6）は Kernel 所有のままとし、skill 側で再記述しない
   ための調整です。`skills/review-code.md` 手順 9 が既に同じ表現
   （「Review stopping rules（`policy/core.md`）に従って 2nd full discovery が
   必要と判断された場合のみ」）を使っており、それに揃えています。既存 guard
   （review-code.md は round-limit 条件を再記述しない）も維持されます。

2. **移行 prose の closure 再実行の語**
   `targeted closure をやり直します` → `targeted closure を再実行します`

   `skills/review-code.md` は既存 review（Root cause 3）で
   「未確認 closure を同一 trigger で無条件 retry しない」guard を持ち、
   `やり直します` を禁止語としています。移行した flow block 自体が既に
   `targeted closure を再実行する` を使っており、prose をそれに揃えました。

### 追加した pointer / provenance 文（normative rule ではない）

上記 2 箇所の文言調整に加えて、canonical source の所在を明示する pointer /
provenance 文を skill 側へ追加しています。新しい normative rule ではなく、
どちらの文書が当該手順の canonical source かを読み手が判断できるようにする
ための記述です。

- `skills/review-code.md` / `skills/review-doc.md` の冒頭:
  「（Executable / Normative）artifact の review 手順（`## 手順` と `## 停止条件`
  の finite flow）の canonical source は本 skill であり、`policy/core.md` には
  置きません。」
- 両 skill の `## 停止条件` 見出し直後の導入文:
  移行してきた finite flow が `policy/core.md` の Review stopping rules の
  stopping semantics を評価する分岐であり、`## 手順` の各 step と同じ手続きの
  分岐構造表現であること、規範的なルール自体は `policy/core.md` が持つこと。

もう 1 箇所、`### Merge readiness and merge authority` 冒頭の参照を更新しました。

- 変更前: 「Review contracts および Review stopping rules で `merge` と記述する到達点は…」
- 変更後: 「Review contracts、Review stopping rules、および Skill routing contract が
  指す review skill の手順で `merge` と記述する到達点は…」

finite flow の `-> merge` が skill へ移ったため、merge-ready と merge execution の
分離が引き続き skill 側の記述にも及ぶことを明示するための参照更新です。gate の
内容は変えていません。

## Canonical source discipline

- 移した normative procedure を Kernel と skill へ二重保持していません。
  Kernel から削除した内容は skill にのみ存在します。
- Code flow は `review-code.md` のみ、Normative flow は `review-doc.md` のみに
  置き、両 skill 間へ同一 normative rule を copy していません。
- Kernel には短い provider-neutral な pointer だけを残しました。

```text
本節が定める stopping semantics（evidence の target 束縛、round / cycle の上限と
escalate 判断）を、artifact classification ごとの具体的な review 手順のどこで評価
するかは、その手順自体に属します。この review 手順の canonical source は
Foundation-owned な review skill であり、本節には置きません。該当する review 手順
へ入る前に、Skill routing contract に従って対応する skill を load します。
```

MUST routing 自体は Phase 0（#41 / PR #42）で確立済みの `### Skill routing contract`
がそのまま担っており、本 PR では変更していません。

## Context-size evidence（before / after 実測）

| artifact | before | after | delta |
| --- | ---: | ---: | ---: |
| `policy/core.md` | 942 lines / 57,275 bytes | 848 lines / 52,433 bytes | **-94 lines / -4,842 bytes（-10.0% / -8.5%）** |
| `Review stopping rules` section | 152 lines / 9,101 bytes | 57 lines / 4,199 bytes | **-95 lines / -4,902 bytes（-62.5% / -53.9%）** |
| generated consumer `AGENTS.md` | 983 lines / 59,434 bytes | 889 lines / 54,592 bytes | **-94 lines / -4,842 bytes（-9.6% / -8.1%）** |
| `skills/review-code.md` | 365 lines / 27,575 bytes | 442 lines / 32,081 bytes | +77 lines / +4,506 bytes |
| `skills/review-doc.md` | 151 lines / 10,985 bytes | 190 lines / 13,162 bytes | +39 lines / +2,177 bytes |

always-on context は実測で減少しており、増加分は phase-specific に load される
skill 側にのみ発生しています。新しい mandatory token ceiling は導入していません。

## Deterministic verification

```
npm test
# node --test --test-concurrency=1 test/*.test.mjs
#   ℹ tests 98 / ℹ pass 98 / ℹ fail 0
# node tooling/verify-guardrails.mjs
#   Verified 8 guardrail fixtures.

npm run check:fixture
# Generated adapters, quality profile, and skill bundle are current

npx prettier --check policy/core.md skills/*.md
# All matched files use Prettier code style!
```

## Regression guard（routing remains / procedure moved）

`test/review-protocol.test.mjs` に 2 つの test を追加し、既存 assertion を
移行先 canonical source へ retarget しました。

1. **`review skills own the artifact-class review finite flow (#51 Phase 1)`**
   移行前に `policy/core.md` に対して行われていた finite flow assertion
   （closure entry predicate、2nd discovery route、3rd discovery 禁止、
   Normative の 1 round 制約など）を、`skills/review-code.md` /
   `skills/review-doc.md` に対する assertion として保持しています。
   元の review finding 由来の comment もそのまま移しています。

2. **`Phase 1 migration keeps routing in the Kernel and the procedure in the skills`**
   Phase 1 contract そのものを guard します。
   - 移行した finite-flow marker が `policy/core.md` と generated consumer
     `AGENTS.md` の**どちらにも残っていない**こと
   - `### Review stopping rules` section 自体は Kernel / generated adapter に
     残っていること（fence と skill が名前で参照するため）
   - MUST skill-load routing（`… review 手順に入る前に、対応する skill を load
     することは **MUST** です。` と両 skill path）が Kernel / generated adapter
     から discoverable であること
   - Kernel の pointer 文が存在すること
   - 配布された `.ai-dev-foundation/skills/*.md` が canonical skill と
     **exact match** であり、移行先 section と finite flow を実際に持つこと

`foundation:check` による stale / missing skill の blocking（Phase 0 contract）は
既存 `test/sync-check.test.mjs` がそのまま担保しており、変更していません。

## Consumer propagation

実 consumer repository は変更していません。Foundation reference consumer fixture
（`test/fixtures/consumer`）上で確認済みです。

- `npm run sync:fixture` 後、`.ai-dev-foundation/skills/review-code.md` /
  `review-doc.md` が canonical skill と exact match で配布される
- generated `AGENTS.md` には詳細 stopping procedure ではなく routing contract が残る
- `npm run check:fixture` が currentness を確認できる
- consumer 側へ duplicate review policy を追加する必要がない

実 stage-tracker への canary / compliance probe は、Issue #51 の release
sequencing どおり v0.3.0 release / repin 後の別 checkpoint です。

## Technical checkpoint（silent fix していない観察）

migration 中に見つけた current semantics 上の小さな不整合を、本 PR では
修正せず報告します。

- `skills/review-doc.md` の step 8 は
  「手順 5 の semantic discovery Resolution も完了していることが review
  procedure 完了の条件です」と述べ、移行してきた prose は
  「semantic discovery（手順 3）の Resolution が完了していることも review
  completion の条件です」と述べます。指している obligation は同一
  （semantic discovery stage の finding の Resolution）ですが、step 番号の
  参照先が 3（discovery 実行）と 5（triage）で揃っていません。
  semantics は変わらないため、Phase 1 の scope 外として据え置きます。

## Scope

Issue #51 の out of scope（`Acquisition & Validity` / `Review Adapter boundary` /
`Failure / retry` / Issue closure / Foundation Change / thin invocation の migration、
consumer product rules の progressive disclosure、provider-native skill index 生成、
generalized loader / orchestrator、#39 / #44、version bump / release tag、
stage-tracker repin）には触れていません。

## Authority

本 session に PR merge / Issue #51 close / version bump / v0.3.0 tag /
stage-tracker repin の authority はありません。merge-ready で停止します。
auto-close keyword は使用していません。

