### PR TITLE
Review acquisition: GitHub durable review surfaceをthin deterministic helperで収集する (Issue #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ fixtureの`supabase/schema.json`はoffline検証用のsource of truthであり�
 ありません。実consumerでは実際のSupabase schemaからtypesを生成し、その生成結果のdriftを
 blocking checkで検知します。
 
+## Review evidence helper
+
+`tooling/review-evidence.mjs` は、指定した GitHub PR について durable review
+surface（PR metadata / head SHA、Conversation comments、review submissions、
+inline review comments、review thread の resolved/unresolved 状態、combined
+commit status、check runs）を fresh に取得し、pagination を完了した上で
+human-readable summary または `--json` machine-readable output を返す
+snapshot tool です。
+
+```text
+node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> [--json]
+```
+
+GitHub token は `--token`、`GH_TOKEN`、`GITHUB_TOKEN`、`gh auth token` の順で
+解決します。surface ごとに `fetch_status`（`fetched` / `partial` / `failed` /
+`not_applicable`）と count を独立に報告し、あるsurfaceのfetch failureを他
+surfaceの `0` へ変換しません。paginationが途中で失敗した場合は `partial`
+として明示し、取得できたitemsはpartialなcountのまま返します。
+
+この helper は GitHub durable surface の mechanical acquisition に限定され、
+review completion / target Validity / finding triage / merge-readiness の
+判定は行いません。それらは `policy/core.md` の Review Protocol と
+`skills/review-code.md` / `skills/review-doc.md` が引き続き所有します
+（Issue #62）。
+
 ## Next.js + Supabase quality profile
 
 consumerへprofileを展開するには、Foundation checkoutから次を実行します。

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -292,6 +292,107 @@ test("review thread GraphQL pagination across pages accumulates the full unresol
   assert.equal(result.surfaces.review_threads.unresolved_count, 1);
 });
 
