### PR TITLE
Skill routing contract: mixed-classification review target routing (Issue #57)

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -728,6 +728,36 @@ provider 名や provider 固有の skill 機構（特定 CLI の skill directory
 することは **MUST** です。skill は本節の規範的なルールを複製せず、手順を説明します。
 skill を load せずに review 手順を進めることは、この routing contract への違反です。
 
+#### Mixed-classification review target
+
+1 つの review target が、異なる artifact classification に属する artifact を同時に
+含む場合（mixed-classification review target）、上記の table は 1 つの skill だけを
+選べば足りるという意味ではありません。
+
+- target に含まれる artifact classification のうち、mandatory review skill を持つ
+  classification（上記 table の Executable および Normative）が複数含まれる場合、
+  該当する classification すべてに対応する skill を load することを MUST とします。
+  いずれか 1 つの classification の skill だけを load し、他の classification に
+  属する artifact もそれで代替したことにしてはいけません。
+- 各 classification の手続き的 obligation（stopping rule、discovery round 数、
+  required review 数、closure / verification 手順を含む）は、その classification に
+  属する artifact subset にのみ適用します。ある classification の rule を、他の
+  classification に属する artifact へ流用してはいけません（例: Normative の
+  1 round discovery を Executable の artifact へ適用しない、Executable の
+  discovery -> triage -> batch fix -> verify -> targeted closure を Normative の
+  artifact へ適用しない）。
+- target に Informational な artifact が同時に含まれていても、Informational に
+  mandatory review skill が無いという Artifact classification の定義は変わりません。
+  Informational の artifact subset は、他の classification の skill が定義する
+  手続きの対象に含めません。
+- 複数の skill を load した場合、各 skill が定義する discovery / closure /
+  stopping semantics は、classification ごとに独立した review flow として並行に
+  適用してよく、単一の flow へ統合することを要求しません。
+
+この routing は Skill routing contract の 1:1 table を置き換えません。target が
+単一の classification のみで構成される場合は、上記 table のとおり単一の skill を
+load します。
+
 `.ai-dev-foundation/skills/` は Foundation-owned な配布物です。consumer はこの path
 を編集しません。canonical source は Foundation リポジトリの `skills/` であり、
 consumer 側の内容がこれと一致しない場合は drift として検知されます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -736,6 +736,36 @@ provider 名や provider 固有の skill 機構（特定 CLI の skill directory
 することは **MUST** です。skill は本節の規範的なルールを複製せず、手順を説明します。
 skill を load せずに review 手順を進めることは、この routing contract への違反です。
 
+#### Mixed-classification review target
+
+1 つの review target が、異なる artifact classification に属する artifact を同時に
+含む場合（mixed-classification review target）、上記の table は 1 つの skill だけを
+選べば足りるという意味ではありません。
+
+- target に含まれる artifact classification のうち、mandatory review skill を持つ
+  classification（上記 table の Executable および Normative）が複数含まれる場合、
+  該当する classification すべてに対応する skill を load することを MUST とします。
+  いずれか 1 つの classification の skill だけを load し、他の classification に
+  属する artifact もそれで代替したことにしてはいけません。
+- 各 classification の手続き的 obligation（stopping rule、discovery round 数、
+  required review 数、closure / verification 手順を含む）は、その classification に
+  属する artifact subset にのみ適用します。ある classification の rule を、他の
+  classification に属する artifact へ流用してはいけません（例: Normative の
+  1 round discovery を Executable の artifact へ適用しない、Executable の
+  discovery -> triage -> batch fix -> verify -> targeted closure を Normative の
+  artifact へ適用しない）。
+- target に Informational な artifact が同時に含まれていても、Informational に
+  mandatory review skill が無いという Artifact classification の定義は変わりません。
+  Informational の artifact subset は、他の classification の skill が定義する
+  手続きの対象に含めません。
+- 複数の skill を load した場合、各 skill が定義する discovery / closure /
+  stopping semantics は、classification ごとに独立した review flow として並行に
+  適用してよく、単一の flow へ統合することを要求しません。
+
+この routing は Skill routing contract の 1:1 table を置き換えません。target が
+単一の classification のみで構成される場合は、上記 table のとおり単一の skill を
+load します。
+
 `.ai-dev-foundation/skills/` は Foundation-owned な配布物です。consumer はこの path
 を編集しません。canonical source は Foundation リポジトリの `skills/` であり、
 consumer 側の内容がこれと一致しない場合は drift として検知されます。

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -854,6 +854,90 @@ test("core policy defines a provider-neutral skill routing contract", async () =
   assert.doesNotMatch(core, /\.claude\/skills|\.codex\/skills/);
 });
 
