### PR TITLE
Next.js profile: check-agent-rules-disabledのnext.config.mts support / guidance gapを修正する (Issue #56)

### DIFF
--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -219,12 +219,17 @@ dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRul
 node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
 ```
 
-このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`
-（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する場合は
-Next.jsが実際に読むfileを検証します）をfilesystemだけで検査し、
-comment除去後・brace-depth 1（exportされる config
-object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
-場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
+このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`、および
+実行中のNode runtimeがnative TypeScript supportを持つ場合
+（`process.features.typescript`がtruthyな場合）は`next.config.mts`も対象に
+含めます（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する
+場合はNext.jsが実際に読むfileを検証します）。Next.js自身が`.mts`を受理する
+条件と同じ条件をcheckerが評価するため、`.cjs`/`.cts`等の他の拡張子（Next.js
+自身がconfigとして受理しないため引き続きこのcheckerの対象外）とは異なる
+扱いです。これらの候補fileをfilesystemだけで検査し、comment除去後・
+brace-depth 1（exportされる config object直下）に限定した`agentRules:
+false`（quoted keyを含む）が見つからない場合（fileが存在しない場合を含む）
+はnon-zeroで失敗します。`false`は完全な
 property valueである場合だけ有効とします（`agentRules: false || true`は
 実際にはtrueとして評価されるため無効）。次はfalseとして扱いません:
 comment内の記述（`// agentRules: false`）、ネストしたobject内の同名property

--- a/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
+++ b/profiles/next-supabase/quality/check-agent-rules-disabled.mjs
@@ -11,20 +11,33 @@ import path from 'node:path';
 // artifact (see tooling/sync.mjs); Next.js runtime mutating it is drift this
 // profile's consumers must not hit on an ordinary `next dev`.
 //
-// Only the three filenames Next.js itself accepts for configuration are
-// checked (an unsupported extension such as .cjs/.cts is itself a Next.js
-// config error, not this checker's concern). The order matters and matches
-// Next.js's own `CONFIG_FILES` precedence (node_modules/next/dist/shared/
-// lib/constants.js in 16.3.2: `['next.config.js', 'next.config.mjs',
-// 'next.config.ts', ...]`) — if more than one candidate coexists (e.g.
-// mid-migration between formats, or a stale file left behind), Next.js
-// loads only the first it finds in that order, and this checker must
-// inspect the same file Next.js actually loads. Checking a different one
-// (an earlier version of this checker tried `.ts` first) risks reporting
-// a config as disabled based on a file `next dev` never reads, while the
-// file it does read still has agentRules enabled (Codex review finding on
-// this PR).
-const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.config.ts'];
+// The candidates and their order match Next.js's own `CONFIG_FILES`
+// (node_modules/next/dist/shared/lib/constants.js in 16.3.2):
+// `['next.config.js', 'next.config.mjs', 'next.config.ts', ...process?.features
+// ?.typescript ? ['next.config.mts'] : []]`. `.js`/`.mjs`/`.ts` are always
+// accepted; `.mts` is accepted only when the executing Node runtime has
+// native TypeScript support (`process.features.typescript` is truthy — e.g.
+// `'strip'`, confirmed present under stage-tracker's Next.js 16.3.1 runtime,
+// see Issue #56). This checker evaluates the identical condition on its own
+// `process`, rather than assuming `.mts` is always a candidate or treating it
+// as an unsupported extension like `.cjs`/`.cts` (which remain Next.js config
+// errors regardless of runtime and stay out of this checker's concern). If
+// more than one candidate coexists (e.g. mid-migration between formats, or a
+// stale file left behind), Next.js loads only the first it finds in that
+// order, and this checker must inspect the same file Next.js actually loads.
+// Checking a different one (an earlier version of this checker tried `.ts`
+// first) risks reporting a config as disabled based on a file `next dev`
+// never reads, while the file it does read still has agentRules enabled
+// (Codex review finding on this PR).
+const CANDIDATE_CONFIG_EXTENSIONS = [
+  'js',
+  'mjs',
+  'ts',
+  ...(process?.features?.typescript ? ['mts'] : []),
+];
+const CANDIDATE_CONFIG_FILENAMES = CANDIDATE_CONFIG_EXTENSIONS.map(
+  (extension) => `next.config.${extension}`,
+);
 
 // Matches a JS object property key that is EXACTLY `agentRules` — either a
 // bare identifier not embedded in a longer one, or a fully quoted string
@@ -347,8 +360,8 @@ const configFile = await findConfigFile(process.cwd());
 
 if (configFile === null) {
   console.error(
-    `No next.config.{js,mjs,ts} found. Foundation-generated AGENTS.md is a generated artifact ` +
-      `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
+    `No next.config.{${CANDIDATE_CONFIG_EXTENSIONS.join(',')}} found. Foundation-generated AGENTS.md is a generated ` +
+      `artifact (see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
       `with \`agentRules: false\`.`,
   );
   process.exitCode = 1;

--- a/test/agent-rules-check.test.mjs
+++ b/test/agent-rules-check.test.mjs
@@ -19,6 +19,40 @@ test("agentRules: false in next.config.ts is green", () => {
   assert.match(result.stdout, /agentRules: false/);
 });
 
+// Next.js's own CONFIG_FILES (node_modules/next/dist/shared/lib/constants.js)
+// only includes next.config.mts when the executing Node runtime has native
+// TypeScript support (process.features.typescript is truthy). This checker
+// evaluates the identical condition on its own process, so what counts as
+// "correct" for these two fixtures depends on the Node running this test
+// suite, exactly as it would for `next dev` itself (Issue #56).
+const nodeHasNativeTypeScriptSupport = Boolean(process.features?.typescript);
+
+test("agentRules: false in next.config.mts is green on a Node runtime with native TypeScript support (Issue #56)", () => {
+  const result = runChecker(path.join(fixturesRoot, "disabled-mts"));
+  if (nodeHasNativeTypeScriptSupport) {
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /next\.config\.mts/);
+    assert.match(result.stdout, /agentRules: false/);
+  } else {
+    // Next.js itself does not accept next.config.mts as a config candidate
+    // without native TypeScript support, so this checker must not either —
+    // it should report the same "no config found" state Next.js would face.
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /No next\.config/);
+  }
+});
+
+test("a next.config.mts that never sets agentRules is deterministically red on a Node runtime with native TypeScript support (Issue #56)", () => {
+  const result = runChecker(path.join(fixturesRoot, "not-disabled-mts"));
+  assert.notEqual(result.status, 0);
+  if (nodeHasNativeTypeScriptSupport) {
+    assert.match(result.stderr, /does not disable Next\.js's generated-AGENTS\.md agent rules/);
+    assert.match(result.stderr, /next\.config\.mts/);
+  } else {
+    assert.match(result.stderr, /No next\.config/);
+  }
+});
+
 test("a single-quoted 'agentRules': false key in next.config.mjs is also green", () => {
   // Codex + Claude review finding on this PR (2nd closure round): this
   // fixture previously had a *bare* `agentRules` key despite its name and

--- a/test/fixtures/agent-rules/disabled-mts/next.config.mts
+++ b/test/fixtures/agent-rules/disabled-mts/next.config.mts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  agentRules: false,
+};
+
+export default nextConfig;

--- a/test/fixtures/agent-rules/not-disabled-mts/next.config.mts
+++ b/test/fixtures/agent-rules/not-disabled-mts/next.config.mts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -219,12 +219,17 @@ dirtyになります。Next.js 16.3未満はこの自動生成挙動も`agentRul
 node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs
 ```
 
-このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`
-（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する場合は
-Next.jsが実際に読むfileを検証します）をfilesystemだけで検査し、
-comment除去後・brace-depth 1（exportされる config
-object直下）に限定した`agentRules: false`（quoted keyを含む）が見つからない
-場合（fileが存在しない場合を含む）はnon-zeroで失敗します。`false`は完全な
+このcheckerは`next.config.js` / `next.config.mjs` / `next.config.ts`、および
+実行中のNode runtimeがnative TypeScript supportを持つ場合
+（`process.features.typescript`がtruthyな場合）は`next.config.mts`も対象に
+含めます（Next.js自身のCONFIG_FILES優先順位と同じ順で検索し、複数が共存する
+場合はNext.jsが実際に読むfileを検証します）。Next.js自身が`.mts`を受理する
+条件と同じ条件をcheckerが評価するため、`.cjs`/`.cts`等の他の拡張子（Next.js
+自身がconfigとして受理しないため引き続きこのcheckerの対象外）とは異なる
+扱いです。これらの候補fileをfilesystemだけで検査し、comment除去後・
+brace-depth 1（exportされる config object直下）に限定した`agentRules:
+false`（quoted keyを含む）が見つからない場合（fileが存在しない場合を含む）
+はnon-zeroで失敗します。`false`は完全な
 property valueである場合だけ有効とします（`agentRules: false || true`は
 実際にはtrueとして評価されるため無効）。次はfalseとして扱いません:
 comment内の記述（`// agentRules: false`）、ネストしたobject内の同名property

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/check-agent-rules-disabled.mjs
@@ -11,20 +11,33 @@ import path from 'node:path';
 // artifact (see tooling/sync.mjs); Next.js runtime mutating it is drift this
 // profile's consumers must not hit on an ordinary `next dev`.
 //
-// Only the three filenames Next.js itself accepts for configuration are
-// checked (an unsupported extension such as .cjs/.cts is itself a Next.js
-// config error, not this checker's concern). The order matters and matches
-// Next.js's own `CONFIG_FILES` precedence (node_modules/next/dist/shared/
-// lib/constants.js in 16.3.2: `['next.config.js', 'next.config.mjs',
-// 'next.config.ts', ...]`) — if more than one candidate coexists (e.g.
-// mid-migration between formats, or a stale file left behind), Next.js
-// loads only the first it finds in that order, and this checker must
-// inspect the same file Next.js actually loads. Checking a different one
-// (an earlier version of this checker tried `.ts` first) risks reporting
-// a config as disabled based on a file `next dev` never reads, while the
-// file it does read still has agentRules enabled (Codex review finding on
-// this PR).
-const CANDIDATE_CONFIG_FILENAMES = ['next.config.js', 'next.config.mjs', 'next.config.ts'];
+// The candidates and their order match Next.js's own `CONFIG_FILES`
+// (node_modules/next/dist/shared/lib/constants.js in 16.3.2):
+// `['next.config.js', 'next.config.mjs', 'next.config.ts', ...process?.features
+// ?.typescript ? ['next.config.mts'] : []]`. `.js`/`.mjs`/`.ts` are always
+// accepted; `.mts` is accepted only when the executing Node runtime has
+// native TypeScript support (`process.features.typescript` is truthy — e.g.
+// `'strip'`, confirmed present under stage-tracker's Next.js 16.3.1 runtime,
+// see Issue #56). This checker evaluates the identical condition on its own
+// `process`, rather than assuming `.mts` is always a candidate or treating it
+// as an unsupported extension like `.cjs`/`.cts` (which remain Next.js config
+// errors regardless of runtime and stay out of this checker's concern). If
+// more than one candidate coexists (e.g. mid-migration between formats, or a
+// stale file left behind), Next.js loads only the first it finds in that
+// order, and this checker must inspect the same file Next.js actually loads.
+// Checking a different one (an earlier version of this checker tried `.ts`
+// first) risks reporting a config as disabled based on a file `next dev`
+// never reads, while the file it does read still has agentRules enabled
+// (Codex review finding on this PR).
+const CANDIDATE_CONFIG_EXTENSIONS = [
+  'js',
+  'mjs',
+  'ts',
+  ...(process?.features?.typescript ? ['mts'] : []),
+];
+const CANDIDATE_CONFIG_FILENAMES = CANDIDATE_CONFIG_EXTENSIONS.map(
+  (extension) => `next.config.${extension}`,
+);
 
 // Matches a JS object property key that is EXACTLY `agentRules` — either a
 // bare identifier not embedded in a longer one, or a fully quoted string
@@ -347,8 +360,8 @@ const configFile = await findConfigFile(process.cwd());
 
 if (configFile === null) {
   console.error(
-    `No next.config.{js,mjs,ts} found. Foundation-generated AGENTS.md is a generated artifact ` +
-      `(see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
+    `No next.config.{${CANDIDATE_CONFIG_EXTENSIONS.join(',')}} found. Foundation-generated AGENTS.md is a generated ` +
+      `artifact (see tooling/sync.mjs) that \`next dev\` will otherwise silently mutate. Add a next.config ` +
       `with \`agentRules: false\`.`,
   );
   process.exitCode = 1;


### PR DESCRIPTION
## Canonical Task

Issue #56 — Next.js profile: agent-rules guardの next.config.mts support / guidance gapを修正する
(https://github.com/reitojike/ai-dev-foundation/issues/56)

本PRの canonical context は Issue #56 本文です。auto-close keyword は使用していません。
merge / Issue close authority はこの lane にありません。**merge-ready で停止**します。

## 1. Target

| item | value |
| --- | --- |
| base (fresh main) | `11f90ada61219c4ccc1f6ccaec6c1ca51a5efda5` |
| head (final) | `9bd3e1c8148afc77d5ad7fd66a93c539a641f138` |

作業開始時に、handoff値をcurrentと仮定せず以下をfresh確認しました。

- Foundation `main`: `11f90ad`（Issue #57 mixed-classification routing / PR #58 merge済み）
- open PR: 0件（作業開始時点でこのIssueに対する既存PRなし）
- `#40` design authority: CLOSEDのまま。二層contract（proactive bounded text matcher +
  reactive exact layer `foundation:check`）は再adjudicationせず、そのまま前提にしています。
- stage-tracker `#59`（CLOSED）/ PR #60 Observation O-1: `check-agent-rules-disabled.mjs`の
  `CANDIDATE_CONFIG_FILENAMES`が`next.config.mts`を候補に含まず、checker/READMEのcomment上も
  「Next.jsが受理する3つのfilenameのみ」という記述が事実として不正確であることを確認しました。

## 2. Current Next.js behavior の fresh evidence

stage-tracker（Next.js 16.3.1）の実環境で確認:

```
$ node -e "console.log(JSON.stringify(process.features))"
{"...":"...","typescript":"strip"}

$ grep -n "CONFIG_FILES" -A 8 node_modules/next/dist/shared/lib/constants.js
const CONFIG_FILES = [
    'next.config.js',
    'next.config.mjs',
    'next.config.ts',
    // process.features can be undefined on Edge runtime
    ...process?.features?.typescript ? [
        'next.config.mts'
    ] : []
```

`process.features.typescript`が`"strip"`（truthy）である実行環境では、Next.js自身が
`next.config.mts`をvalid config filenameとしてCONFIG_FILES末尾に含みます。checker側は
この条件を反映しておらず、`.mts`のみを持つconsumerでは`No next.config.{js,mjs,ts} found`
（fail-closedのfalse alarm。O-1のImpact評価どおりsilent passではありません）となっていました。

## 2. Changes

### `profiles/next-supabase/quality/check-agent-rules-disabled.mjs`

- `CANDIDATE_CONFIG_FILENAMES`の生成を、Next.js自身のCONFIG_FILES構築と同一の条件
  （`process?.features?.typescript`が truthy な場合のみ`next.config.mts`を追加）で
  行うように変更しました。checkerは自分自身のprocessでこの条件を評価するため、
  `next dev`を実行するのと同じNode runtime上であれば、Next.js自身の判定と一致します。
- `.mts`は`.cjs`/`.cts`のような「Next.js自身が常に拒否するunsupported extension」とは
  異なる扱いである旨をcomment上で明示しました。
- missing-config時のerror messageを`CANDIDATE_CONFIG_EXTENSIONS`から動的生成するように
  変更し、実行時の実際の候補集合（3つまたは4つ）と一致させました。

### `profiles/next-supabase/quality/README.md`

- checkerが検査するfilenameの説明に`next.config.mts`（native TypeScript support時のみ）
  を追加し、`.cjs`/`.cts`との扱いの違いを明記しました。

### `test/agent-rules-check.test.mjs` + 新規fixture

- `test/fixtures/agent-rules/disabled-mts/next.config.mts`（`agentRules: false`）→ green
- `test/fixtures/agent-rules/not-disabled-mts/next.config.mts`（agentRules未設定）→ red
- 両テストは、テストを実行するNode runtime自身の`process.features.typescript`を見て
  期待値を切り替えます（native TypeScript supportがない場合、Next.js自身が`.mts`を
  configとして受理しないため、checkerも同じ`No next.config`状態を報告するのが正しい
  挙動であり、それをそのまま検証します）。
- 既存の`.js`/`.mjs`/`.ts`関連の全fixture/testは変更していません。

### `test/fixtures/consumer/.ai-dev-foundation/quality/*`

- `node tooling/bootstrap-next-supabase.mjs --consumer test/fixtures/consumer`を再実行し、
  reference consumer fixtureをcanonical sourceと再同期しました（diffなし化）。

## 3. Deterministic verification（fresh clone, isolated path）

Foundation `main`をnode_modules階層汚染のない独立pathへfresh cloneし、`npm ci`実行後に
検証しました（既存checkoutが古いpin (`v0.2.0`)で止まっていたため、stale checkoutを流用
していません）。

```
$ npm test
...
ℹ tests 102
ℹ suites 0
ℹ pass 101
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1   # symlink fixture test: EPERM (Windows platform制約、pre-existing、本PR非関連)
ℹ todo 0

> ai-dev-foundation@0.3.0 test:guardrails
> node tooling/verify-guardrails.mjs
Verified 8 guardrail fixtures.
```

fix前のbaseline（stash / clean main、同一isolated clone）でも同じ`skipped 1`
（symlink EPERM）を除き全green（100 tests / 100 pass）であることを確認しており、
本PRの変更によるregressionはありません。

`git diff --check`: exit 0（whitespace errorなし）。

## 4. #40 design authority の維持

- proactive layerは引き続きbounded filesystem/text matcherです。parser/tokenizer/
  generalized config evaluatorへは発展させていません（`process.features.typescript`の
  参照はNode runtime自身のfeature flag読み取りであり、consumer configのJS/TS semantics
  を実行・評価するものではありません）。
- reactive exact layer（`foundation:check`）はそのまま維持しています。
- consumer-owned `next.config`をFoundation toolingが書き換える変更は含みません。

## 5. Scope

In scope の項目のみを変更しました。generalized parser/tokenizer/evaluator、Next.js
upstream実装、consumer `next.config`の自動rewrite、AGENTS composition architecture
再設計、progressive disclosure Phase 2、stage-tracker working treeへの変更は行って
いません。

## Unresolved / blockers

現時点で未解決のblockerはありません。

## Authority

implementation agentにmerge / Issue-close / release authorityはありません。
merge-readyで停止します。