+test("a thread with more than one page of its own comments is paginated to completion, not silently capped", async () => {
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: (url, init) => {
+      const variables = graphqlVariables(init);
+      if ("id" in variables) {
+        assert.equal(variables.id, "th1");
+        assert.equal(variables.cursor, "comment-cursor-2");
+        return jsonResponse({
+          data: {
+            node: {
+              comments: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ id: "c2", author: { login: "b" }, createdAt: "t2", url: "loc2", commit: { oid: "abc1234" } }],
+              },
+            },
+          },
+        });
+      }
+      return jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "th1",
+                    isResolved: false,
+                    isOutdated: false,
+                    path: "a.mjs",
+                    line: 1,
+                    comments: {
+                      pageInfo: { hasNextPage: true, endCursor: "comment-cursor-2" },
+                      nodes: [{ id: "c1", author: { login: "a" }, createdAt: "t1", url: "loc1", commit: { oid: "abc1234" } }],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_threads.fetch_status, "fetched");
+  assert.equal(result.surfaces.review_threads.items[0].comments.length, 2);
+  assert.deepEqual(
+    result.surfaces.review_threads.items[0].comments.map((comment) => comment.id),
+    ["c1", "c2"],
+  );
+});
+
+test("a failure while paginating a thread's own comments downgrades review_threads to partial, not a silent fetched", async () => {
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: (url, init) => {
+      const variables = graphqlVariables(init);
+      if ("id" in variables) {
+        return jsonResponse({ errors: [{ message: "server error" }] }, { status: 500 });
+      }
+      return jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "th1",
+                    isResolved: false,
+                    isOutdated: false,
+                    path: "a.mjs",
+                    line: 1,
+                    comments: {
+                      pageInfo: { hasNextPage: true, endCursor: "comment-cursor-2" },
+                      nodes: [{ id: "c1", author: { login: "a" }, createdAt: "t1", url: "loc1", commit: { oid: "abc1234" } }],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_threads.fetch_status, "partial");
+  assert.ok(result.surfaces.review_threads.failure);
+  // The thread itself, and what comments were fetched before the failure, are still reported.
+  assert.equal(result.surfaces.review_threads.count, 1);
+});
+
 test("a surface fetch failure is reported as failed with a null count, never a false zero", async () => {
   const routes = baseRoutes();
   routes[1] = {

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -1,0 +1,399 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { collectReviewEvidence, formatHumanSummary, parseReviewEvidenceArgs } from "../tooling/review-evidence-lib.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function jsonResponse(body, { status = 200, link } = {}) {
+  const headers = link ? { link } : undefined;
+  return new Response(body === null ? "" : JSON.stringify(body), { status, headers });
+}
+
+// Builds a fetch stub from an ordered list of { match(url, init), handler(url, init) }
+// entries; the first matching entry produces the response. Throws loudly on
+// an unmatched URL so a test with a missing route fails clearly instead of
+// hanging on a real network call.
+function createFetch(routes) {
+  return async (url, init = {}) => {
+    const href = typeof url === "string" ? url : url.toString();
+    const route = routes.find((candidate) => candidate.match(href, init));
+    if (!route) throw new Error(`No mock route for ${init.method ?? "GET"} ${href}`);
+    return route.handler(href, init);
+  };
+}
+
+function graphqlVariables(init) {
+  return JSON.parse(init.body).variables;
+}
+
+const PR_META = {
+  head: { sha: "abc1234" },
+  state: "open",
+  html_url: "https://github.com/octo/demo/pull/62",
+  updated_at: "2026-08-27T00:00:00Z",
+};
+
+function prRoute(pr = PR_META) {
+  return {
+    match: (url, init) => url.endsWith("/repos/octo/demo/pulls/62") && (!init.method || init.method === "GET"),
+    handler: () => jsonResponse(pr),
+  };
+}
+
+function emptyListRoute(suffix) {
+  return {
+    match: (url) => url.startsWith(`https://api.github.com/repos/octo/demo${suffix}`),
+    handler: () => jsonResponse([]),
+  };
+}
+
+function emptyReviewThreadsRoute() {
+  return {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: () =>
+      jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            },
+          },
+        },
+      }),
+  };
+}
+
+function emptyCommitStatusRoute() {
+  return {
+    match: (url) => url.endsWith("/commits/abc1234/status"),
+    handler: () => jsonResponse({ state: "success", total_count: 0, statuses: [] }),
+  };
+}
+
+function emptyCheckRunsRoute() {
+  return {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
+    handler: () => jsonResponse({ total_count: 0, check_runs: [] }),
+  };
+}
+
+function baseRoutes() {
+  return [
+    prRoute(),
+    emptyListRoute("/issues/62/comments"),
+    emptyListRoute("/pulls/62/reviews"),
+    emptyListRoute("/pulls/62/comments"),
+    emptyReviewThreadsRoute(),
+    emptyCommitStatusRoute(),
+    emptyCheckRunsRoute(),
+  ];
+}
+
+test("collects a representative multi-surface snapshot with independent per-surface counts", async () => {
+  const routes = [
+    prRoute(),
+    {
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/issues/62/comments"),
+      handler: () =>
+        jsonResponse([{ id: 1, user: { login: "alice", type: "User" }, created_at: "t1", updated_at: "t1", html_url: "loc1" }]),
+    },
+    {
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/reviews"),
+      handler: () =>
+        jsonResponse([
+          { id: 2, user: { login: "codex" }, state: "APPROVED", commit_id: "abc1234", submitted_at: "t2", html_url: "loc2" },
+        ]),
+    },
+    {
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/comments"),
+      handler: () =>
+        jsonResponse([
+          { id: 3, user: { login: "codex" }, path: "a.mjs", line: 5, commit_id: "abc1234", html_url: "loc3" },
+        ]),
+    },
+    {
+      match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+      handler: () =>
+        jsonResponse({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      id: "th1",
+                      isResolved: true,
+                      isOutdated: false,
+                      path: "a.mjs",
+                      line: 5,
+                      comments: { nodes: [{ id: "c1", author: { login: "codex" }, createdAt: "t3", url: "loc4", commit: { oid: "abc1234" } }] },
+                    },
+                    {
+                      id: "th2",
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "b.mjs",
+                      line: 9,
+                      comments: { nodes: [] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+    },
+    {
+      match: (url) => url.endsWith("/commits/abc1234/status"),
+      handler: () => jsonResponse({ state: "success", total_count: 2, statuses: [{ context: "ci/build", state: "success" }] }),
+    },
+    {
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
+      handler: () => jsonResponse({ total_count: 1, check_runs: [{ id: 9, name: "test", status: "completed", conclusion: "success" }] }),
+    },
+  ];
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.pr_metadata.fetch_status, "fetched");
+  assert.equal(result.pr_metadata.head_sha, "abc1234");
+  assert.equal(result.fetch_failures, 0);
+
+  assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
+  assert.equal(result.surfaces.conversation_comments.count, 1);
+
+  assert.equal(result.surfaces.review_submissions.count, 1);
+  assert.equal(result.surfaces.review_submissions.items[0].reviewed_sha, "abc1234");
+
+  assert.equal(result.surfaces.inline_review_comments.count, 1);
+  assert.equal(result.surfaces.inline_review_comments.items[0].reviewed_sha, "abc1234");
+
+  assert.equal(result.surfaces.review_threads.count, 2);
+  assert.equal(result.surfaces.review_threads.unresolved_count, 1);
+  assert.equal(result.surfaces.review_threads.items[0].comments[0].reviewed_sha, "abc1234");
+
+  assert.equal(result.surfaces.commit_status.status.state, "success");
+  assert.equal(result.surfaces.check_runs.count, 1);
+});
+
+test("a surface with genuinely zero items is reported as fetched(0), not conflated with the other surfaces", async () => {
+  const routes = baseRoutes();
+  routes[1] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/issues/62/comments"),
+    handler: () => jsonResponse([{ id: 1, user: { login: "alice" }, created_at: "t", updated_at: "t", html_url: "loc" }]),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.conversation_comments.count, 1);
+  for (const key of ["review_submissions", "inline_review_comments", "check_runs"]) {
+    assert.equal(result.surfaces[key].fetch_status, "fetched");
+    assert.equal(result.surfaces[key].count, 0);
+  }
+  assert.equal(result.surfaces.review_threads.fetch_status, "fetched");
+  assert.equal(result.surfaces.review_threads.count, 0);
+  assert.equal(result.surfaces.review_threads.unresolved_count, 0);
+  assert.equal(result.fetch_failures, 0);
+});
+
+test("an inline-only fixture does not misreport the other surfaces as absent", async () => {
+  const routes = baseRoutes();
+  routes[3] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/comments"),
+    handler: () => jsonResponse([{ id: 1, user: { login: "codex" }, path: "a.mjs", line: 1, commit_id: "abc1234", html_url: "loc" }]),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.inline_review_comments.count, 1);
+  assert.equal(result.surfaces.conversation_comments.count, 0);
+  assert.equal(result.surfaces.review_submissions.count, 0);
+});
+
+test("a submission-only fixture does not misreport the other surfaces as absent", async () => {
+  const routes = baseRoutes();
+  routes[2] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/reviews"),
+    handler: () => jsonResponse([{ id: 1, user: { login: "codex" }, state: "COMMENTED", commit_id: "abc1234", html_url: "loc" }]),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_submissions.count, 1);
+  assert.equal(result.surfaces.conversation_comments.count, 0);
+  assert.equal(result.surfaces.inline_review_comments.count, 0);
+});
+
+test("pagination is followed to completion, not truncated to the first page", async () => {
+  const routes = baseRoutes();
+  routes[1] = {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100",
+    handler: () =>
+      jsonResponse([{ id: 1, user: { login: "a" }, html_url: "loc1" }], {
+        link: '<https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100&page=2>; rel="next"',
+      }),
+  };
+  routes.splice(2, 0, {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100&page=2",
+    handler: () => jsonResponse([{ id: 2, user: { login: "b" }, html_url: "loc2" }]),
+  });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
+  assert.equal(result.surfaces.conversation_comments.count, 2);
+  assert.equal(result.surfaces.conversation_comments.pages_fetched, 2);
+});
+
+test("review thread GraphQL pagination across pages accumulates the full unresolved count", async () => {
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: (url, init) => {
+      const { cursor } = graphqlVariables(init);
+      if (!cursor) {
+        return jsonResponse({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: { hasNextPage: true, endCursor: "cursor-2" },
+                  nodes: [{ id: "th1", isResolved: false, isOutdated: false, path: "a.mjs", line: 1, comments: { nodes: [] } }],
+                },
+              },
+            },
+          },
+        });
+      }
+      assert.equal(cursor, "cursor-2");
+      return jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ id: "th2", isResolved: true, isOutdated: false, path: "b.mjs", line: 2, comments: { nodes: [] } }],
+              },
+            },
+          },
+        },
+      });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_threads.fetch_status, "fetched");
+  assert.equal(result.surfaces.review_threads.count, 2);
+  assert.equal(result.surfaces.review_threads.unresolved_count, 1);
+});
+
+test("a surface fetch failure is reported as failed with a null count, never a false zero", async () => {
+  const routes = baseRoutes();
+  routes[1] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/issues/62/comments"),
+    handler: () => jsonResponse({ message: "API rate limit exceeded" }, { status: 403 }),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.conversation_comments.fetch_status, "failed");
+  assert.equal(result.surfaces.conversation_comments.count, null);
+  assert.equal(result.surfaces.conversation_comments.failure.status, 403);
+  assert.match(result.surfaces.conversation_comments.failure.message, /rate limit/);
+  // Other surfaces must still be attempted independently.
+  assert.equal(result.surfaces.review_submissions.fetch_status, "fetched");
+  assert.equal(result.fetch_failures, 1);
+});
+
+test("a mid-pagination failure is reported as partial, not silently truncated to a complete fetch", async () => {
+  const routes = baseRoutes();
+  routes[1] = {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100",
+    handler: () =>
+      jsonResponse([{ id: 1, user: { login: "a" }, html_url: "loc1" }], {
+        link: '<https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100&page=2>; rel="next"',
+      }),
+  };
+  routes.splice(2, 0, {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/issues/62/comments?per_page=100&page=2",
+    handler: () => jsonResponse({ message: "server error" }, { status: 502 }),
+  });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.conversation_comments.fetch_status, "partial");
+  assert.equal(result.surfaces.conversation_comments.count, 1);
+  assert.equal(result.surfaces.conversation_comments.items.length, 1);
+  assert.equal(result.fetch_failures, 1);
+});
+
+test("a PR-metadata fetch failure does not crash the run and marks head-dependent surfaces not_applicable", async () => {
+  const routes = baseRoutes();
+  routes[0] = {
+    match: (url) => url.endsWith("/repos/octo/demo/pulls/62"),
+    handler: () => jsonResponse({ message: "Not Found" }, { status: 404 }),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.pr_metadata.fetch_status, "failed");
+  assert.equal(result.pr_metadata.failure.status, 404);
+  assert.equal(result.surfaces.commit_status.fetch_status, "not_applicable");
+  assert.equal(result.surfaces.check_runs.fetch_status, "not_applicable");
+  // Surfaces that don't depend on head SHA are still attempted.
+  assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
+  assert.equal(result.fetch_failures, 1);
+});
+
+test("formatHumanSummary renders a deterministic snapshot summary", async () => {
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(baseRoutes()) });
+  result.generated_at = "2026-08-27T00:00:00.000Z";
+
+  const text = formatHumanSummary(result);
+
+  assert.match(text, /^PR #62 review evidence snapshot \(octo\/demo\)$/m);
+  assert.match(text, /^Head: abc1234 \(state: open\)$/m);
+  assert.match(text, /^Conversation comments: fetched \(0\)$/m);
+  assert.match(text, /^Review threads: fetched \(0\) — unresolved: 0$/m);
+  assert.match(text, /^Fetch failures: 0$/m);
+});
+
+test("parseReviewEvidenceArgs parses --repo/--pr/--json and rejects malformed input", () => {
+  assert.deepEqual(parseReviewEvidenceArgs(["--repo", "octo/demo", "--pr", "62"]), { json: false, repo: "octo/demo", pr: "62" });
+  assert.deepEqual(parseReviewEvidenceArgs(["--repo", "octo/demo", "--pr", "62", "--json"]), {
+    json: true,
+    repo: "octo/demo",
+    pr: "62",
+  });
+  assert.throws(() => parseReviewEvidenceArgs(["--pr", "62"]), /Usage:/);
+  assert.throws(() => parseReviewEvidenceArgs(["--repo", "octo/demo"]), /Usage:/);
+  assert.throws(() => parseReviewEvidenceArgs(["--repo", "octo/demo", "--pr", "not-a-number"]), /Usage:/);
+});
+
+// Issue #62 boundary: this helper is mechanical acquisition only. It must
+// never grow completion/Validity/triage/merge-ready judgment logic — those
+// stay owned by policy/core.md's Review Protocol and the review skills.
+test("the helper's source stays free of Review Protocol judgment vocabulary", async () => {
+  const forbidden = [
+    "merge-ready",
+    "merge_ready",
+    "validity",
+    "triage",
+    "false-positive",
+    "needs-verification",
+    "technical-dispute",
+    "intent-question",
+    "finding_count",
+  ];
+  for (const file of ["tooling/review-evidence-lib.mjs", "tooling/review-evidence.mjs"]) {
+    const source = (await readFile(path.join(root, file), "utf8")).toLowerCase();
+    for (const term of forbidden) {
+      assert.ok(!source.includes(term), `${file} must not contain judgment vocabulary "${term}"`);
+    }
+  }
+});

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -393,6 +393,20 @@ test("a failure while paginating a thread's own comments downgrades review_threa
   assert.equal(result.surfaces.review_threads.count, 1);
 });
 