+// Issue #57 (O-2 prerequisite hardening): a single review target can straddle
+// multiple artifact classifications (observed on reitojike/stage-tracker
+// PR#60 / #127 — a mix of Executable and Normative artifacts in one target).
+// The 1:1 Skill routing contract table didn't say what to do then; fresh
+// agents independently converged on "load every applicable skill, apply each
+// classification's procedure only to its own artifact subset" without it
+// being written down. This test locks that resolution in as a deterministic,
+// mechanically-checkable rule.
+test("skill routing contract defines mixed-classification review target routing (Issue #57)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(core.includes("#### Mixed-classification review target"));
+
+  // MUST load every applicable classification's skill — not just one.
+  assert.ok(
+    containsText(
+      core,
+      "target に含まれる artifact classification のうち、mandatory review skill を持つ classification（上記 table の Executable および Normative）が複数含まれる場合、該当する classification すべてに対応する skill を load することを MUST とします。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "いずれか 1 つの classification の skill だけを load し、他の classification に属する artifact もそれで代替したことにしてはいけません。",
+    ),
+  );
+
+  // Each classification's procedural obligations apply only to its own artifact
+  // subset — no cross-classification borrowing of stricter/looser rules.
+  assert.ok(
+    containsText(
+      core,
+      "各 classification の手続き的 obligation（stopping rule、discovery round 数、required review 数、closure / verification 手順を含む）は、その classification に属する artifact subset にのみ適用します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "ある classification の rule を、他の classification に属する artifact へ流用してはいけません",
+    ),
+  );
+
+  // Informational's "no mandatory review skill" definition is unaffected by
+  // being mixed into the same target as Executable/Normative artifacts.
+  assert.ok(
+    containsText(
+      core,
+      "target に Informational な artifact が同時に含まれていても、Informational に mandatory review skill が無いという Artifact classification の定義は変わりません。",
+    ),
+  );
+
+  // Multiple loaded skills run as independent parallel flows, not one forced
+  // merge into a single procedure.
+  assert.ok(
+    containsText(
+      core,
+      "複数の skill を load した場合、各 skill が定義する discovery / closure / stopping semantics は、classification ごとに独立した review flow として並行に適用してよく、単一の flow へ統合することを要求しません。",
+    ),
+  );
+
+  // This routing must not replace or restructure the existing 1:1 table for
+  // single-classification targets (Issue #57 explicitly rules out a matrix
+  // redesign as in-scope discretion).
+  assert.ok(
+    containsText(
+      core,
+      "この routing は Skill routing contract の 1:1 table を置き換えません。target が単一の classification のみで構成される場合は、上記 table のとおり単一の skill を load します。",
+    ),
+  );
+  assert.ok(
+    containsText(core, "| Executable | `.ai-dev-foundation/skills/review-code.md` |"),
+    "the single-classification 1:1 table must survive unchanged",
+  );
+  assert.ok(
+    containsText(core, "| Normative | `.ai-dev-foundation/skills/review-doc.md` |"),
+    "the single-classification 1:1 table must survive unchanged",
+  );
+
+  // Provider-neutral, and no new Kernel-level round-counter/schema invented
+  // just to express this routing rule.
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+  assert.doesNotMatch(core, /mixed_classification|classification_matrix|Mixed Classification Contract/i);
+});
+
 test("the skill routing contract table stays in sync with the actual skills/ directory", async () => {
   // The routing contract table in policy/core.md is static prose, not
   // generated from skills/. This guards against it silently going stale if a


### PR DESCRIPTION
## 概要

Issue #57（Issue #54 checkpoint の O-2 prerequisite hardening）。1 つの review target が複数の artifact classification へまたがるケースが `reitojike/stage-tracker` PR#60 / PR#127 で観測された（Executable の TS/SQL と、Normative の `.ai-dev-foundation/product-rules.md` が同一 target に混在）。Skill routing contract の 1:1 table（artifact classification -> skill）は、このケースでの routing を明記していなかった。複数の fresh agent がそれぞれ独立に「該当する全 classification の skill を load し、各 classification の手順はその classification に属する artifact subset にのみ適用する」という同一の解決へ収束していたが、これは文書化されていなかった。

本 PR は、この解決を `policy/core.md` の Skill routing contract へ `#### Mixed-classification review target` 節として追加する。

- Executable / Normative の両方が 1 つの target に混在する場合、mandatory review skill を持つ該当 classification すべての skill を load することを MUST とする（1 つだけ load して済ませない）。
- 各 classification の手続き的 obligation（stopping rule、discovery round 数、required review 数、closure / verification 手順）は、その classification に属する artifact subset にのみ適用する。
- 同一 target に Informational な artifact が混在していても、Informational 自体が mandatory review skill を持たないという既存定義は変わらない。
- 複数の skill を load した場合、各 classification の review flow は独立した並行 flow として適用してよく、単一 flow への統合は要求しない。
- 既存の single-classification 1:1 table はそのまま変更していない。

## 変更内容

- `policy/core.md`: `#### Mixed-classification review target` 節を新設（Normative）。
- `test/review-protocol.test.mjs`: 新規テスト `skill routing contract defines mixed-classification review target routing (Issue #57)` を追加（Executable）。上記 rule の文言を機械的に検証し、provider 名や新しい schema の混入を防ぐ guard も含む。
- `test/fixtures/consumer/AGENTS.md`: `npm run sync:fixture` で再生成。`npm run check:fixture` で drift 0 件を確認済み。

## Review classification

この review target 自体が Normative（`policy/core.md`、生成される `AGENTS.md`）と Executable（`test/review-protocol.test.mjs`）の混在であり、Issue #57 が扱っているシナリオそのもの。新しい rule に従い、`skills/review-doc.md` と `skills/review-code.md` の両方を、それぞれの artifact subset に適用する。

- Executable precondition: この commit で `npm test`（99 pass / 0 fail / 1 件は既存の platform 起因 skip）と `npm run test:guardrails`（fixture 8 件）が green であることを確認済み。
- Normative precondition: このリポジトリの慣行では、`policy/core.md` に対する mechanical markdown check は本 repo の test assertion 群として表現されている（別立ての linter ではない）。

## Test plan

- [x] `npm test` — 99 pass / 0 fail / 1 件は既存の platform 起因 skip（symlink test）
- [x] `npm run check:fixture` — `sync:fixture` 後の drift 0 件
- [ ] review 依頼: `@claude` にこの PR を、この repo 自身の Foundation Review Protocol（`.ai-dev-foundation` 規約）に沿ってレビューを依頼（`policy/core.md` の新節に対する Normative review と、test assertion 追加分に対する Executable review）。確認してほしい点: (1) 新しい rule の文言が mixed-classification のケースを一意に解決できているか、(2) 既存の single-classification table を暗黙に変更していないか、(3) 追加した test assertion が表面的な string-match ではなく意味のある deterministic check になっているか、(4) provider 名の混入や Issue #57 の out-of-scope（Phase 2 / Review Protocol 全体再設計）への scope creep がないか。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>