### PR TITLE
Release v0.3.0: version bump・final verification・tag-ready state (Issue #53)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-dev-foundation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-foundation",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-dev-foundation",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "sync:fixture": "node tooling/sync.mjs --consumer test/fixtures/consumer",


### PR DESCRIPTION
## Summary

`v0.2.0` 以降に main へ land した Foundation improvement を `v0.3.0` release candidate として freeze する version bump です（Issue #53）。新しい Foundation capability の実装は含みません。

- v0.2.0 base SHA: `300c79bb8bd2df91a8322f68dea7c25eaff3683c`
- final candidate head SHA: `b4521b63682d57bc0d8169c5a657f55946485b45`
- `v0.2.0...b4521b6`: 24 commits（23 commits + 本 version bump commit）

## なぜ v0.3.0 か

v0.2.0 以降の delta は単一の bugfix ではなく、複数の consumer-facing contract / process 改善を含むため minor release とします。

- Foundation-owned skill bundle 配布・drift 検知（Phase 0, #41 / PR #42）
- Next.js generated `AGENTS.md` 上書き防止 guard（#40 / PR #47）
- Supabase migration version-prefix collision guardrail（#43 / PR #46）
- async review completion fence の確立（#45 / PR #48）
- Claude formal review acquisition の GitHub-native routing 確立（#49 / PR #50）
- Review stopping rules の finite flow を Foundation-owned review skill へ移行（Phase 1 canary, #51 / PR #52）

## Release delta（v0.2.0 -> v0.3.0, consumer が repin した際に何が変わるか）

### Consumer-facing contract / behavior

- **Foundation-owned skill bundle配布**（#41 / PR #42）: `skills/` が `.ai-dev-foundation/skills/` として consumer へ配布されるようになり、`sync` / `check` が skill bundle の exact-match drift を検知するようになりました（ネストしたサブディレクトリのdriftも検知）。`source == destination` のケースで配布先を誤って削除しないguardも含みます（Codex P1 fix, 6800b79）。
- **Next.js AGENTS.md書き換え防止**（#40 / PR #47）: `next dev` 実行時に generated `AGENTS.md` が `agentRules: false` 設定によって上書きされてしまう既知の問題を、複数の config file / spread pattern を含めてdeterministicに検出するguardへ変更しました。
- **Supabase migration version-prefix collision guardrail**（#43 / PR #46）: DB起動前にsupabase migrationのversion prefix重複をfilesystemのみで検出するguardrailを追加しました（symlinkされたmigration fileも対象）。

### Review / runtime process change

- **async review completion fence**（#45 / PR #48）: merge-ready宣言前に、expected review setの各memberのreview obligationをfresh acquisitionで判定するcompletion fenceをpolicy/core.mdへ確立しました。ancestor target findingやin-flight runの扱いを含む複数のregression caseをcanonicalに固定しています。
- **Claude formal review acquisition routing**（#49 / PR #50）: Claudeがreviewerとしてselectionされた場合、GitHub-native `@claude` mention trigger workflow（存在する場合）をpreferred routeとするroutingを確立し、formal reviewとpreflight/local利用の境界を明確化しました。
- **Review stopping rules Phase 1 canary**（#51 / PR #52）: Executable artifactのreview finite flow（discovery -> triage -> batch fix -> closure -> merge-ready）のcanonical sourceを、`policy/core.md`から Foundation-owned review skill（`skills/review-code.md` / `skills/review-doc.md`）へ移行しました。normative ruleそのものはpolicy側に残ります。

### Deterministic guardrail / tooling

- skill bundle exact-match drift検知（上記）
- Next.js AGENTS.md書き換えguard（上記）
- Supabase migration collision guard（上記、filesystem-onlyでDB/Docker不要）

### Progressive disclosure

- Review stopping rulesのfinite flow移行がPhase 1 canaryとして完了（上記）。Phase 2以降は本releaseに含まれません（Issue #54でPhase 1 real-consumer canary後に再評価）。

### Compatibility / migration notes

- consumerが`v0.2.0`から`v0.3.0`へrepinする場合、`sync` / `check`実行により`.ai-dev-foundation/skills/`が新規に配布されます。既存consumerでこのpathを手動編集している場合はdrift検知の対象になるため、Foundation-ownedな配布物として扱ってください。
- Next.js consumerで`next.config`が`agentRules: false`相当の設定を持つ場合、`check`がdeterministicにredを報告するようになります（既存の設定ミスを新たに検出する変更であり、正しい設定のconsumerへの影響はありません）。
- Supabase consumerでmigration file間にversion prefix重複がある場合、`check`がDB起動前にredを報告するようになります。
- 上記以外の破壊的変更はありません。

## Version-bearing artifacts

- `package.json`: `0.2.0` -> `0.3.0`
- `package-lock.json`: root `version` field を `0.3.0` へ整合（dependency treeの変更なし。`npm ci`後の`npm version --no-git-tag-version`で更新）

diffはこの2ファイルのversion fieldのみに限定されています（dependency upgrade / formatter・linter upgrade / unrelated cleanup / review policy変更 / Phase 2 migration / 新guardrail / #39・#44 implementationは含みません）。

## Deterministic verification（final candidate head SHA `b4521b6`, Windows環境）

- `npm test`: 99 tests中 98 pass / 1 skipped（`test:guardrails`含む、8 guardrail fixtures verified）
  - skippedは `a migration file that exists only as a symlink is still scanned, not silently skipped` の1件のみで、理由は `symlink creation not permitted on this platform: EPERM`（Windows環境固有のsymlink権限制限であり、documented happy path上のregressionではありません）
- `npm run check:fixture`: generated adapters / quality profile / skill bundleがすべてcurrent（drift 0件）
- `npm test`内のskill bundle exact-match / currentness test群、および reference consumer bootstrapped quality profile currentness testは全てpass
- formatting / static check: repositoryに`lint` / `format` scriptおよびeslint/prettier configが存在しないため、`npm test`（skill routing contract table sync test等のmechanical checkを含む）以外に追加実行すべきscriptはありません

## Release-candidate integrity

- package version: `0.3.0`（確認済み）
- pre-existing `v0.3.0` tag: なし（`git tag -l`で `v0.1.0` / `v0.2.0` のみ確認）
- diffのscope: `package.json` / `package-lock.json` のversion fieldのみ（release-preparationに限定）
- #51 Phase 1 skill routing / stopping semantics: `npm test`内の該当regression testがpassしており維持を確認
- #45 merge-ready completion fence: 同上、regression test群がpassしており維持を確認
- #49 Claude acquisition routing: 同上、workflow trigger制限・runtime tuningのtestがpassしており維持を確認
- deterministic guardrails: 上記verification参照、全green

## Review

`policy/core.md` の Review Protocolに従い、`skills/review-code.md`（Executable artifact classification）をloadした上でReviewを実施します。本PRのdiff自体はversion field 2行のみですが、本Taskの性質上、v0.2.0以降のmain deltaをv0.3.0としてconsumerへfreezeしてよいかというrelease-candidate integrityもreview lensに含めます。

（Review Selection / Acquisition / Resolution結果は本PRのdurable commentとして追記します）

## Unresolved blocker

現時点でrelease preparation自体をblockするmaterial regressionは確認していません。

## Tag-ready判定

deterministic verificationはgreen、diffはscope限定、pre-existing tag conflictなし。current Review Protocolの完了evidenceを追記した後、tag-ready判定を確定します。

## Authority

本PRはmerge-ready / tag-ready stateまでの準備を目的とします。PR merge、Issue close、`v0.3.0` tag作成、GitHub Release公開、stage-tracker repin、Phase 2着手のauthorityはこのsessionにありません。