+test("a 200 OK GraphQL response with an empty body is reported as a failure, not a crash", async () => {
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: () => jsonResponse(null),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_threads.fetch_status, "failed");
+  assert.equal(result.surfaces.review_threads.count, null);
+  assert.ok(result.surfaces.review_threads.failure);
+});
+
 test("a surface fetch failure is reported as failed with a null count, never a false zero", async () => {
   const routes = baseRoutes();
   routes[1] = {

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -68,7 +68,7 @@ function emptyReviewThreadsRoute() {
 
 function emptyCommitStatusRoute() {
   return {
-    match: (url) => url.endsWith("/commits/abc1234/status"),
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/status"),
     handler: () => jsonResponse({ state: "success", total_count: 0, statuses: [] }),
   };
 }
@@ -148,7 +148,7 @@ test("collects a representative multi-surface snapshot with independent per-surf
         }),
     },
     {
-      match: (url) => url.endsWith("/commits/abc1234/status"),
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/status"),
       handler: () => jsonResponse({ state: "success", total_count: 2, statuses: [{ context: "ci/build", state: "success" }] }),
     },
     {
@@ -445,6 +445,128 @@ test("a mid-pagination failure is reported as partial, not silently truncated to
   assert.equal(result.surfaces.conversation_comments.count, 1);
   assert.equal(result.surfaces.conversation_comments.items.length, 1);
   assert.equal(result.fetch_failures, 1);
+});
+
+test("the combined commit status's own statuses list is paginated to completion, not capped at the first page", async () => {
+  const routes = baseRoutes();
+  routes[5] = {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100",
+    handler: () =>
+      jsonResponse(
+        { state: "success", total_count: 2, statuses: [{ context: "ci/a", state: "success" }] },
+        { link: '<https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100&page=2>; rel="next"' },
+      ),
+  };
+  routes.splice(6, 0, {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100&page=2",
+    handler: () => jsonResponse({ state: "success", total_count: 2, statuses: [{ context: "ci/b", state: "success" }] }),
+  });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.commit_status.fetch_status, "fetched");
+  assert.equal(result.surfaces.commit_status.status.statuses.length, 2);
+  assert.deepEqual(
+    result.surfaces.commit_status.status.statuses.map((status) => status.context),
+    ["ci/a", "ci/b"],
+  );
+});
+
+test("a mid-pagination failure on the combined commit status is reported as partial, not a silent fetched", async () => {
+  const routes = baseRoutes();
+  routes[5] = {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100",
+    handler: () =>
+      jsonResponse(
+        { state: "success", total_count: 2, statuses: [{ context: "ci/a", state: "success" }] },
+        { link: '<https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100&page=2>; rel="next"' },
+      ),
+  };
+  routes.splice(6, 0, {
+    match: (url) => url === "https://api.github.com/repos/octo/demo/commits/abc1234/status?per_page=100&page=2",
+    handler: () => jsonResponse({ message: "server error" }, { status: 502 }),
+  });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.commit_status.fetch_status, "partial");
+  assert.equal(result.surfaces.commit_status.status.statuses.length, 1);
+  assert.ok(result.surfaces.commit_status.failure);
+  assert.equal(result.fetch_failures, 1);
+});
+
+// Codex review on this PR (Issue #62): a status's `description` is the field
+// that carries a reviewer's positive non-participation declaration (e.g.
+// CodeRabbit's "Review skipped: automatic reviews are disabled" — the exact
+// case documented in skills/review-code.md). Dropping it made a declined
+// reviewer indistinguishable from an ordinary green status.
+test("a status's description (e.g. a declined-reviewer signal) is preserved, not dropped", async () => {
+  const routes = baseRoutes();
+  routes[5] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/status"),
+    handler: () =>
+      jsonResponse({
+        state: "success",
+        total_count: 1,
+        statuses: [{ context: "CodeRabbit", state: "success", description: "Review skipped: automatic reviews are disabled" }],
+      }),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.commit_status.status.statuses[0].description, "Review skipped: automatic reviews are disabled");
+});
+
+// Codex review on this PR (Issue #62): without the raw body, an agent using
+// only this tool's --json output cannot see what a reviewer actually said
+// (completion markers, finding text) and would have to re-fetch every
+// comment individually — defeating the point of a single fresh snapshot.
+test("comment/review body text is preserved across every comment-shaped surface, not discarded", async () => {
+  const routes = baseRoutes();
+  routes[1] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/issues/62/comments"),
+    handler: () => jsonResponse([{ id: 1, user: { login: "a" }, html_url: "loc1", body: "conversation body text" }]),
+  };
+  routes[2] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/reviews"),
+    handler: () => jsonResponse([{ id: 2, user: { login: "a" }, state: "APPROVED", html_url: "loc2", body: "review submission body text" }]),
+  };
+  routes[3] = {
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/comments"),
+    handler: () => jsonResponse([{ id: 3, user: { login: "a" }, path: "a.mjs", line: 1, html_url: "loc3", body: "inline comment body text" }]),
+  };
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: () =>
+      jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: "th1",
+                    isResolved: false,
+                    isOutdated: false,
+                    path: "a.mjs",
+                    line: 1,
+                    comments: { nodes: [{ id: "c1", author: { login: "a" }, url: "loc4", body: "thread comment body text" }] },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.conversation_comments.items[0].body, "conversation body text");
+  assert.equal(result.surfaces.review_submissions.items[0].body, "review submission body text");
+  assert.equal(result.surfaces.inline_review_comments.items[0].body, "inline comment body text");
+  assert.equal(result.surfaces.review_threads.items[0].comments[0].body, "thread comment body text");
 });
 
 test("a PR-metadata fetch failure does not crash the run and marks head-dependent surfaces not_applicable", async () => {

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -119,7 +119,7 @@ async function fetchGraphQL(fetchImpl, token, query, variables) {
     error.failure = { status: null, message: body.errors.map((graphqlError) => graphqlError.message).join("; ") };
     throw error;
   }
-  return body.data;
+  return body?.data ?? null;
 }
 
 const REVIEW_THREADS_QUERY = `
@@ -190,9 +190,12 @@ async function completeThreadComments(fetchImpl, token, threadId, firstPage) {
 
 // Review thread resolved/unresolved state is only exposed by the GraphQL
 // API, not REST, so this surface is fetched separately from the other list
-// surfaces. unresolved_count is only trustworthy when fetch_status is
-// "fetched" — a partial/failed fetch cannot claim to have seen every thread,
-// nor every comment within a thread.
+// surfaces. unresolved_count reflects the full thread list once that list
+// itself is complete, even if fetch_status ends up "partial" because a
+// single thread's own comments couldn't be paginated to completion — that
+// failure narrows only that thread's comment list, not thread enumeration
+// or resolved state. unresolved_count is unreliable only when fetch_status
+// is "failed" (the thread list itself was never fully enumerated).
 export async function fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber) {
   let cursor = null;
   let nodes = [];

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -1,0 +1,433 @@
+// Issue #62: deterministic mechanical acquisition of GitHub durable review
+// surfaces for a single PR snapshot. This module does not decide whether a
+// review is complete, whether a reviewed target is acceptable, how to
+// categorize a finding, or whether the PR is ready to merge — it only
+// fetches, paginates, and normalizes what each surface returned. Those
+// semantic judgments stay in policy/core.md's Review Protocol and the
+// review skills; this file must not encode them.
+
+const GITHUB_API_ROOT = "https://api.github.com";
+
+function defaultFetch(...args) {
+  return globalThis.fetch(...args);
+}
+
+function restHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "ai-dev-foundation-review-evidence",
+  };
+}
+
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+async function readJsonBody(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function failureFromResponse(response, body) {
+  const message = body && typeof body === "object" && typeof body.message === "string" ? body.message : `HTTP ${response.status}`;
+  return { status: response.status, message };
+}
+
+// Fetches one REST page. Throws an object with { failure } on non-2xx so
+// callers can distinguish "no page fetched yet" (failed) from "some pages
+// already fetched, this one broke" (partial) without losing prior items.
+async function fetchRestPage(fetchImpl, token, url) {
+  const response = await fetchImpl(url, { headers: restHeaders(token) });
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const error = new Error("REST page fetch failed");
+    error.failure = failureFromResponse(response, body);
+    throw error;
+  }
+  return { body, nextUrl: parseNextLink(response.headers.get("link")) };
+}
+
+// Generic paginated REST list surface. `extractItems` pulls the array out of
+// a page body (bare array for most list endpoints, a named field for others
+// like check-runs). Pagination that fails after collecting >=1 page is
+// reported as "partial" (count reflects only what was fetched, not the
+// surface's true total) rather than silently truncated to "fetched".
+export async function fetchPaginatedSurface(fetchImpl, token, initialUrl, extractItems = (body) => (Array.isArray(body) ? body : [])) {
+  let url = initialUrl;
+  let items = [];
+  let pages = 0;
+  while (url) {
+    let page;
+    try {
+      page = await fetchRestPage(fetchImpl, token, url);
+    } catch (error) {
+      return {
+        fetch_status: pages === 0 ? "failed" : "partial",
+        count: pages === 0 ? null : items.length,
+        pages_fetched: pages,
+        items,
+        failure: error.failure ?? { status: null, message: error.message },
+      };
+    }
+    pages += 1;
+    items = items.concat(extractItems(page.body));
+    url = page.nextUrl;
+  }
+  return { fetch_status: "fetched", count: items.length, pages_fetched: pages, items, failure: null };
+}
+
+// Single-object REST surface (e.g. combined commit status), not a list.
+export async function fetchSingleSurface(fetchImpl, token, url) {
+  try {
+    const page = await fetchRestPage(fetchImpl, token, url);
+    return { fetch_status: "fetched", body: page.body, failure: null };
+  } catch (error) {
+    return { fetch_status: "failed", body: null, failure: error.failure ?? { status: null, message: error.message } };
+  }
+}
+
+async function fetchGraphQL(fetchImpl, token, query, variables) {
+  const response = await fetchImpl(`${GITHUB_API_ROOT}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "ai-dev-foundation-review-evidence",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const error = new Error("GraphQL request failed");
+    error.failure = failureFromResponse(response, body);
+    throw error;
+  }
+  if (body?.errors?.length) {
+    const error = new Error("GraphQL response contained errors");
+    error.failure = { status: null, message: body.errors.map((graphqlError) => graphqlError.message).join("; ") };
+    throw error;
+  }
+  return body.data;
+}
+
+const REVIEW_THREADS_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            nodes {
+              id
+              databaseId
+              url
+              createdAt
+              author { login }
+              commit { oid }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// Review thread resolved/unresolved state is only exposed by the GraphQL
+// API, not REST, so this surface is fetched separately from the other list
+// surfaces. unresolved_count is only trustworthy when fetch_status is
+// "fetched" — a partial/failed fetch cannot claim to have seen every thread.
+export async function fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber) {
+  let cursor = null;
+  let nodes = [];
+  let pages = 0;
+  for (;;) {
+    let data;
+    try {
+      data = await fetchGraphQL(fetchImpl, token, REVIEW_THREADS_QUERY, { owner, repo, number: pullNumber, cursor });
+    } catch (error) {
+      return {
+        fetch_status: pages === 0 ? "failed" : "partial",
+        count: pages === 0 ? null : nodes.length,
+        unresolved_count: null,
+        pages_fetched: pages,
+        items: nodes,
+        failure: error.failure ?? { status: null, message: error.message },
+      };
+    }
+    pages += 1;
+    const connection = data?.repository?.pullRequest?.reviewThreads;
+    if (!connection) {
+      return {
+        fetch_status: pages === 1 ? "failed" : "partial",
+        count: pages === 1 ? null : nodes.length,
+        unresolved_count: null,
+        pages_fetched: pages,
+        items: nodes,
+        failure: { status: null, message: "reviewThreads connection missing from GraphQL response (PR/repo may not exist)" },
+      };
+    }
+    nodes = nodes.concat(connection.nodes ?? []);
+    if (connection.pageInfo?.hasNextPage) {
+      cursor = connection.pageInfo.endCursor;
+    } else {
+      break;
+    }
+  }
+  const unresolvedCount = nodes.filter((node) => node.isResolved === false).length;
+  return { fetch_status: "fetched", count: nodes.length, unresolved_count: unresolvedCount, pages_fetched: pages, items: nodes, failure: null };
+}
+
+function normalizeConversationComment(item) {
+  return {
+    id: item.id,
+    actor: item.user?.login ?? null,
+    actor_type: item.user?.type ?? null,
+    created_at: item.created_at ?? null,
+    updated_at: item.updated_at ?? null,
+    locator: item.html_url ?? null,
+  };
+}
+
+function normalizeReviewSubmission(item) {
+  return {
+    id: item.id,
+    actor: item.user?.login ?? null,
+    actor_type: item.user?.type ?? null,
+    state: item.state ?? null,
+    reviewed_sha: item.commit_id ?? null,
+    submitted_at: item.submitted_at ?? null,
+    locator: item.html_url ?? null,
+  };
+}
+
+function normalizeInlineReviewComment(item) {
+  return {
+    id: item.id,
+    actor: item.user?.login ?? null,
+    actor_type: item.user?.type ?? null,
+    path: item.path ?? null,
+    line: item.line ?? item.original_line ?? null,
+    reviewed_sha: item.commit_id ?? null,
+    original_commit_sha: item.original_commit_id ?? null,
+    in_reply_to_id: item.in_reply_to_id ?? null,
+    created_at: item.created_at ?? null,
+    updated_at: item.updated_at ?? null,
+    locator: item.html_url ?? null,
+  };
+}
+
+function normalizeReviewThread(node) {
+  return {
+    id: node.id ?? null,
+    is_resolved: node.isResolved ?? null,
+    is_outdated: node.isOutdated ?? null,
+    path: node.path ?? null,
+    line: node.line ?? null,
+    comments: (node.comments?.nodes ?? []).map((comment) => ({
+      id: comment.id ?? null,
+      actor: comment.author?.login ?? null,
+      created_at: comment.createdAt ?? null,
+      reviewed_sha: comment.commit?.oid ?? null,
+      locator: comment.url ?? null,
+    })),
+  };
+}
+
+function normalizeCheckRun(item) {
+  return {
+    id: item.id,
+    name: item.name ?? null,
+    status: item.status ?? null,
+    conclusion: item.conclusion ?? null,
+    started_at: item.started_at ?? null,
+    completed_at: item.completed_at ?? null,
+    locator: item.html_url ?? null,
+  };
+}
+
+function normalizeCombinedStatus(body) {
+  if (!body) return null;
+  return {
+    state: body.state ?? null,
+    total_count: body.total_count ?? null,
+    statuses: (body.statuses ?? []).map((status) => ({
+      context: status.context ?? null,
+      state: status.state ?? null,
+      target_url: status.target_url ?? null,
+      created_at: status.created_at ?? null,
+      updated_at: status.updated_at ?? null,
+    })),
+  };
+}
+
+function notApplicableSurface(note) {
+  return { fetch_status: "not_applicable", count: null, pages_fetched: 0, items: [], failure: null, note };
+}
+
+// Collects a single PR's durable GitHub review-evidence surfaces: PR
+// metadata/head SHA, Conversation comments, review submissions, inline
+// review comments, review threads (with resolved state), combined commit
+// status, and check runs. Every surface reports its own fetch_status
+// (fetched / partial / failed / not_applicable) and count independently —
+// a failure on one surface never becomes a 0 on another, and a 0 count is
+// only ever reported when the surface actually completed a fetch.
+export async function collectReviewEvidence({ owner, repo, pullNumber, token, fetchImpl = defaultFetch }) {
+  const restBase = `${GITHUB_API_ROOT}/repos/${owner}/${repo}`;
+
+  let prBody = null;
+  let prMetadataFailure = null;
+  try {
+    const page = await fetchRestPage(fetchImpl, token, `${restBase}/pulls/${pullNumber}`);
+    prBody = page.body;
+  } catch (error) {
+    prMetadataFailure = error.failure ?? { status: null, message: error.message };
+  }
+  const headSha = prBody?.head?.sha ?? null;
+
+  const [conversationComments, reviewSubmissions, inlineReviewComments, reviewThreads] = await Promise.all([
+    fetchPaginatedSurface(fetchImpl, token, `${restBase}/issues/${pullNumber}/comments?per_page=100`),
+    fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/reviews?per_page=100`),
+    fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/comments?per_page=100`),
+    fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber),
+  ]);
+
+  let commitStatus;
+  let checkRuns;
+  if (headSha) {
+    [commitStatus, checkRuns] = await Promise.all([
+      fetchSingleSurface(fetchImpl, token, `${restBase}/commits/${headSha}/status`),
+      fetchPaginatedSurface(
+        fetchImpl,
+        token,
+        `${restBase}/commits/${headSha}/check-runs?per_page=100`,
+        (body) => body?.check_runs ?? [],
+      ),
+    ]);
+  } else {
+    commitStatus = notApplicableSurface("head SHA unavailable because PR metadata fetch failed");
+    checkRuns = notApplicableSurface("head SHA unavailable because PR metadata fetch failed");
+  }
+
+  const surfaces = {
+    conversation_comments: { ...conversationComments, items: conversationComments.items.map(normalizeConversationComment) },
+    review_submissions: { ...reviewSubmissions, items: reviewSubmissions.items.map(normalizeReviewSubmission) },
+    inline_review_comments: { ...inlineReviewComments, items: inlineReviewComments.items.map(normalizeInlineReviewComment) },
+    review_threads: { ...reviewThreads, items: reviewThreads.items.map(normalizeReviewThread) },
+    commit_status:
+      commitStatus.fetch_status === "fetched"
+        ? { fetch_status: "fetched", failure: null, status: normalizeCombinedStatus(commitStatus.body) }
+        : { fetch_status: commitStatus.fetch_status, failure: commitStatus.failure ?? null, status: null, note: commitStatus.note },
+    check_runs: { ...checkRuns, items: checkRuns.items.map(normalizeCheckRun) },
+  };
+
+  let fetchFailures = prMetadataFailure ? 1 : 0;
+  for (const surface of Object.values(surfaces)) {
+    if (surface.fetch_status === "failed" || surface.fetch_status === "partial") fetchFailures += 1;
+  }
+
+  return {
+    repo: `${owner}/${repo}`,
+    pull_number: pullNumber,
+    generated_at: new Date().toISOString(),
+    pr_metadata: prBody
+      ? { fetch_status: "fetched", failure: null, head_sha: headSha, state: prBody.state ?? null, html_url: prBody.html_url ?? null, updated_at: prBody.updated_at ?? null }
+      : { fetch_status: "failed", failure: prMetadataFailure, head_sha: null, state: null, html_url: null, updated_at: null },
+    surfaces,
+    fetch_failures: fetchFailures,
+  };
+}
+
+const SURFACE_LABELS = [
+  ["conversation_comments", "Conversation comments"],
+  ["review_submissions", "Review submissions"],
+  ["inline_review_comments", "Inline review comments"],
+  ["review_threads", "Review threads"],
+  ["commit_status", "Commit status (combined)"],
+  ["check_runs", "Check runs"],
+];
+
+// Renders the same collectReviewEvidence() result as a human-readable
+// snapshot summary. Purely a presentation of the counts/fetch states already
+// computed above — it adds no new judgment.
+export function formatHumanSummary(result) {
+  const lines = [];
+  lines.push(`PR #${result.pull_number} review evidence snapshot (${result.repo})`);
+  if (result.pr_metadata.fetch_status === "fetched") {
+    lines.push(`Head: ${result.pr_metadata.head_sha ?? "unknown"} (state: ${result.pr_metadata.state ?? "unknown"})`);
+  } else {
+    lines.push(`Head: unknown (PR metadata fetch failed: ${result.pr_metadata.failure?.message ?? "unknown error"})`);
+  }
+  lines.push(`Snapshot fetched at: ${result.generated_at}`);
+  lines.push("");
+
+  for (const [key, label] of SURFACE_LABELS) {
+    const surface = result.surfaces[key];
+    if (!surface) continue;
+    let line = `${label}: ${surface.fetch_status}`;
+    if (key === "commit_status") {
+      if (surface.fetch_status === "fetched") line += ` (state: ${surface.status?.state ?? "unknown"}, contexts: ${surface.status?.total_count ?? 0})`;
+    } else if (surface.count !== null && surface.count !== undefined) {
+      line += ` (${surface.count})`;
+    }
+    if (surface.fetch_status === "failed" || surface.fetch_status === "partial") {
+      line += ` — ${surface.failure?.message ?? "unknown failure"}`;
+    }
+    if (surface.fetch_status === "not_applicable" && surface.note) {
+      line += ` — ${surface.note}`;
+    }
+    if (key === "review_threads" && surface.fetch_status === "fetched") {
+      line += ` — unresolved: ${surface.unresolved_count}`;
+    }
+    lines.push(line);
+  }
+
+  lines.push("");
+  lines.push(`Fetch failures: ${result.fetch_failures}`);
+  return lines.join("\n");
+}
+
+export function parseReviewEvidenceArgs(argv) {
+  const args = { json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") {
+      args.repo = argv[index + 1];
+      index += 1;
+    } else if (arg === "--pr") {
+      args.pr = argv[index + 1];
+      index += 1;
+    } else if (arg === "--token") {
+      args.token = argv[index + 1];
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.repo || !args.repo.includes("/")) {
+    throw new Error("Usage: node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> [--json] [--token <token>]");
+  }
+  if (!args.pr || !/^\d+$/.test(args.pr)) {
+    throw new Error("Usage: node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> [--json] [--token <token>]");
+  }
+  return args;
+}

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -88,14 +88,21 @@ export async function fetchPaginatedSurface(fetchImpl, token, initialUrl, extrac
   return { fetch_status: "fetched", count: items.length, pages_fetched: pages, items, failure: null };
 }
 
