### PR TITLE
Next.js + Supabase profile: client-role residual privilegeをdeterministicに検出するsecurity guardrailを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
+        "pg": "^8.11.0",
         "prettier": "^3.0.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0"
@@ -1273,6 +1274,103 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -1284,6 +1382,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -1366,6 +1507,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1509,6 +1660,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "check:fixture": "node tooling/check.mjs --consumer test/fixtures/consumer",
     "bootstrap:next-supabase:fixture": "node tooling/bootstrap-next-supabase.mjs --consumer test/fixtures/quality-consumer",
     "test:guardrails": "node tooling/verify-guardrails.mjs",
-    "test": "node --test --test-concurrency=1 test/*.test.mjs && npm run test:guardrails"
+    "test": "node --test --test-concurrency=1 test/*.test.mjs && npm run test:guardrails",
+    "test:client-role-table-privileges-guardrail": "node --test test/db/*.test.mjs"
   },
   "devDependencies": {
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "pg": "^8.11.0",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0"

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -28,6 +28,9 @@ prettier
 typescript
 ```
 
+Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile`から呼び出す
+consumerは、これに加えて`pg`を追加します。
+
 ## 適用方法
 
 consumerの`tsconfig.json`でstrict TypeScript設定を継承します。
@@ -134,6 +137,64 @@ collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local sta
 node .ai-dev-foundation/quality/check-migration-version-collision.mjs
 ```
 
+## Client-role table privilege guardrail
+
+RLS policyが正しく定義されていても、table-level grantとして`anon` / `authenticated` /
+`PUBLIC`に意図しないprivilegeが残ると、RLSだけを検証してもsecurity boundaryが成立し
+ません。特に`TRUNCATE`はRLSを完全に迂回するため、RLS testsがgreenでもclient roleが
+tableをtruncateできる状態を見逃し得ます（confirmed defect:
+`reitojike/stage-tracker#42` / `reitojike/stage-tracker#49`。多くの場合、原因は
+schema-wide `ALTER DEFAULT PRIVILEGES`が新規tableへ既定でこれらのprivilegeを
+付与することです — migrationがgrantを追加するだけでは、この既存の残存ACLには一切
+触れません）。
+
+`check-client-role-table-privileges.mjs`は、actual local/CI PostgreSQL上の`public`
+schema全table（動的に列挙、`pg_tables`基準）を対象に、`anon` / `authenticated` /
+`PUBLIC`（PostgreSQLのpseudo-role。`has_table_privilege('public', ...)`で判定）が
+次のいずれかを保持していないかをdeterministicに検査します。
+
+```text
+TRUNCATE
+REFERENCES
+TRIGGER
+MAINTAIN  (PostgreSQL 17+のみ。has_table_privilegeは17未満のserverでは
+           "unrecognized privilege type"を送出するため、server_version_num
+           で判定しexplicitにskipします — 例外を握りつぶすのではなく、
+           checkしたprivilege集合をpositiveに報告します)
+```
+
+### Foundation-owned safety boundaryとconsumer-owned permission matrixの境界
+
+このcheckerはSELECT / INSERT / UPDATE / DELETE（table-levelおよびcolumn-level）を
+一切検査しません。それらはproduct固有のpermission matrixであり、consumer-ownedの
+ままです。上記4つのprivilegeが対象になるのは、PostgREST-styleのclient roleが
+意図的なCRUD permission matrixの一部としてこれらを持つ正当な理由が構造的に存在
+しないためです。TRUNCATEはRLSを迂回し、REFERENCESはforeign key制約違反エラー経由の
+covert channel（PostgreSQL自身のrow security documentationが明記する既知の
+制約）になり得ます。TRIGGER/MAINTAINも同様にclient roleに不要な特権です。
+
+evidence上、これら4つのprivilegeについてconsumer側で正当な例外が必要になった実例は
+ないため（stage-trackerの現行grant matrixはどのtableにもこれらを一切持ちません）、
+本checkerはunconditional denyとして実装され、consumer向けのexception/override機構は
+持ちません。将来具体的な必要が生じた場合は、先行してexception機構を用意するのでは
+なく、その時点でFoundation ObservationまたはChange Proposalとして扱います。
+`service_role`等のadministrative roleはこの検査対象に含めません。
+
+### 使い方
+
+```text
+node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs
+```
+
+既定では、consumerのDB/RLS testと同じ方法（`supabase status -o json`）でlocal
+Supabaseの接続先を自動検出します。実行には稼働中のlocal Supabase stackが必要です
+（DB / Docker / Supabase local stackを起動する他のcheckより後に実行します）。
+`SUPABASE_DB_URL`を設定すると、この自動検出をbypassして直接その接続先を検査します。
+
+failure診断にはrole / table / privilegeの組が一覧表示され、remediationとして
+`revoke all ... from public, anon, authenticated`した上で意図するSELECT/INSERT/
+UPDATE/DELETEのみを再grantする例を示します。
+
 ## Next.js agent-rules (generated AGENTS.md) drift prevention
 
 `AGENTS.md`はFoundation canonical inputsから生成されるgenerated artifactです
@@ -211,11 +272,15 @@ driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsume
 `verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
 同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
 呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
+local Supabase stackを起動するconsumerは、同じ`verify:profile`から
+`client-role-privileges:check`（DB / Docker / Supabase local stackを起動する他の
+checkより後）も呼び出し、残存privilegeの回帰をblockingで検知します。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
+    "client-role-privileges:check": "node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs",
+    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }
@@ -245,6 +310,7 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 - migration apply / rollback相当のoperation
 - DB / RLS / auth integration test
 - schema由来のgenerated types生成、およびdrift verification
+- `client-role-privileges:check`（client-role table privilege guardrail）
 - 上記のいずれかを内包する`verify:profile`
 - 上記のいずれかを内包するfull `verify`
 

--- a/profiles/next-supabase/quality/check-client-role-table-privileges.mjs
+++ b/profiles/next-supabase/quality/check-client-role-table-privileges.mjs
@@ -1,0 +1,219 @@
+import { execFileSync } from 'node:child_process';
+import pg from 'pg';
+
+// Foundation-owned safety boundary vs. consumer-owned permission matrix
+// (Issue #44 security/design checkpoint):
+//
+// This checker only ever asserts about the four table-level privilege bits
+// below. It never inspects, and must never be extended to inspect, SELECT /
+// INSERT / UPDATE / DELETE (table- or column-level) — that permission
+// matrix is entirely product-specific and stays consumer-owned (see
+// profiles/next-supabase/quality/README.md). What makes TRUNCATE /
+// REFERENCES / TRIGGER / MAINTAIN different is that none of them is ever
+// part of an intended CRUD permission matrix for a PostgREST-style client
+// role in the first place, so denying them requires no product knowledge:
+//
+// - TRUNCATE bypasses row level security entirely (confirmed defect,
+//   stage-tracker#42 / reitojike/stage-tracker#49): a policy-only reading
+//   of "is this table safe" cannot see it.
+// - REFERENCES lets the grantee create a foreign key referencing the
+//   table. PostgreSQL's own row security documentation names this a
+//   covert channel: referential integrity checks always bypass row
+//   security, so a crafted FK constraint can leak whether a specific key
+//   value exists via the constraint-violation error, independent of any
+//   policy.
+// - TRIGGER lets the grantee attach a trigger to the table.
+// - MAINTAIN (PostgreSQL 17+) permits VACUUM/ANALYZE/CLUSTER/REINDEX/
+//   REFRESH MATERIALIZED VIEW — maintenance operations a client role never
+//   needs, some of which can lock or rewrite the table.
+//
+// stage-tracker's real, hardened grant matrix (Issue #42/#49) holds none of
+// these four on any of its public tables — there is no observed consumer
+// need for an exception. Foundation therefore denies all four
+// unconditionally, with no consumer exception/override mechanism in this
+// change. Building a speculative escape hatch without an evidenced need
+// would itself be the kind of premature machinery Foundation's own
+// "先行実装しない" stance rejects; if a genuine need surfaces later, that is
+// a new Foundation Observation / Change Proposal, not a preemptive default.
+const ALWAYS_DENIED_PRIVILEGES = ['TRUNCATE', 'REFERENCES', 'TRIGGER'];
+
+// has_table_privilege(role, table, 'MAINTAIN') raises "unrecognized
+// privilege type" on a server older than PostgreSQL 17 (confirmed against
+// postgres:15 while building this checker) — MAINTAIN did not exist before
+// 17. Gating on the server's own reported version, rather than attempting
+// the call and swallowing the error, keeps an older server's skip an
+// explicit, positive diagnostic instead of a silently-caught failure that
+// could just as easily hide a real connection problem.
+const MAINTAIN_MIN_SERVER_VERSION_NUM = 170000;
+
+// service_role and other administrative roles are deliberately excluded:
+// they are not normal PostgREST client roles, and this checker must not
+// treat them the same way (Issue #44 Invariants). 'public' is the
+// PostgreSQL pseudo-role denoting PUBLIC — has_table_privilege('public',
+// table, privilege) reports whether PUBLIC itself holds the privilege
+// (confirmed empirically: distinct from, and not to be confused with, the
+// `public` *schema*), which is the most severe case since it grants the
+// privilege to literally every role.
+const CLIENT_ROLES = ['anon', 'authenticated', 'public'];
+
+// `supabase status -o json` is not safe to run concurrently — it rewrites
+// the CLI's own ~/.supabase/telemetry.json through a temp file plus a
+// rename, and a losing rename aborts the CLI outright. This is the same
+// observed provider behavior already documented and retried in stage-
+// tracker's test/rls/support/localSupabase.ts; carried over here bounded
+// and unchanged now that this script also shells out to the same command.
+const STATUS_ATTEMPTS = 5;
+const STATUS_RETRY_BASE_MS = 150;
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function readDatabaseUrlFromSupabaseStatus() {
+  let lastError;
+  for (let attempt = 0; attempt < STATUS_ATTEMPTS; attempt += 1) {
+    try {
+      const raw = execFileSync('supabase', ['status', '-o', 'json'], {
+        encoding: 'utf8',
+        // Windows can only launch node_modules/.bin's supabase.cmd shim
+        // through a shell (Node throws EINVAL otherwise); the args above
+        // are static literals, not external input, so shell:true carries
+        // no injection risk here.
+        shell: process.platform === 'win32',
+      });
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.DB_URL !== 'string' || parsed.DB_URL.length === 0) {
+        throw new Error('"supabase status -o json" did not report a DB_URL.');
+      }
+      return parsed.DB_URL;
+    } catch (error) {
+      lastError = error;
+      sleep(STATUS_RETRY_BASE_MS * (attempt + 1) + Math.floor(Math.random() * 100));
+    }
+  }
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Could not determine the local Supabase database URL: "supabase status -o json" failed ` +
+      `${String(STATUS_ATTEMPTS)} times (last error: ${detail}). Is the local Supabase stack ` +
+      `running ("supabase start")? Set SUPABASE_DB_URL to bypass this and connect directly.`,
+  );
+}
+
+// SUPABASE_DB_URL is an explicit override, primarily for testing this
+// checker against a database that is not a full local Supabase stack (see
+// test/db/). Consumers running a normal local Supabase stack do not need
+// to set it — the default path below discovers the URL the same way
+// stage-tracker's own DB/RLS tests already do.
+function resolveDatabaseUrl() {
+  if (process.env.SUPABASE_DB_URL) return process.env.SUPABASE_DB_URL;
+  return readDatabaseUrlFromSupabaseStatus();
+}
+
+async function withPgClient(databaseUrl, run) {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function requireClientRolesExist(client) {
+  const roleNames = CLIENT_ROLES.filter((role) => role !== 'public');
+  const { rows } = await client.query(
+    `select rolname from pg_roles where rolname = any($1::text[])`,
+    [roleNames],
+  );
+  const foundRoleNames = new Set(rows.map((row) => row.rolname));
+  const missingRoleNames = roleNames.filter((role) => !foundRoleNames.has(role));
+  if (missingRoleNames.length > 0) {
+    throw new Error(
+      `Role(s) ${missingRoleNames.map((role) => `"${role}"`).join(', ')} do not exist on this ` +
+        `database. This checker expects the standard Supabase-provisioned client roles ` +
+        `(anon, authenticated) to be present; is SUPABASE_DB_URL/the local Supabase stack ` +
+        `pointed at a Supabase-managed database?`,
+    );
+  }
+}
+
+async function resolveDeniedPrivileges(client) {
+  const { rows } = await client.query(`select current_setting('server_version_num') as version`);
+  const serverVersionNum = Number.parseInt(rows[0].version, 10);
+  if (serverVersionNum >= MAINTAIN_MIN_SERVER_VERSION_NUM) {
+    return { privileges: [...ALWAYS_DENIED_PRIVILEGES, 'MAINTAIN'], serverVersionNum };
+  }
+  console.log(
+    `Server version ${String(serverVersionNum)} is older than PostgreSQL 17 ` +
+      `(${String(MAINTAIN_MIN_SERVER_VERSION_NUM)}); MAINTAIN does not exist on this server and is ` +
+      `skipped. Checking: ${ALWAYS_DENIED_PRIVILEGES.join(', ')}.`,
+  );
+  return { privileges: [...ALWAYS_DENIED_PRIVILEGES], serverVersionNum };
+}
+
+async function findResidualPrivileges(client, deniedPrivileges) {
+  const { rows: tables } = await client.query(
+    `select tablename from pg_tables where schemaname = 'public'`,
+  );
+  const { rows } = await client.query(
+    `select t.tablename, r.role, p.privilege
+     from pg_tables t
+     cross join unnest($1::text[]) as r(role)
+     cross join unnest($2::text[]) as p(privilege)
+     where t.schemaname = 'public'
+       and has_table_privilege(r.role, 'public.' || t.tablename, p.privilege)
+     order by t.tablename, r.role, p.privilege`,
+    [CLIENT_ROLES, deniedPrivileges],
+  );
+  return { residual: rows, tableCount: tables.length };
+}
+
+function formatResidualLine(row) {
+  return `${row.role} -> ${row.tablename}: ${row.privilege}`;
+}
+
+async function main() {
+  const databaseUrl = resolveDatabaseUrl();
+  await withPgClient(databaseUrl, async (client) => {
+    await requireClientRolesExist(client);
+    const { privileges: deniedPrivileges, serverVersionNum } =
+      await resolveDeniedPrivileges(client);
+    const { residual, tableCount } = await findResidualPrivileges(client, deniedPrivileges);
+
+    if (tableCount === 0) {
+      console.log('No tables found in the public schema; nothing to inventory.');
+      return;
+    }
+
+    if (residual.length > 0) {
+      console.error(
+        `Residual client-role table privilege(s) detected in the public schema ` +
+          `(server_version_num ${String(serverVersionNum)}, checked ${String(tableCount)} table(s) for ` +
+          `${deniedPrivileges.join(', ')}):`,
+      );
+      for (const row of residual) {
+        console.error(`  ${formatResidualLine(row)}`);
+      }
+      console.error(
+        'None of anon, authenticated, or PUBLIC may hold TRUNCATE/REFERENCES/TRIGGER/MAINTAIN on ' +
+          'any public schema table (Foundation Next.js + Supabase profile). Revoke the privilege(s) ' +
+          'above, e.g.:\n' +
+          '  revoke all on public.<table> from public, anon, authenticated;\n' +
+          '  -- then re-grant only the SELECT/INSERT/UPDATE/DELETE this table actually intends.',
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `No residual ${deniedPrivileges.join('/')} for anon/authenticated/PUBLIC on any of ` +
+          `${String(tableCount)} public schema table(s) (server_version_num ${String(serverVersionNum)}).`,
+      );
+    }
+  });
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/profiles/next-supabase/quality/check-client-role-table-privileges.mjs
+++ b/profiles/next-supabase/quality/check-client-role-table-privileges.mjs
@@ -161,7 +161,7 @@ async function findResidualPrivileges(client, deniedPrivileges) {
      cross join unnest($1::text[]) as r(role)
      cross join unnest($2::text[]) as p(privilege)
      where t.schemaname = 'public'
-       and has_table_privilege(r.role, 'public.' || t.tablename, p.privilege)
+       and has_table_privilege(r.role, format('%I.%I', t.schemaname, t.tablename), p.privilege)
      order by t.tablename, r.role, p.privilege`,
     [CLIENT_ROLES, deniedPrivileges],
   );

--- a/test/db/client-role-table-privileges.test.mjs
+++ b/test/db/client-role-table-privileges.test.mjs
@@ -203,6 +203,28 @@ if (!dockerAvailable()) {
     });
 
     await t.test(
+      'a table whose name requires quoting (mixed-case) is still checked, not silently skipped or crashed',
+      async () => {
+        // Regression for a Claude review finding on this PR: the table
+        // argument to has_table_privilege was originally built via unquoted
+        // string concatenation ('public.' || t.tablename). Postgres's
+        // regclass parsing of an unquoted identifier lowercases it, so a
+        // stored table name that is not already all-lowercase - only
+        // reachable via a quoted identifier at CREATE TABLE time, e.g.
+        // Prisma-style "Users" - resolved to the wrong (usually
+        // nonexistent) relation, either erroring the whole cross-join query
+        // (masking every other table's check) or, if a same-named lowercase
+        // table happened to exist, silently checking the wrong one. Fixed
+        // by format('%I.%I', schema, table) to properly quote both parts.
+        await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+        await applyFixture(pg17.databaseUrl, 'mixed-case-quoted-table');
+        const result = runChecker(pg17.databaseUrl);
+        assert.notEqual(result.status, 0, result.stdout + result.stderr);
+        assert.match(result.stderr, /authenticated -> Users: TRIGGER/);
+      },
+    );
+
+    await t.test(
       'a grant to the PUBLIC pseudo-role is detected for PUBLIC and propagates to anon/authenticated',
       async () => {
         // Confirms the Issue #44 design-checkpoint decision to check the

--- a/test/db/client-role-table-privileges.test.mjs
+++ b/test/db/client-role-table-privileges.test.mjs
@@ -1,0 +1,281 @@
+// Positive/negative guardrail proof for
+// profiles/next-supabase/quality/check-client-role-table-privileges.mjs
+// (Issue #44). Unlike every other test/*.test.mjs in this repo, this file
+// needs an actual PostgreSQL server to exercise real has_table_privilege /
+// server-version semantics, not just filesystem fixtures. It therefore:
+//
+//  - lives under test/db/, not test/, so the top-level `npm test`
+//    (`test/*.test.mjs`, non-recursive) does not pick it up and does not
+//    require Docker;
+//  - is run explicitly via `npm run test:client-role-table-privileges-guardrail`;
+//  - manages its own disposable, randomly-named, dynamically-ported
+//    PostgreSQL containers, so it cannot collide with any other checkout's
+//    or session's Docker resources (including a running Supabase local
+//    stack) on the same machine, and requires no pre-existing local
+//    Supabase stack itself.
+//
+// Skips (does not fail) when Docker is unavailable, mirroring the platform
+// -capability skip already used for the symlink case in
+// test/migration-version-collision.test.mjs.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const checkerScript = path.join(
+  root,
+  'profiles',
+  'next-supabase',
+  'quality',
+  'check-client-role-table-privileges.mjs',
+);
+const fixturesRoot = path.join(root, 'test', 'fixtures', 'client-role-table-privileges');
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function dockerAvailable() {
+  return spawnSync('docker', ['info'], { encoding: 'utf8' }).status === 0;
+}
+
+function startPostgresContainer(image) {
+  const name = `ai-dev-foundation-privileges-test-${process.pid}-${Date.now()}`;
+  const run = spawnSync(
+    'docker',
+    [
+      'run',
+      '-d',
+      '--rm',
+      '--name',
+      name,
+      '-e',
+      'POSTGRES_PASSWORD=postgres',
+      '-p',
+      '0:5432',
+      image,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (run.status !== 0) {
+    throw new Error(`Failed to start ${image}: ${run.stderr}`);
+  }
+
+  const stop = () => {
+    spawnSync('docker', ['rm', '-f', name], { encoding: 'utf8' });
+  };
+
+  try {
+    const portResult = spawnSync('docker', ['port', name, '5432/tcp'], { encoding: 'utf8' });
+    const firstLine = portResult.stdout.trim().split('\n')[0] ?? '';
+    const match = /:(\d+)\s*$/.exec(firstLine);
+    if (!match) {
+      throw new Error(
+        `Could not determine host port for ${name}: ${portResult.stdout}${portResult.stderr}`,
+      );
+    }
+    const databaseUrl = `postgresql://postgres:postgres@127.0.0.1:${match[1]}/postgres`;
+
+    const deadline = Date.now() + 30_000;
+    let ready = false;
+    while (Date.now() < deadline) {
+      if (
+        spawnSync('docker', ['exec', name, 'pg_isready', '-U', 'postgres'], { encoding: 'utf8' })
+          .status === 0
+      ) {
+        ready = true;
+        break;
+      }
+      sleep(500);
+    }
+    if (!ready) {
+      throw new Error(`${name} did not become ready within 30s`);
+    }
+
+    return { databaseUrl, stop };
+  } catch (error) {
+    stop();
+    throw error;
+  }
+}
+
+async function withClient(databaseUrl, run) {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function resetPublicSchemaWithClientRoles(databaseUrl) {
+  await withClient(databaseUrl, async (client) => {
+    await client.query('drop schema public cascade; create schema public;');
+    await client.query(`
+      do $$
+      begin
+        if not exists (select 1 from pg_roles where rolname = 'anon') then
+          create role anon nologin;
+        end if;
+        if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+          create role authenticated nologin;
+        end if;
+      end
+      $$;
+    `);
+  });
+}
+
+async function applyFixture(databaseUrl, fixtureName) {
+  const sql = await readFile(path.join(fixturesRoot, `${fixtureName}.sql`), 'utf8');
+  await withClient(databaseUrl, (client) => client.query(sql));
+}
+
+function runChecker(databaseUrl) {
+  return spawnSync(process.execPath, [checkerScript], {
+    encoding: 'utf8',
+    env: { ...process.env, SUPABASE_DB_URL: databaseUrl },
+  });
+}
+
+if (!dockerAvailable()) {
+  test('client-role table privilege guardrail (skipped: Docker unavailable)', (t) => {
+    t.skip('Docker is required to exercise this checker against a real PostgreSQL server');
+  });
+} else {
+  test('client-role table privilege guardrail', async (t) => {
+    const pg17 = startPostgresContainer('postgres:17');
+    t.after(pg17.stop);
+
+    await t.test('a clean grant set (SELECT only) is green', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      await applyFixture(pg17.databaseUrl, 'clean');
+      const result = runChecker(pg17.databaseUrl);
+      assert.equal(result.status, 0, result.stdout + result.stderr);
+      assert.match(result.stdout, /No residual TRUNCATE\/REFERENCES\/TRIGGER\/MAINTAIN/);
+    });
+
+    await t.test('an empty public schema (no tables) is green, not an error', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      const result = runChecker(pg17.databaseUrl);
+      assert.equal(result.status, 0, result.stdout + result.stderr);
+      assert.match(result.stdout, /nothing to inventory/);
+    });
+
+    await t.test(
+      'anon holding TRUNCATE is deterministically red and named in the diagnostic',
+      async () => {
+        await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+        await applyFixture(pg17.databaseUrl, 'residual-truncate');
+        const result = runChecker(pg17.databaseUrl);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /anon -> orders: TRUNCATE/);
+      },
+    );
+
+    await t.test('authenticated holding REFERENCES is deterministically red', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      await applyFixture(pg17.databaseUrl, 'residual-references');
+      const result = runChecker(pg17.databaseUrl);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /authenticated -> orders: REFERENCES/);
+    });
+
+    await t.test('authenticated holding TRIGGER is deterministically red', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      await applyFixture(pg17.databaseUrl, 'residual-trigger');
+      const result = runChecker(pg17.databaseUrl);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /authenticated -> orders: TRIGGER/);
+    });
+
+    await t.test('anon holding MAINTAIN is deterministically red on PostgreSQL 17+', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      await applyFixture(pg17.databaseUrl, 'residual-maintain');
+      const result = runChecker(pg17.databaseUrl);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /anon -> orders: MAINTAIN/);
+    });
+
+    await t.test(
+      'a grant to the PUBLIC pseudo-role is detected for PUBLIC and propagates to anon/authenticated',
+      async () => {
+        // Confirms the Issue #44 design-checkpoint decision to check the
+        // PUBLIC pseudo-role itself, not just anon/authenticated: granting to
+        // PUBLIC is the most severe case (every role gains the privilege),
+        // and has_table_privilege(role, ...) resolves privileges anon/
+        // authenticated inherit via PUBLIC, so both effects must be visible.
+        await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+        await applyFixture(pg17.databaseUrl, 'residual-public-pseudo-role');
+        const result = runChecker(pg17.databaseUrl);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /public -> orders: TRUNCATE/);
+        assert.match(result.stderr, /anon -> orders: TRUNCATE/);
+        assert.match(result.stderr, /authenticated -> orders: TRUNCATE/);
+      },
+    );
+
+    await t.test(
+      'a residual privilege on one table does not false-positive an unrelated clean table',
+      async () => {
+        await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+        await applyFixture(pg17.databaseUrl, 'mixed-clean-and-residual');
+        const result = runChecker(pg17.databaseUrl);
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /authenticated -> leaky_table: TRIGGER/);
+        assert.doesNotMatch(result.stderr, /clean_table/);
+      },
+    );
+
+    await t.test('the failure diagnostic includes remediating guidance', async () => {
+      await resetPublicSchemaWithClientRoles(pg17.databaseUrl);
+      await applyFixture(pg17.databaseUrl, 'residual-truncate');
+      const result = runChecker(pg17.databaseUrl);
+      assert.match(result.stderr, /revoke all on public\.<table> from public, anon, authenticated/);
+    });
+
+    await t.test(
+      'a database missing the Supabase client roles fails with a clear diagnostic, not a stack trace',
+      async () => {
+        const bareContainer = startPostgresContainer('postgres:17');
+        try {
+          const result = runChecker(bareContainer.databaseUrl);
+          assert.notEqual(result.status, 0);
+          assert.match(result.stderr, /Role\(s\) "anon", "authenticated" do not exist/);
+          assert.doesNotMatch(result.stderr, /at requireClientRolesExist/);
+        } finally {
+          bareContainer.stop();
+        }
+      },
+    );
+
+    await t.test(
+      'MAINTAIN is version-gated and explicitly skipped, not crashed, before PostgreSQL 17',
+      async () => {
+        // has_table_privilege(role, table, 'MAINTAIN') raises "unrecognized
+        // privilege type" before PostgreSQL 17 (MAINTAIN did not exist yet) -
+        // confirmed against postgres:15 while building this checker. A
+        // consumer pinned to an older server must still get a clean pass
+        // (for TRUNCATE/REFERENCES/TRIGGER) with an explicit skip note, not a
+        // crash.
+        const pg15 = startPostgresContainer('postgres:15');
+        try {
+          await resetPublicSchemaWithClientRoles(pg15.databaseUrl);
+          await applyFixture(pg15.databaseUrl, 'clean');
+          const result = runChecker(pg15.databaseUrl);
+          assert.equal(result.status, 0, result.stdout + result.stderr);
+          assert.match(result.stdout, /older than PostgreSQL 17/);
+          assert.match(result.stdout, /MAINTAIN does not exist on this server and is skipped/);
+          assert.match(result.stdout, /No residual TRUNCATE\/REFERENCES\/TRIGGER for/);
+        } finally {
+          pg15.stop();
+        }
+      },
+    );
+  });
+}

--- a/test/fixtures/client-role-table-privileges/clean.sql
+++ b/test/fixtures/client-role-table-privileges/clean.sql
@@ -1,0 +1,2 @@
+create table public.clean_table (id int primary key);
+grant select on public.clean_table to anon, authenticated;

--- a/test/fixtures/client-role-table-privileges/mixed-case-quoted-table.sql
+++ b/test/fixtures/client-role-table-privileges/mixed-case-quoted-table.sql
@@ -1,0 +1,3 @@
+create table public."Users" (id int primary key);
+grant select on public."Users" to authenticated;
+grant trigger on public."Users" to authenticated;

--- a/test/fixtures/client-role-table-privileges/mixed-clean-and-residual.sql
+++ b/test/fixtures/client-role-table-privileges/mixed-clean-and-residual.sql
@@ -1,0 +1,6 @@
+create table public.clean_table (id int primary key);
+grant select on public.clean_table to anon, authenticated;
+
+create table public.leaky_table (id int primary key);
+grant select on public.leaky_table to authenticated;
+grant trigger on public.leaky_table to authenticated;

--- a/test/fixtures/client-role-table-privileges/residual-maintain.sql
+++ b/test/fixtures/client-role-table-privileges/residual-maintain.sql
@@ -1,0 +1,2 @@
+create table public.orders (id int primary key);
+grant maintain on public.orders to anon;

--- a/test/fixtures/client-role-table-privileges/residual-public-pseudo-role.sql
+++ b/test/fixtures/client-role-table-privileges/residual-public-pseudo-role.sql
@@ -1,0 +1,2 @@
+create table public.orders (id int primary key);
+grant truncate on public.orders to public;

--- a/test/fixtures/client-role-table-privileges/residual-references.sql
+++ b/test/fixtures/client-role-table-privileges/residual-references.sql
@@ -1,0 +1,3 @@
+create table public.orders (id int primary key);
+grant select on public.orders to authenticated;
+grant references on public.orders to authenticated;

--- a/test/fixtures/client-role-table-privileges/residual-trigger.sql
+++ b/test/fixtures/client-role-table-privileges/residual-trigger.sql
@@ -1,0 +1,2 @@
+create table public.orders (id int primary key);
+grant trigger on public.orders to authenticated;

--- a/test/fixtures/client-role-table-privileges/residual-truncate.sql
+++ b/test/fixtures/client-role-table-privileges/residual-truncate.sql
@@ -1,0 +1,3 @@
+create table public.orders (id int primary key);
+grant select on public.orders to authenticated;
+grant truncate on public.orders to anon;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -28,6 +28,9 @@ prettier
 typescript
 ```
 
+Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile`から呼び出す
+consumerは、これに加えて`pg`を追加します。
+
 ## 適用方法
 
 consumerの`tsconfig.json`でstrict TypeScript設定を継承します。
@@ -134,6 +137,64 @@ collisionを未然に防ぐ機構ではなく、DB / Docker / Supabase local sta
 node .ai-dev-foundation/quality/check-migration-version-collision.mjs
 ```
 
+## Client-role table privilege guardrail
+
+RLS policyが正しく定義されていても、table-level grantとして`anon` / `authenticated` /
+`PUBLIC`に意図しないprivilegeが残ると、RLSだけを検証してもsecurity boundaryが成立し
+ません。特に`TRUNCATE`はRLSを完全に迂回するため、RLS testsがgreenでもclient roleが
+tableをtruncateできる状態を見逃し得ます（confirmed defect:
+`reitojike/stage-tracker#42` / `reitojike/stage-tracker#49`。多くの場合、原因は
+schema-wide `ALTER DEFAULT PRIVILEGES`が新規tableへ既定でこれらのprivilegeを
+付与することです — migrationがgrantを追加するだけでは、この既存の残存ACLには一切
+触れません）。
+
+`check-client-role-table-privileges.mjs`は、actual local/CI PostgreSQL上の`public`
+schema全table（動的に列挙、`pg_tables`基準）を対象に、`anon` / `authenticated` /
+`PUBLIC`（PostgreSQLのpseudo-role。`has_table_privilege('public', ...)`で判定）が
+次のいずれかを保持していないかをdeterministicに検査します。
+
+```text
+TRUNCATE
+REFERENCES
+TRIGGER
+MAINTAIN  (PostgreSQL 17+のみ。has_table_privilegeは17未満のserverでは
+           "unrecognized privilege type"を送出するため、server_version_num
+           で判定しexplicitにskipします — 例外を握りつぶすのではなく、
+           checkしたprivilege集合をpositiveに報告します)
+```
+
+### Foundation-owned safety boundaryとconsumer-owned permission matrixの境界
+
+このcheckerはSELECT / INSERT / UPDATE / DELETE（table-levelおよびcolumn-level）を
+一切検査しません。それらはproduct固有のpermission matrixであり、consumer-ownedの
+ままです。上記4つのprivilegeが対象になるのは、PostgREST-styleのclient roleが
+意図的なCRUD permission matrixの一部としてこれらを持つ正当な理由が構造的に存在
+しないためです。TRUNCATEはRLSを迂回し、REFERENCESはforeign key制約違反エラー経由の
+covert channel（PostgreSQL自身のrow security documentationが明記する既知の
+制約）になり得ます。TRIGGER/MAINTAINも同様にclient roleに不要な特権です。
+
+evidence上、これら4つのprivilegeについてconsumer側で正当な例外が必要になった実例は
+ないため（stage-trackerの現行grant matrixはどのtableにもこれらを一切持ちません）、
+本checkerはunconditional denyとして実装され、consumer向けのexception/override機構は
+持ちません。将来具体的な必要が生じた場合は、先行してexception機構を用意するのでは
+なく、その時点でFoundation ObservationまたはChange Proposalとして扱います。
+`service_role`等のadministrative roleはこの検査対象に含めません。
+
+### 使い方
+
+```text
+node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs
+```
+
+既定では、consumerのDB/RLS testと同じ方法（`supabase status -o json`）でlocal
+Supabaseの接続先を自動検出します。実行には稼働中のlocal Supabase stackが必要です
+（DB / Docker / Supabase local stackを起動する他のcheckより後に実行します）。
+`SUPABASE_DB_URL`を設定すると、この自動検出をbypassして直接その接続先を検査します。
+
+failure診断にはrole / table / privilegeの組が一覧表示され、remediationとして
+`revoke all ... from public, anon, authenticated`した上で意図するSELECT/INSERT/
+UPDATE/DELETEのみを再grantする例を示します。
+
 ## Next.js agent-rules (generated AGENTS.md) drift prevention
 
 `AGENTS.md`はFoundation canonical inputsから生成されるgenerated artifactです
@@ -211,11 +272,15 @@ driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsume
 `verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
 同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
 呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
+local Supabase stackを起動するconsumerは、同じ`verify:profile`から
+`client-role-privileges:check`（DB / Docker / Supabase local stackを起動する他の
+checkより後）も呼び出し、残存privilegeの回帰をblockingで検知します。
 
 ```json
 {
   "scripts": {
-    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls",
+    "client-role-privileges:check": "node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs",
+    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
   }
 }
@@ -245,6 +310,7 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 - migration apply / rollback相当のoperation
 - DB / RLS / auth integration test
 - schema由来のgenerated types生成、およびdrift verification
+- `client-role-privileges:check`（client-role table privilege guardrail）
 - 上記のいずれかを内包する`verify:profile`
 - 上記のいずれかを内包するfull `verify`
 

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-client-role-table-privileges.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-client-role-table-privileges.mjs
@@ -1,0 +1,219 @@
+import { execFileSync } from 'node:child_process';
+import pg from 'pg';
+
+// Foundation-owned safety boundary vs. consumer-owned permission matrix
+// (Issue #44 security/design checkpoint):
+//
+// This checker only ever asserts about the four table-level privilege bits
+// below. It never inspects, and must never be extended to inspect, SELECT /
+// INSERT / UPDATE / DELETE (table- or column-level) — that permission
+// matrix is entirely product-specific and stays consumer-owned (see
+// profiles/next-supabase/quality/README.md). What makes TRUNCATE /
+// REFERENCES / TRIGGER / MAINTAIN different is that none of them is ever
+// part of an intended CRUD permission matrix for a PostgREST-style client
+// role in the first place, so denying them requires no product knowledge:
+//
+// - TRUNCATE bypasses row level security entirely (confirmed defect,
+//   stage-tracker#42 / reitojike/stage-tracker#49): a policy-only reading
+//   of "is this table safe" cannot see it.
+// - REFERENCES lets the grantee create a foreign key referencing the
+//   table. PostgreSQL's own row security documentation names this a
+//   covert channel: referential integrity checks always bypass row
+//   security, so a crafted FK constraint can leak whether a specific key
+//   value exists via the constraint-violation error, independent of any
+//   policy.
+// - TRIGGER lets the grantee attach a trigger to the table.
+// - MAINTAIN (PostgreSQL 17+) permits VACUUM/ANALYZE/CLUSTER/REINDEX/
+//   REFRESH MATERIALIZED VIEW — maintenance operations a client role never
+//   needs, some of which can lock or rewrite the table.
+//
+// stage-tracker's real, hardened grant matrix (Issue #42/#49) holds none of
+// these four on any of its public tables — there is no observed consumer
+// need for an exception. Foundation therefore denies all four
+// unconditionally, with no consumer exception/override mechanism in this
+// change. Building a speculative escape hatch without an evidenced need
+// would itself be the kind of premature machinery Foundation's own
+// "先行実装しない" stance rejects; if a genuine need surfaces later, that is
+// a new Foundation Observation / Change Proposal, not a preemptive default.
+const ALWAYS_DENIED_PRIVILEGES = ['TRUNCATE', 'REFERENCES', 'TRIGGER'];
+
+// has_table_privilege(role, table, 'MAINTAIN') raises "unrecognized
+// privilege type" on a server older than PostgreSQL 17 (confirmed against
+// postgres:15 while building this checker) — MAINTAIN did not exist before
+// 17. Gating on the server's own reported version, rather than attempting
+// the call and swallowing the error, keeps an older server's skip an
+// explicit, positive diagnostic instead of a silently-caught failure that
+// could just as easily hide a real connection problem.
+const MAINTAIN_MIN_SERVER_VERSION_NUM = 170000;
+
+// service_role and other administrative roles are deliberately excluded:
+// they are not normal PostgREST client roles, and this checker must not
+// treat them the same way (Issue #44 Invariants). 'public' is the
+// PostgreSQL pseudo-role denoting PUBLIC — has_table_privilege('public',
+// table, privilege) reports whether PUBLIC itself holds the privilege
+// (confirmed empirically: distinct from, and not to be confused with, the
+// `public` *schema*), which is the most severe case since it grants the
+// privilege to literally every role.
+const CLIENT_ROLES = ['anon', 'authenticated', 'public'];
+
+// `supabase status -o json` is not safe to run concurrently — it rewrites
+// the CLI's own ~/.supabase/telemetry.json through a temp file plus a
+// rename, and a losing rename aborts the CLI outright. This is the same
+// observed provider behavior already documented and retried in stage-
+// tracker's test/rls/support/localSupabase.ts; carried over here bounded
+// and unchanged now that this script also shells out to the same command.
+const STATUS_ATTEMPTS = 5;
+const STATUS_RETRY_BASE_MS = 150;
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function readDatabaseUrlFromSupabaseStatus() {
+  let lastError;
+  for (let attempt = 0; attempt < STATUS_ATTEMPTS; attempt += 1) {
+    try {
+      const raw = execFileSync('supabase', ['status', '-o', 'json'], {
+        encoding: 'utf8',
+        // Windows can only launch node_modules/.bin's supabase.cmd shim
+        // through a shell (Node throws EINVAL otherwise); the args above
+        // are static literals, not external input, so shell:true carries
+        // no injection risk here.
+        shell: process.platform === 'win32',
+      });
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.DB_URL !== 'string' || parsed.DB_URL.length === 0) {
+        throw new Error('"supabase status -o json" did not report a DB_URL.');
+      }
+      return parsed.DB_URL;
+    } catch (error) {
+      lastError = error;
+      sleep(STATUS_RETRY_BASE_MS * (attempt + 1) + Math.floor(Math.random() * 100));
+    }
+  }
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Could not determine the local Supabase database URL: "supabase status -o json" failed ` +
+      `${String(STATUS_ATTEMPTS)} times (last error: ${detail}). Is the local Supabase stack ` +
+      `running ("supabase start")? Set SUPABASE_DB_URL to bypass this and connect directly.`,
+  );
+}
+
+// SUPABASE_DB_URL is an explicit override, primarily for testing this
+// checker against a database that is not a full local Supabase stack (see
+// test/db/). Consumers running a normal local Supabase stack do not need
+// to set it — the default path below discovers the URL the same way
+// stage-tracker's own DB/RLS tests already do.
+function resolveDatabaseUrl() {
+  if (process.env.SUPABASE_DB_URL) return process.env.SUPABASE_DB_URL;
+  return readDatabaseUrlFromSupabaseStatus();
+}
+
+async function withPgClient(databaseUrl, run) {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function requireClientRolesExist(client) {
+  const roleNames = CLIENT_ROLES.filter((role) => role !== 'public');
+  const { rows } = await client.query(
+    `select rolname from pg_roles where rolname = any($1::text[])`,
+    [roleNames],
+  );
+  const foundRoleNames = new Set(rows.map((row) => row.rolname));
+  const missingRoleNames = roleNames.filter((role) => !foundRoleNames.has(role));
+  if (missingRoleNames.length > 0) {
+    throw new Error(
+      `Role(s) ${missingRoleNames.map((role) => `"${role}"`).join(', ')} do not exist on this ` +
+        `database. This checker expects the standard Supabase-provisioned client roles ` +
+        `(anon, authenticated) to be present; is SUPABASE_DB_URL/the local Supabase stack ` +
+        `pointed at a Supabase-managed database?`,
+    );
+  }
+}
+
+async function resolveDeniedPrivileges(client) {
+  const { rows } = await client.query(`select current_setting('server_version_num') as version`);
+  const serverVersionNum = Number.parseInt(rows[0].version, 10);
+  if (serverVersionNum >= MAINTAIN_MIN_SERVER_VERSION_NUM) {
+    return { privileges: [...ALWAYS_DENIED_PRIVILEGES, 'MAINTAIN'], serverVersionNum };
+  }
+  console.log(
+    `Server version ${String(serverVersionNum)} is older than PostgreSQL 17 ` +
+      `(${String(MAINTAIN_MIN_SERVER_VERSION_NUM)}); MAINTAIN does not exist on this server and is ` +
+      `skipped. Checking: ${ALWAYS_DENIED_PRIVILEGES.join(', ')}.`,
+  );
+  return { privileges: [...ALWAYS_DENIED_PRIVILEGES], serverVersionNum };
+}
+
+async function findResidualPrivileges(client, deniedPrivileges) {
+  const { rows: tables } = await client.query(
+    `select tablename from pg_tables where schemaname = 'public'`,
+  );
+  const { rows } = await client.query(
+    `select t.tablename, r.role, p.privilege
+     from pg_tables t
+     cross join unnest($1::text[]) as r(role)
+     cross join unnest($2::text[]) as p(privilege)
+     where t.schemaname = 'public'
+       and has_table_privilege(r.role, 'public.' || t.tablename, p.privilege)
+     order by t.tablename, r.role, p.privilege`,
+    [CLIENT_ROLES, deniedPrivileges],
+  );
+  return { residual: rows, tableCount: tables.length };
+}
+
+function formatResidualLine(row) {
+  return `${row.role} -> ${row.tablename}: ${row.privilege}`;
+}
+
+async function main() {
+  const databaseUrl = resolveDatabaseUrl();
+  await withPgClient(databaseUrl, async (client) => {
+    await requireClientRolesExist(client);
+    const { privileges: deniedPrivileges, serverVersionNum } =
+      await resolveDeniedPrivileges(client);
+    const { residual, tableCount } = await findResidualPrivileges(client, deniedPrivileges);
+
+    if (tableCount === 0) {
+      console.log('No tables found in the public schema; nothing to inventory.');
+      return;
+    }
+
+    if (residual.length > 0) {
+      console.error(
+        `Residual client-role table privilege(s) detected in the public schema ` +
+          `(server_version_num ${String(serverVersionNum)}, checked ${String(tableCount)} table(s) for ` +
+          `${deniedPrivileges.join(', ')}):`,
+      );
+      for (const row of residual) {
+        console.error(`  ${formatResidualLine(row)}`);
+      }
+      console.error(
+        'None of anon, authenticated, or PUBLIC may hold TRUNCATE/REFERENCES/TRIGGER/MAINTAIN on ' +
+          'any public schema table (Foundation Next.js + Supabase profile). Revoke the privilege(s) ' +
+          'above, e.g.:\n' +
+          '  revoke all on public.<table> from public, anon, authenticated;\n' +
+          '  -- then re-grant only the SELECT/INSERT/UPDATE/DELETE this table actually intends.',
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `No residual ${deniedPrivileges.join('/')} for anon/authenticated/PUBLIC on any of ` +
+          `${String(tableCount)} public schema table(s) (server_version_num ${String(serverVersionNum)}).`,
+      );
+    }
+  });
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-client-role-table-privileges.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-client-role-table-privileges.mjs
@@ -161,7 +161,7 @@ async function findResidualPrivileges(client, deniedPrivileges) {
      cross join unnest($1::text[]) as r(role)
      cross join unnest($2::text[]) as p(privilege)
      where t.schemaname = 'public'
-       and has_table_privilege(r.role, 'public.' || t.tablename, p.privilege)
+       and has_table_privilege(r.role, format('%I.%I', t.schemaname, t.tablename), p.privilege)
      order by t.tablename, r.role, p.privilege`,
     [CLIENT_ROLES, deniedPrivileges],
   );


### PR DESCRIPTION
## Context

Issue #44 の canonical Task Contract に従う。origin: `reitojike/stage-tracker#42` / `reitojike/stage-tracker#49`。

stage-trackerで確認された、Supabase `public` schema tableに `anon`/`authenticated` が platform default privilege由来で `TRUNCATE`（RLSを完全に迂回）等のresidual privilegeを保持していた confirmed defect を、Next.js + Supabase profile向けの再利用可能な security guardrail として一般化する。

## Security/design checkpoint（Role: High で実施）

- **Foundation-owned safety boundary と consumer-owned permission matrix の境界**: 本guardrailは `TRUNCATE` / `REFERENCES` / `TRIGGER` / `MAINTAIN` の4privilegeのみを検査する。`SELECT`/`INSERT`/`UPDATE`/`DELETE`（table-level/column-level）は一切検査しない — これは引き続き100% consumer-owned のproduct permission matrixである。この4privilegeが対象になるのは、PostgREST-styleのclient roleがCRUD permission matrixの一部としてこれらを持つ正当な理由が構造的に存在しないため（product知識を要求しない）。
- **TRUNCATE**: RLSを完全に迂回する confirmed defect（stage-tracker#42）。unconditional deny。
- **REFERENCES**: foreign key制約違反エラー経由のcovert channelになり得る（PostgreSQL自身のrow securityドキュメントが明記する既知の制約：referential integrity checkは常にRLSを迂回する）。unconditional deny。
- **TRIGGER**: client roleに正当な必要性がない。unconditional deny。
- **MAINTAIN**: PostgreSQL 17+ の VACUUM/ANALYZE/CLUSTER/REINDEX/REFRESH MATERIALIZED VIEW相当の特権。`has_table_privilege(..., 'MAINTAIN')` は17未満のserverで `unrecognized privilege type` を送出することを実機確認済み（postgres:15で再現）。`server_version_num` によりgateし、非対応serverではexplicitにskipを報告する（例外を握りつぶさない）。unconditional deny（対応server上で）。
- **exception機構**: 今回は実装しない。stage-trackerの現行grant matrixはこの4privilegeをどのtableにも一切保持しておらず、consumer側で正当な例外が必要になった実例がないため。将来必要が生じた場合はFoundation Observation/Change Proposalとして扱う（先行実装しない）。
- チェック対象role: `anon` / `authenticated` / PostgreSQLのPUBLIC pseudo-role（`has_table_privilege('public', ...)`で判定、実機確認済み）。`service_role`等administrative roleは対象外（Invariants準拠）。

## 実装

- `profiles/next-supabase/quality/check-client-role-table-privileges.mjs`: actual local/CI DBへ接続し、`public` schema全table × 上記role × 上記privilegeをcross joinで検査するdeterministic checker。role/table/privilegeが分かる診断とremediation例を出力。既定では consumer の DB/RLS test と同じ方法（`supabase status -o json`）で接続先を自動検出し、`SUPABASE_DB_URL` でbypass可能。
- `profiles/next-supabase/quality/README.md`: 新guardrailのセクション追加、`verify:profile`統合例の更新、`pg` 依存関係の追記、shared local stack exclusive-resource一覧への追加。
- `test/db/client-role-table-privileges.test.mjs` + `test/fixtures/client-role-table-privileges/*.sql`: positive/negative fixture proof。Dockerで使い捨て・動的port割り当てのPostgres 17/15コンテナを自前管理するため、他checkout/sessionのDocker資源と衝突しない。`test/*.test.mjs`（既定`npm test`）には含めず、`npm run test:client-role-table-privileges-guardrail`で明示実行（Docker必須のため既定のhermeticなtest suiteには含めない）。Docker不在時はskip。

## Verification

- `npm test`: 99 pass / 1 skip（既存のWindows symlink権限制約によるskipで無関係）/ 0 fail。
- `npm run test:guardrails`: 8 guardrail fixture すべてgreen。
- `npm run test:client-role-table-privileges-guardrail`: 12 pass / 0 fail。TRUNCATE/REFERENCES/TRIGGER/MAINTAIN各privilegeのfault injectionでred化、PUBLIC pseudo-roleのanon/authenticatedへの伝播、mixed clean/residual tableでの偽陽性なし、missing-role時のclean diagnostic、PostgreSQL 17未満でのMAINTAIN version-gate skipを実機DBで検証。
- `node tooling/check.mjs --consumer test/fixtures/consumer`: drift無し。
- 使用したDockerコンテナはすべてtear down済み（残存なし）。stage-trackerの稼働中shared local Supabase stackには一切触れていない（専用の使い捨てPostgresコンテナのみ使用）。

## Scope

Issue #44のOut of scope（stage-tracker固有grant matrix、default privilege自動変更、stage-tracker working tree変更等）には触れていない。

## Merge authority

merge / Issue close authorityはない。merge-readyの状態で停止する。PRにauto-close keywordは入れていない。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>