-// Single-object REST surface (e.g. combined commit status), not a list.
-export async function fetchSingleSurface(fetchImpl, token, url) {
-  try {
-    const page = await fetchRestPage(fetchImpl, token, url);
-    return { fetch_status: "fetched", body: page.body, failure: null };
-  } catch (error) {
-    return { fetch_status: "failed", body: null, failure: error.failure ?? { status: null, message: error.message } };
-  }
+// The combined-status endpoint's `statuses` array is itself paginated (one
+// entry per context, which can exceed a single page on a commit with many
+// status contexts). This follows it to completion via fetchPaginatedSurface
+// like every other list surface, while separately capturing the page-level
+// `state`/`total_count` fields that aren't part of the paginated array.
+export async function fetchCombinedStatusSurface(fetchImpl, token, url) {
+  const summary = { state: null, total_count: null };
+  const result = await fetchPaginatedSurface(fetchImpl, token, url, (body) => {
+    if (body && typeof body === "object") {
+      if ("state" in body) summary.state = body.state ?? null;
+      if ("total_count" in body) summary.total_count = body.total_count ?? null;
+    }
+    return body?.statuses ?? [];
+  });
+  return { ...result, state: summary.state, total_count: summary.total_count };
 }
 
 async function fetchGraphQL(fetchImpl, token, query, variables) {
@@ -143,6 +150,7 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
               createdAt
               author { login }
               commit { oid }
+              body
             }
           }
         }
@@ -164,6 +172,7 @@ query($id: ID!, $cursor: String) {
           createdAt
           author { login }
           commit { oid }
+          body
         }
       }
     }
@@ -266,6 +275,7 @@ function normalizeConversationComment(item) {
     created_at: item.created_at ?? null,
     updated_at: item.updated_at ?? null,
     locator: item.html_url ?? null,
+    body: item.body ?? null,
   };
 }
 
@@ -278,6 +288,7 @@ function normalizeReviewSubmission(item) {
     reviewed_sha: item.commit_id ?? null,
     submitted_at: item.submitted_at ?? null,
     locator: item.html_url ?? null,
+    body: item.body ?? null,
   };
 }
 
@@ -294,6 +305,7 @@ function normalizeInlineReviewComment(item) {
     created_at: item.created_at ?? null,
     updated_at: item.updated_at ?? null,
     locator: item.html_url ?? null,
+    body: item.body ?? null,
   };
 }
 
@@ -310,6 +322,7 @@ function normalizeReviewThread(node) {
       created_at: comment.createdAt ?? null,
       reviewed_sha: comment.commit?.oid ?? null,
       locator: comment.url ?? null,
+      body: comment.body ?? null,
     })),
   };
 }
@@ -326,18 +339,14 @@ function normalizeCheckRun(item) {
   };
 }
 
-function normalizeCombinedStatus(body) {
-  if (!body) return null;
+function normalizeStatus(status) {
   return {
-    state: body.state ?? null,
-    total_count: body.total_count ?? null,
-    statuses: (body.statuses ?? []).map((status) => ({
-      context: status.context ?? null,
-      state: status.state ?? null,
-      target_url: status.target_url ?? null,
-      created_at: status.created_at ?? null,
-      updated_at: status.updated_at ?? null,
-    })),
+    context: status.context ?? null,
+    state: status.state ?? null,
+    description: status.description ?? null,
+    target_url: status.target_url ?? null,
+    created_at: status.created_at ?? null,
+    updated_at: status.updated_at ?? null,
   };
 }
 
@@ -376,7 +385,7 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
   let checkRuns;
   if (headSha) {
     [commitStatus, checkRuns] = await Promise.all([
-      fetchSingleSurface(fetchImpl, token, `${restBase}/commits/${headSha}/status`),
+      fetchCombinedStatusSurface(fetchImpl, token, `${restBase}/commits/${headSha}/status?per_page=100`),
       fetchPaginatedSurface(
         fetchImpl,
         token,
@@ -395,9 +404,16 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
     inline_review_comments: { ...inlineReviewComments, items: inlineReviewComments.items.map(normalizeInlineReviewComment) },
     review_threads: { ...reviewThreads, items: reviewThreads.items.map(normalizeReviewThread) },
     commit_status:
-      commitStatus.fetch_status === "fetched"
-        ? { fetch_status: "fetched", failure: null, status: normalizeCombinedStatus(commitStatus.body) }
-        : { fetch_status: commitStatus.fetch_status, failure: commitStatus.failure ?? null, status: null, note: commitStatus.note },
+      commitStatus.fetch_status === "not_applicable"
+        ? { fetch_status: "not_applicable", failure: null, status: null, note: commitStatus.note }
+        : {
+            fetch_status: commitStatus.fetch_status,
+            failure: commitStatus.failure,
+            status:
+              commitStatus.fetch_status === "failed"
+                ? null
+                : { state: commitStatus.state, total_count: commitStatus.total_count, statuses: commitStatus.items.map(normalizeStatus) },
+          },
     check_runs: { ...checkRuns, items: checkRuns.items.map(normalizeCheckRun) },
   };
 
@@ -446,7 +462,9 @@ export function formatHumanSummary(result) {
     if (!surface) continue;
     let line = `${label}: ${surface.fetch_status}`;
     if (key === "commit_status") {
-      if (surface.fetch_status === "fetched") line += ` (state: ${surface.status?.state ?? "unknown"}, contexts: ${surface.status?.total_count ?? 0})`;
+      if (surface.fetch_status === "fetched" || surface.fetch_status === "partial") {
+        line += ` (state: ${surface.status?.state ?? "unknown"}, contexts: ${surface.status?.statuses?.length ?? 0})`;
+      }
     } else if (surface.count !== null && surface.count !== undefined) {
       line += ` (${surface.count})`;
     }

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -135,6 +135,7 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
           path
           line
           comments(first: 50) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               databaseId
@@ -150,10 +151,48 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   }
 }`;
 
+const THREAD_COMMENTS_QUERY = `
+query($id: ID!, $cursor: String) {
+  node(id: $id) {
+    ... on PullRequestReviewThread {
+      comments(first: 50, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          databaseId
+          url
+          createdAt
+          author { login }
+          commit { oid }
+        }
+      }
+    }
+  }
+}`;
+
+// A thread's own `comments` connection can exceed the first page fetched by
+// REVIEW_THREADS_QUERY (>50 replies on one thread). This follows that
+// specific thread's comments to completion so review_threads can only ever
+// report fetch_status "fetched" when every thread's comment list is
+// genuinely complete, not just its first 50.
+async function completeThreadComments(fetchImpl, token, threadId, firstPage) {
+  let comments = firstPage?.nodes ?? [];
+  let pageInfo = firstPage?.pageInfo;
+  while (pageInfo?.hasNextPage) {
+    const data = await fetchGraphQL(fetchImpl, token, THREAD_COMMENTS_QUERY, { id: threadId, cursor: pageInfo.endCursor });
+    const connection = data?.node?.comments;
+    if (!connection) throw new Error("thread comments connection missing from GraphQL response");
+    comments = comments.concat(connection.nodes ?? []);
+    pageInfo = connection.pageInfo;
+  }
+  return comments;
+}
+
 // Review thread resolved/unresolved state is only exposed by the GraphQL
 // API, not REST, so this surface is fetched separately from the other list
 // surfaces. unresolved_count is only trustworthy when fetch_status is
-// "fetched" — a partial/failed fetch cannot claim to have seen every thread.
+// "fetched" — a partial/failed fetch cannot claim to have seen every thread,
+// nor every comment within a thread.
 export async function fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber) {
   let cursor = null;
   let nodes = [];
@@ -191,7 +230,28 @@ export async function fetchReviewThreadsSurface(fetchImpl, token, owner, repo, p
       break;
     }
   }
+  let threadCommentsFailure = null;
+  for (const node of nodes) {
+    if (!node.comments?.pageInfo?.hasNextPage) continue;
+    try {
+      node.comments = { nodes: await completeThreadComments(fetchImpl, token, node.id, node.comments) };
+    } catch (error) {
+      threadCommentsFailure = error.failure ?? { status: null, message: error.message };
+      break;
+    }
+  }
+
   const unresolvedCount = nodes.filter((node) => node.isResolved === false).length;
+  if (threadCommentsFailure) {
+    return {
+      fetch_status: "partial",
+      count: nodes.length,
+      unresolved_count: unresolvedCount,
+      pages_fetched: pages,
+      items: nodes,
+      failure: threadCommentsFailure,
+    };
+  }
   return { fetch_status: "fetched", count: nodes.length, unresolved_count: unresolvedCount, pages_fetched: pages, items: nodes, failure: null };
 }
 

--- a/tooling/review-evidence.mjs
+++ b/tooling/review-evidence.mjs
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { collectReviewEvidence, formatHumanSummary, parseReviewEvidenceArgs } from "./review-evidence-lib.mjs";
+
+// Snapshot tool only (Issue #62): one fresh fetch per invocation, no
+// polling/daemon. Re-run it to get a new snapshot.
+function resolveToken(explicitToken) {
+  if (explicitToken) return explicitToken;
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  try {
+    return execFileSync("gh", ["auth", "token"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const args = parseReviewEvidenceArgs(process.argv.slice(2));
+const [owner, repo] = args.repo.split("/");
+const token = resolveToken(args.token);
+
+if (!token) {
+  console.error("No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.");
+  process.exitCode = 2;
+} else {
+  const result = await collectReviewEvidence({ owner, repo, pullNumber: Number(args.pr), token });
+  console.log(args.json ? JSON.stringify(result, null, 2) : formatHumanSummary(result));
+  process.exitCode = result.fetch_failures > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Context

Closes #62（Issue本文をcanonical Task Contractとする）。
Origin: #59 Runtime Observation O-2 / #59 Decision checkpoint。
Sequencing: #62を#59より先にlandさせる方針（#62#issuecomment-5428120440）。

review resultが既にGitHub上に存在するのに、agentがsingle-surface / partial
responseから「comments/findings 0」と誤認するexecution failure（#59 O-2）を
減らすため、GitHub durable review surfaceのmechanical acquisitionをthin
deterministic helperへ寄せる。

## 実装

- `tooling/review-evidence-lib.mjs` — collectReviewEvidence() が次のsurfaceを
  fresh fetchし、paginationを完了させた上でsurfaceごとに独立した
  `fetch_status`（fetched / partial / failed / not_applicable）とcountを返す。
  - PR metadata / head SHA
  - Conversation (issue) comments
  - review submissions（pulls reviews、`commit_id` を reviewed_sha として保持）
  - inline review comments（`commit_id` / `original_commit_id` を保持）
  - review thread（GraphQL、resolved/unresolved状態・isOutdatedを保持）
  - combined commit status
  - check runs
- `tooling/review-evidence.mjs` — CLI entry。`--repo owner/name --pr N [--json]`。
  tokenは `--token` / `GH_TOKEN` / `GITHUB_TOKEN` / `gh auth token` の順で解決。
- `test/review-evidence.test.mjs` — multi-surface / top-level-only /
  inline-only / submission-only / pagination完了 / surface fetch failure /
  partial pagination / PR metadata failure / human summary format /
  arg parsing、および「Validity/triage/merge-ready等のjudgment語彙を
  helper sourceへ持ち込まない」boundary guardをカバー。

## Invariants（Issue #62 Critical invariants準拠）

- False zeroを作らない — surfaceごとに独立したcount/fetch_status
- fetch failureをemptyへ潰さない — failed時はcount=nullで明示
- pagination途中の失敗はpartialとして明示し、fetched(完了)と区別
- target bindingを捏造しない — 各surfaceが実際に持つ`commit_id`等のみ保持
- snapshot toolに留める — polling/daemonなし、都度fresh fetch
- provider semanticsを持たない — completion / target Validity / finding
  triage / merge-readiness判定は実装しない（review skill側の責務のまま）

## Verification

- `npm test`（112 tests: 111 pass / 1 skip — symlink fixtureはこの環境の
  platform制約でskip、既存の事前条件で本PRの変更とは無関係）
- `npm run test:guardrails`（8 guardrail fixtures green）
- CLIをreitojike/ai-dev-foundation PR #60に対してlive実行し、human-readable
  summaryと`--json`出力、および存在しないPR番号に対するfailure pathを確認

## Scope

Issue #62のOut of scope（provider-specific semantics engine、review
trigger、completion poller、merge-readiness checker、finding parser、
dashboard/statistics、webhook service、generalized orchestrator、
stage-tracker変更、consumer canary前のKernel/review-skill大幅削減）には
踏み込んでいない。skills/review-code.md等へのthin pointer追加も、今回は
見送り、post-landing canary evidenceを待つ。

merge / Issue closeはこのセッションでは実行しない。