### PR TITLE
CI/Review runtime: stage-tracker #118 canaryをpromoteしmanual-on-demand review routingへ更新する (#59)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,3 +2,5 @@ reviews:
   auto_review:
     enabled: false
   review_status: false
+  review_progress: false
+  commit_status: false

--- a/profiles/next-supabase/ci/verify-lanes.example.yml
+++ b/profiles/next-supabase/ci/verify-lanes.example.yml
@@ -14,6 +14,12 @@ name: Verify
 # DB-backed checks in `verify:profile:database` (generated-types drift,
 # RLS/auth tests, client-role privilege guardrail). Consumers without
 # Supabase have no `verify:database` script and should delete this job.
+# This example intentionally has no separate "start Supabase" step: as in
+# the observed working reference (a consumer's own verify:database-chained
+# npm scripts), provisioning the local stack (e.g. `supabase start` /
+# `db reset`) is consumer-owned and expected to happen inside those scripts,
+# not as a Foundation-prescribed CI step — ubuntu-latest's preinstalled
+# Docker is what those scripts rely on.
 
 on:
   push:

--- a/profiles/next-supabase/ci/verify-lanes.example.yml
+++ b/profiles/next-supabase/ci/verify-lanes.example.yml
@@ -1,0 +1,58 @@
+name: Verify
+
+# Non-normative reference example (profiles/next-supabase/quality/README.md
+# "GitHub Actions verification lane"). Foundation does not distribute or
+# bootstrap this file automatically; a consumer copies and adapts it.
+#
+# Splits the consumer's single `npm run verify` sequence into three GitHub
+# Actions jobs by responsibility (`verify:code` / `verify:build` /
+# `verify:database`) so PR Checks show which responsibility failed instead
+# of one collapsed `verify` result. The local/agent one-command `verify`
+# contract is unchanged; each job below runs one slice of it.
+#
+# `Verify / Database` needs a running local Supabase stack for the
+# DB-backed checks in `verify:profile:database` (generated-types drift,
+# RLS/auth tests, client-role privilege guardrail). Consumers without
+# Supabase have no `verify:database` script and should delete this job.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  code:
+    name: Verify / Code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.6'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run verify:code
+
+  build:
+    name: Verify / Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.6'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run verify:build
+
+  database:
+    name: Verify / Database
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.6'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run verify:database

--- a/profiles/next-supabase/ci/verify-lanes.example.yml
+++ b/profiles/next-supabase/ci/verify-lanes.example.yml
@@ -20,6 +20,13 @@ name: Verify
 # `db reset`) is consumer-owned and expected to happen inside those scripts,
 # not as a Foundation-prescribed CI step — ubuntu-latest's preinstalled
 # Docker is what those scripts rely on.
+#
+# `database` declares `needs: code`: the three jobs otherwise have no
+# ordering, so `Verify / Database` could start touching a local Supabase
+# stack before `Verify / Code`'s filesystem-only migration-collision
+# preflight (part of `verify:profile:code`) finishes, defeating the quality
+# README's "run the migration-collision guardrail before any DB/Docker
+# command" invariant.
 
 on:
   push:
@@ -53,6 +60,7 @@ jobs:
 
   database:
     name: Verify / Database
+    needs: code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/profiles/next-supabase/quality/README.md
+++ b/profiles/next-supabase/quality/README.md
@@ -28,8 +28,8 @@ prettier
 typescript
 ```
 
-Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile`から呼び出す
-consumerは、これに加えて`pg`を追加します。
+Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile:database`から
+呼び出すconsumerは、これに加えて`pg`を追加します。
 
 ## 適用方法
 
@@ -266,36 +266,72 @@ duplicate keyなど）は、parser/tokenizer/generalized config evaluatorへ発�
 単体ではなく、この proactive blocking layer（`agent-rules:check`）と reactive exact
 layer（`foundation:check`）を合わせたsystem levelで満たします。
 
-## `verify` への集約
+## `verify` への集約と responsibility lane
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
-profile固有の追加は`verify:profile`に置きます。これはextension pointであり、pluginの
-登録機構ではありません。consumerがSupabaseを使う場合、`supabase:migrations:check`
-（DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
-`supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
-driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
-`verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
-同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
-呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
-local Supabase stackを起動するconsumerは、同じ`verify:profile`から
-`client-role-privileges:check`（DB / Docker / Supabase local stackを起動する他の
-checkより後）も呼び出し、残存privilegeの回帰をblockingで検知します。
+`verify`は、GitHub上でも失敗domainを切り分けられるよう、次の3つのresponsibility lane
+の合成として定義します。
+
+- `verify:code` — format / lint / typecheck / unit test、`foundation:check`、および
+  DB / Docker / Supabase local stackを起動しないprofile check
+- `verify:build` — application build
+- `verify:database` — local Supabase runtimeを必要とするprofile check
+
+profile固有の追加は、DB / Docker / Supabase local stackを起動するかどうかで
+`verify:profile:code`（起動しない）と`verify:profile:database`（起動する）のどちらかに
+置きます。これはextension pointであり、pluginの登録機構ではありません。
+consumerがSupabaseを使う場合、`supabase:migrations:check`はfilesystemだけで完結する
+ため`verify:profile:code`から呼び出します。`supabase:types:check`（typesの再生成後に
+生成ファイルのdriftをnon-zeroで検知するcommand）はlocal Supabase runtimeを必要とする
+ため`verify:profile:database`から呼び出します。DB/RLS testがあるconsumerも同じ
+`verify:profile:database`からそのtest commandを呼び出します。Next.js 16.3以降を使う
+consumerは`agent-rules:check`（filesystemだけで完結）を`verify:profile:code`から
+呼び出します（16.3未満では対象外のため呼び出しません。本節冒頭の「該当しない
+commandは含めない」原則の具体例です）。local Supabase stackを起動するconsumerは、
+`verify:profile:database`から`client-role-privileges:check`（DB / Docker / Supabase
+local stackを起動する他のcheckより後）も呼び出し、残存privilegeの回帰をblockingで
+検知します。
 
 ```json
 {
   "scripts": {
     "client-role-privileges:check": "node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs",
-    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
+    "verify:profile:code": "npm run agent-rules:check && npm run supabase:migrations:check",
+    "verify:profile:database": "npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
+    "verify:code": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run foundation:check && npm run verify:profile:code",
+    "verify:build": "npm run build",
+    "verify:database": "npm run verify:profile:database",
+    "verify": "npm run verify:code && npm run verify:build && npm run verify:database"
   }
 }
 ```
 
-上記のうちconsumerに該当しないcommandは`verify:profile`に含めません。空の成功commandを
-置かず、必要になった時点で実行可能なcheckとして追加します。
+上記のうちconsumerに該当しないcommandは`verify:profile:code` / `verify:profile:database`
+に含めません。空の成功commandを置かず、必要になった時点で実行可能なcheckとして追加
+します。該当するprofile checkが1つも無いlaneはそのlane自体を`verify`から省略します
+（例えばSupabaseを使わないconsumerは`verify:database`を持たず、`verify`は
+`verify:code`と`verify:build`だけを呼び出します）。
 
 `jscpd`や`knip`などのノイズを含み得るcheckはadvisoryです。blocking quality floorには
 含めません。
+
+### GitHub Actions verification lane（reference、non-normative）
+
+consumerのGitHub Actions上のPR checksを`verify`単一jobとして直列実行すると、format /
+lint / typecheck、build、DB runtimeというfailure domainがすべて1つのcheck結果へ
+collapseし、どの責務が落ちたか一目で切り分けにくくなります。responsibilityごとに
+独立したjobへ分けたいconsumerのための、non-normativeなreference exampleを
+`profiles/next-supabase/ci/verify-lanes.example.yml`に置きます。このfileは`sync` /
+`bootstrap-next-supabase.mjs`のどちらからもconsumerへ自動配布されません。必要な
+consumerが手動でcopy/adaptしてください。
+
+このreferenceは`verify:code` / `verify:build` / `verify:database`をそれぞれ独立した
+GitHub Actions jobとして実行し、job名を`Verify / Code`・`Verify / Build`・
+`Verify / Database`とします。consumer local/agent向けの一括`verify`はこのreferenceの
+有無にかかわらず維持され、このreferenceはGitHub Actions上の実行を3つのlaneへ分ける
+だけで、それ以上の細粒度checkへ分裂させることを意図しません。Supabaseを使わず
+`verify:database`が空のconsumerは、`Verify / Database` job自体をreferenceから
+削除してください。
 
 ## Worktree/checkoutをまたぐlocal Supabase stack
 
@@ -316,7 +352,8 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 - DB / RLS / auth integration test
 - schema由来のgenerated types生成、およびdrift verification
 - `client-role-privileges:check`（client-role table privilege guardrail）
-- 上記のいずれかを内包する`verify:profile`
+- 上記のいずれかを内包する`verify:profile:database`
+- 上記のいずれかを内包する`verify:database`
 - 上記のいずれかを内包するfull `verify`
 
 shared local stackに対して上記を実行するagentは、少なくとも次を満たします。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -440,3 +440,42 @@ capability/profile 側で再検証可能な observed evidence として扱いま
 同じ Review Contract を使って Selection / Completion / Acquisition / Validity /
 Resolution を人手で判定できることを確認します。この skill の範囲では pilot 自体を
 実施・拡張せず、contract を適用できる準備を整えるところまでとします。
+
+## Manual-on-demand review runtime preference（current runtime preference、Issue #59）
+
+上記 Manual review pilot が確認した準備を踏まえた、current environment における
+runtime preference です。Kernel の provider-neutral な Selection Contract / required
+review 数を置換せず、task risk / artifact / capability による別 Selection を引き続き
+許容します。特定 provider を Kernel へ固定するものではありません。
+
+複数 perspective が必要な通常の Executable review における current runtime
+preference は次のとおりです。
+
+- Claude が selection された場合は、上記「Claude formal acquisition routing」の
+  GitHub-native `@claude` preferred route を使います。
+- CodeRabbit の manual acquisition（明示的な `@coderabbitai review` 系 command）を、
+  複数 perspective が必要な場合の primary candidate の一つとして扱ってよいです。
+  CodeRabbit automatic review が無効化されている場合、その非参加を `0 findings` へ
+  変換しないことは Acquisition & Validity Contract（`policy/core.md`）どおりです。
+- CodeRabbit acquisition が quota / rate limit / unavailable、または structurally
+  invalid（intended target を review していない等）で completion evidence を得られ
+  ない場合、その run は Failure / retry（`policy/core.md`）に従い `unknown` または
+  `failure` として扱い、success や `0 findings` へ変換しません。この場合、alternate
+  reviewer として Codex の manual acquisition（明示的な `@codex review` 系 command）を
+  選択でき、Selection Contract を明示的に amend した上でその run を required/expected
+  member として扱えます。amend したことと根拠は他の Selection 記録と同様に残します。
+- Codex の automatic（PR-open）review を、current runtime preference の default /
+  baseline として前提にしません。Selection で明示的に Codex（automatic / manual の
+  いずれも）を選ぶこと自体は禁止しません。
+
+Codex Cloud Review の PR-open automatic review が有効かどうかは、多くの場合
+repository code だけでは完結しない operator/account 側の設定である observed
+evidence があります。この skill および Foundation は、review 対象 repository の
+operator がこの automatic review 設定を変更したことを、repository code から完了した
+ものとして偽装しません。この設定変更が必要な場合は、implementation agent の
+repository write scope とは別の operator action として扱います。
+
+上記はいずれも observed / current な runtime preference であり、provider の恒久仕様
+にも、required reviewer 数を常に固定数（例えば 2）へ固定する mandatory pairing にも
+昇格させません。Selection Contract の risk-based reviewer 数と capability validity は
+この節によって変更されません。

--- a/test/consumer-verify.test.mjs
+++ b/test/consumer-verify.test.mjs
@@ -53,41 +53,51 @@ test("consumer verify is green and detects generated adapter and profile drift",
 
 test("consumer verify fixes the required command set", async () => {
   const packageJson = JSON.parse(await readFile(path.join(fixture, "package.json"), "utf8"));
-  const verifyCommand = packageJson.scripts.verify;
-  const requiredCommands = [
-    "format:check",
-    "lint",
-    "typecheck",
-    "test:unit",
-    "build",
-    "foundation:check",
-    "verify:profile",
-  ];
+  const requiredLanes = ["verify:code", "verify:build", "verify:database"];
 
-  assert.equal(verifyCommand, requiredCommands.map((command) => `npm run ${command}`).join(" && "));
-  for (const command of requiredCommands) {
+  assert.equal(
+    packageJson.scripts.verify,
+    requiredLanes.map((command) => `npm run ${command}`).join(" && "),
+  );
+
+  const requiredCodeCommands = ["format:check", "lint", "typecheck", "test:unit", "foundation:check", "verify:profile:code"];
+  assert.equal(
+    packageJson.scripts["verify:code"],
+    requiredCodeCommands.map((command) => `npm run ${command}`).join(" && "),
+  );
+  assert.equal(packageJson.scripts["verify:build"], "npm run build");
+  assert.equal(packageJson.scripts["verify:database"], "npm run verify:profile:database");
+
+  for (const command of [...requiredLanes, ...requiredCodeCommands, "verify:profile:database"]) {
     assert.equal(typeof packageJson.scripts[command], "string");
   }
 });
 
-test("verify:profile runs the filesystem-only migration collision check before any DB/Docker-touching Supabase command", async () => {
-  // Issue #43: the migration version collision guardrail must execute before
-  // the DB / Docker / Supabase local stack is ever touched. supabase:types:check
-  // stands in for the DB/Docker-touching step here (per profile README, real
-  // consumers' supabase:types shells out to `supabase gen types`), so
-  // supabase:migrations:check must be sequenced strictly before it. Other
-  // filesystem-only guardrails (e.g. Issue #40's agent-rules:check) may sit
-  // anywhere else in the chain without violating this DB/Docker-ordering
-  // invariant, so this asserts relative order rather than an exact string.
+test("Verify / Code lane runs the filesystem-only migration collision check; Verify / Database lane runs the DB/Docker-touching Supabase command", async () => {
+  // Issue #43 (migration collision guardrail must precede any DB/Docker-touching
+  // Supabase command) plus Issue #59 (Verify / Code, Build, Database responsibility
+  // lanes): the invariant is now structural — supabase:migrations:check lives in
+  // verify:profile:code (Verify / Code lane), supabase:types:check stands in for
+  // the DB/Docker-touching step (per profile README, real consumers' supabase:types
+  // shells out to `supabase gen types`) and lives in verify:profile:database
+  // (Verify / Database lane). The top-level `verify` composition (asserted above)
+  // already runs verify:code strictly before verify:database, so this ordering
+  // holds without needing the two checks to share one script.
   const packageJson = JSON.parse(await readFile(path.join(fixture, "package.json"), "utf8"));
-  const steps = packageJson.scripts["verify:profile"].split(" && ").map((step) => step.trim());
-  const migrationsCheckIndex = steps.indexOf("npm run supabase:migrations:check");
-  const typesCheckIndex = steps.indexOf("npm run supabase:types:check");
-  assert.notEqual(migrationsCheckIndex, -1, "verify:profile must run supabase:migrations:check");
-  assert.notEqual(typesCheckIndex, -1, "verify:profile must run supabase:types:check");
+  const codeSteps = packageJson.scripts["verify:profile:code"].split(" && ").map((step) => step.trim());
+  const databaseSteps = packageJson.scripts["verify:profile:database"].split(" && ").map((step) => step.trim());
+
   assert.ok(
-    migrationsCheckIndex < typesCheckIndex,
-    `supabase:migrations:check (index ${migrationsCheckIndex}) must precede supabase:types:check (index ${typesCheckIndex})`,
+    codeSteps.includes("npm run supabase:migrations:check"),
+    "verify:profile:code must run supabase:migrations:check",
+  );
+  assert.ok(
+    databaseSteps.includes("npm run supabase:types:check"),
+    "verify:profile:database must run supabase:types:check",
+  );
+  assert.ok(
+    !databaseSteps.includes("npm run supabase:migrations:check"),
+    "the filesystem-only migration collision check must not also run in the Verify / Database lane",
   );
   assert.equal(
     packageJson.scripts["supabase:migrations:check"],

--- a/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/quality/README.md
@@ -28,8 +28,8 @@ prettier
 typescript
 ```
 
-Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile`から呼び出す
-consumerは、これに加えて`pg`を追加します。
+Supabaseを使い、`client-role-privileges:check`（後述）を`verify:profile:database`から
+呼び出すconsumerは、これに加えて`pg`を追加します。
 
 ## 適用方法
 
@@ -266,36 +266,72 @@ duplicate keyなど）は、parser/tokenizer/generalized config evaluatorへ発�
 単体ではなく、この proactive blocking layer（`agent-rules:check`）と reactive exact
 layer（`foundation:check`）を合わせたsystem levelで満たします。
 
-## `verify` への集約
+## `verify` への集約と responsibility lane
 
 consumerはrequired checkを通常のnpm scriptsとして固定し、`verify` から順番に実行します。
-profile固有の追加は`verify:profile`に置きます。これはextension pointであり、pluginの
-登録機構ではありません。consumerがSupabaseを使う場合、`supabase:migrations:check`
-（DB / Docker / Supabase local stackを起動する他のcheckより前）に続けて
-`supabase:types:check`を`verify:profile`から呼び出し、typesの再生成後に生成ファイルの
-driftをnon-zeroで検知するcommandにします。DB/RLS testがあるconsumerは同じ
-`verify:profile`からそのtest commandを呼び出します。Next.js 16.3以降を使うconsumerは
-同じ`verify:profile`から`agent-rules:check`を呼び出します（16.3未満では対象外のため
-呼び出しません。本節冒頭の「該当しないcommandは含めない」原則の具体例です）。
-local Supabase stackを起動するconsumerは、同じ`verify:profile`から
-`client-role-privileges:check`（DB / Docker / Supabase local stackを起動する他の
-checkより後）も呼び出し、残存privilegeの回帰をblockingで検知します。
+`verify`は、GitHub上でも失敗domainを切り分けられるよう、次の3つのresponsibility lane
+の合成として定義します。
+
+- `verify:code` — format / lint / typecheck / unit test、`foundation:check`、および
+  DB / Docker / Supabase local stackを起動しないprofile check
+- `verify:build` — application build
+- `verify:database` — local Supabase runtimeを必要とするprofile check
+
+profile固有の追加は、DB / Docker / Supabase local stackを起動するかどうかで
+`verify:profile:code`（起動しない）と`verify:profile:database`（起動する）のどちらかに
+置きます。これはextension pointであり、pluginの登録機構ではありません。
+consumerがSupabaseを使う場合、`supabase:migrations:check`はfilesystemだけで完結する
+ため`verify:profile:code`から呼び出します。`supabase:types:check`（typesの再生成後に
+生成ファイルのdriftをnon-zeroで検知するcommand）はlocal Supabase runtimeを必要とする
+ため`verify:profile:database`から呼び出します。DB/RLS testがあるconsumerも同じ
+`verify:profile:database`からそのtest commandを呼び出します。Next.js 16.3以降を使う
+consumerは`agent-rules:check`（filesystemだけで完結）を`verify:profile:code`から
+呼び出します（16.3未満では対象外のため呼び出しません。本節冒頭の「該当しない
+commandは含めない」原則の具体例です）。local Supabase stackを起動するconsumerは、
+`verify:profile:database`から`client-role-privileges:check`（DB / Docker / Supabase
+local stackを起動する他のcheckより後）も呼び出し、残存privilegeの回帰をblockingで
+検知します。
 
 ```json
 {
   "scripts": {
     "client-role-privileges:check": "node .ai-dev-foundation/quality/check-client-role-table-privileges.mjs",
-    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
+    "verify:profile:code": "npm run agent-rules:check && npm run supabase:migrations:check",
+    "verify:profile:database": "npm run supabase:types:check && npm run test:rls && npm run client-role-privileges:check",
+    "verify:code": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run foundation:check && npm run verify:profile:code",
+    "verify:build": "npm run build",
+    "verify:database": "npm run verify:profile:database",
+    "verify": "npm run verify:code && npm run verify:build && npm run verify:database"
   }
 }
 ```
 
-上記のうちconsumerに該当しないcommandは`verify:profile`に含めません。空の成功commandを
-置かず、必要になった時点で実行可能なcheckとして追加します。
+上記のうちconsumerに該当しないcommandは`verify:profile:code` / `verify:profile:database`
+に含めません。空の成功commandを置かず、必要になった時点で実行可能なcheckとして追加
+します。該当するprofile checkが1つも無いlaneはそのlane自体を`verify`から省略します
+（例えばSupabaseを使わないconsumerは`verify:database`を持たず、`verify`は
+`verify:code`と`verify:build`だけを呼び出します）。
 
 `jscpd`や`knip`などのノイズを含み得るcheckはadvisoryです。blocking quality floorには
 含めません。
+
+### GitHub Actions verification lane（reference、non-normative）
+
+consumerのGitHub Actions上のPR checksを`verify`単一jobとして直列実行すると、format /
+lint / typecheck、build、DB runtimeというfailure domainがすべて1つのcheck結果へ
+collapseし、どの責務が落ちたか一目で切り分けにくくなります。responsibilityごとに
+独立したjobへ分けたいconsumerのための、non-normativeなreference exampleを
+`profiles/next-supabase/ci/verify-lanes.example.yml`に置きます。このfileは`sync` /
+`bootstrap-next-supabase.mjs`のどちらからもconsumerへ自動配布されません。必要な
+consumerが手動でcopy/adaptしてください。
+
+このreferenceは`verify:code` / `verify:build` / `verify:database`をそれぞれ独立した
+GitHub Actions jobとして実行し、job名を`Verify / Code`・`Verify / Build`・
+`Verify / Database`とします。consumer local/agent向けの一括`verify`はこのreferenceの
+有無にかかわらず維持され、このreferenceはGitHub Actions上の実行を3つのlaneへ分ける
+だけで、それ以上の細粒度checkへ分裂させることを意図しません。Supabaseを使わず
+`verify:database`が空のconsumerは、`Verify / Database` job自体をreferenceから
+削除してください。
 
 ## Worktree/checkoutをまたぐlocal Supabase stack
 
@@ -316,7 +352,8 @@ containers / volumes等）を共有する場合、そのstackはshared local sta
 - DB / RLS / auth integration test
 - schema由来のgenerated types生成、およびdrift verification
 - `client-role-privileges:check`（client-role table privilege guardrail）
-- 上記のいずれかを内包する`verify:profile`
+- 上記のいずれかを内包する`verify:profile:database`
+- 上記のいずれかを内包する`verify:database`
 - 上記のいずれかを内包するfull `verify`
 
 shared local stackに対して上記を実行するagentは、少なくとも次を満たします。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -440,3 +440,42 @@ capability/profile 側で再検証可能な observed evidence として扱いま
 同じ Review Contract を使って Selection / Completion / Acquisition / Validity /
 Resolution を人手で判定できることを確認します。この skill の範囲では pilot 自体を
 実施・拡張せず、contract を適用できる準備を整えるところまでとします。
+
+## Manual-on-demand review runtime preference（current runtime preference、Issue #59）
+
+上記 Manual review pilot が確認した準備を踏まえた、current environment における
+runtime preference です。Kernel の provider-neutral な Selection Contract / required
+review 数を置換せず、task risk / artifact / capability による別 Selection を引き続き
+許容します。特定 provider を Kernel へ固定するものではありません。
+
+複数 perspective が必要な通常の Executable review における current runtime
+preference は次のとおりです。
+
+- Claude が selection された場合は、上記「Claude formal acquisition routing」の
+  GitHub-native `@claude` preferred route を使います。
+- CodeRabbit の manual acquisition（明示的な `@coderabbitai review` 系 command）を、
+  複数 perspective が必要な場合の primary candidate の一つとして扱ってよいです。
+  CodeRabbit automatic review が無効化されている場合、その非参加を `0 findings` へ
+  変換しないことは Acquisition & Validity Contract（`policy/core.md`）どおりです。
+- CodeRabbit acquisition が quota / rate limit / unavailable、または structurally
+  invalid（intended target を review していない等）で completion evidence を得られ
+  ない場合、その run は Failure / retry（`policy/core.md`）に従い `unknown` または
+  `failure` として扱い、success や `0 findings` へ変換しません。この場合、alternate
+  reviewer として Codex の manual acquisition（明示的な `@codex review` 系 command）を
+  選択でき、Selection Contract を明示的に amend した上でその run を required/expected
+  member として扱えます。amend したことと根拠は他の Selection 記録と同様に残します。
+- Codex の automatic（PR-open）review を、current runtime preference の default /
+  baseline として前提にしません。Selection で明示的に Codex（automatic / manual の
+  いずれも）を選ぶこと自体は禁止しません。
+
+Codex Cloud Review の PR-open automatic review が有効かどうかは、多くの場合
+repository code だけでは完結しない operator/account 側の設定である observed
+evidence があります。この skill および Foundation は、review 対象 repository の
+operator がこの automatic review 設定を変更したことを、repository code から完了した
+ものとして偽装しません。この設定変更が必要な場合は、implementation agent の
+repository write scope とは別の operator action として扱います。
+
+上記はいずれも observed / current な runtime preference であり、provider の恒久仕様
+にも、required reviewer 数を常に固定数（例えば 2）へ固定する mandatory pairing にも
+昇格させません。Selection Contract の risk-based reviewer 数と capability validity は
+この節によって変更されません。

--- a/test/fixtures/consumer/package.json
+++ b/test/fixtures/consumer/package.json
@@ -15,7 +15,11 @@
     "agent-rules:check": "node .ai-dev-foundation/quality/check-agent-rules-disabled.mjs",
     "supabase:migrations:check": "node .ai-dev-foundation/quality/check-migration-version-collision.mjs",
     "supabase:types:check": "node scripts/check-generated-supabase-types.mjs",
-    "verify:profile": "npm run agent-rules:check && npm run supabase:migrations:check && npm run supabase:types:check",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run build && npm run foundation:check && npm run verify:profile"
+    "verify:profile:code": "npm run agent-rules:check && npm run supabase:migrations:check",
+    "verify:profile:database": "npm run supabase:types:check",
+    "verify:code": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run foundation:check && npm run verify:profile:code",
+    "verify:build": "npm run build",
+    "verify:database": "npm run verify:profile:database",
+    "verify": "npm run verify:code && npm run verify:build && npm run verify:database"
   }
 }

--- a/test/quality-profile-worktree-isolation.test.mjs
+++ b/test/quality-profile-worktree-isolation.test.mjs
@@ -30,7 +30,8 @@ test("Next.js + Supabase quality profile defines shared local stack exclusive-re
     "migration apply / rollback相当のoperation",
     "DB / RLS / auth integration test",
     "schema由来のgenerated types生成、およびdrift verification",
-    "`verify:profile`",
+    "`verify:profile:database`",
+    "`verify:database`",
     "full `verify`",
   ]) {
     assert.ok(readme.includes(operation), `missing exclusive-resource operation: ${operation}`);

--- a/test/review-runtime-preference.test.mjs
+++ b/test/review-runtime-preference.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Issue #59: stage-tracker #118 canary promotion (Verify lane split,
+// CodeRabbit misleading-status removal) and manual-on-demand review runtime
+// preference (Claude GitHub-native + CodeRabbit manual primary, Codex manual
+// on-demand/fallback, Codex automatic no longer assumed as default baseline).
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function stripWhitespace(text) {
+  return text.replace(/\s+/g, "");
+}
+
+function containsText(haystack, needle) {
+  return stripWhitespace(haystack).includes(stripWhitespace(needle));
+}
+
+test("root .coderabbit.yaml disables automatic review and every misleading progress/status surface", async () => {
+  const config = await readFile(path.join(root, ".coderabbit.yaml"), "utf8");
+
+  assert.match(config, /auto_review:\s*\n\s*enabled:\s*false/);
+  assert.match(config, /review_status:\s*false/);
+  assert.match(config, /review_progress:\s*false/);
+  assert.match(config, /commit_status:\s*false/);
+});
+
+test("review-code.md materializes CodeRabbit manual acquisition as a primary candidate without hardcoding a mandatory pairing", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  assert.ok(reviewCode.includes("## Manual-on-demand review runtime preference"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "CodeRabbitのmanual acquisition（明示的な`@coderabbitai review`系command）を、複数perspectiveが必要な場合のprimary candidateの一つとして扱ってよいです。",
+    ),
+  );
+
+  // CodeRabbit rate-limit/unavailable/invalid acquisition must stay
+  // unknown/failure, never converted to success or 0 findings.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "CodeRabbit acquisitionがquota / rate limit / unavailable、またはstructurally invalid（intended targetをreviewしていない等）でcompletion evidenceを得られない場合、そのrunはFailure / retry（`policy/core.md`）に従い`unknown`または`failure`として扱い、successや`0findings`へ変換しません。",
+    ),
+  );
+
+  // Codex manual is an explicit fallback that requires an explicit Selection
+  // amendment, not a silent substitution.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "alternate reviewerとしてCodexのmanual acquisition（明示的な`@codex review`系command）を選択でき、Selection Contractを明示的にamendした上でそのrunをrequired/expected memberとして扱えます。",
+    ),
+  );
+
+  // Codex automatic (PR-open) review is no longer assumed as the default
+  // baseline runtime preference, but Selection may still choose Codex.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Codexのautomatic（PR-open）reviewを、current runtime preferenceのdefault / baselineとして前提にしません。Selectionで明示的にCodex（automatic / manualのいずれも）を選ぶこと自体は禁止しません。",
+    ),
+  );
+
+  // Operator boundary: repo code must not claim to have completed an
+  // account/UI-level automatic-review setting change.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "この skill および Foundation は、review 対象 repository の operator がこの automatic review 設定を変更したことを、repository code から完了したものとして偽装しません。",
+    ),
+  );
+
+  // Must not upgrade this to a permanent Kernel mandate (e.g. fixed count 2).
+  assert.ok(
+    containsText(
+      reviewCode,
+      "required reviewer数を常に固定数（例えば2）へ固定するmandatory pairingにも昇格させません。",
+    ),
+  );
+});
+
+test("policy/core.md Kernel stays provider-neutral after the Issue #59 runtime preference update", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("Next.js + Supabase profile promotes a Code/Build/Database Verify lane reference while keeping the one-command verify contract", async () => {
+  const readme = await readFile(
+    path.join(root, "profiles", "next-supabase", "quality", "README.md"),
+    "utf8",
+  );
+
+  assert.ok(readme.includes("## `verify` への集約と responsibility lane"));
+  assert.ok(readme.includes("### GitHub Actions verification lane"));
+
+  // The local/agent one-command contract composes the three lanes, in order.
+  assert.ok(
+    containsText(
+      readme,
+      '"verify": "npm run verify:code && npm run verify:build && npm run verify:database"',
+    ),
+    "the profile's suggested verify script must remain a single command composing the three lanes",
+  );
+  assert.ok(containsText(readme, '"verify:build": "npm run build"'));
+
+  // Reference workflow is documented as non-normative and not auto-distributed.
+  assert.ok(readme.includes("profiles/next-supabase/ci/verify-lanes.example.yml"));
+  assert.ok(
+    containsText(
+      readme,
+      "このfileは`sync` / `bootstrap-next-supabase.mjs`のどちらからもconsumerへ自動配布されません。",
+    ),
+  );
+
+  // Must not fragment into more than the three named lanes.
+  assert.ok(containsText(readme, "`Verify / Code`・`Verify / Build`・`Verify / Database`"));
+});
+
+test("the reference Verify-lane workflow example defines exactly the three named jobs and is not part of the bootstrapped quality directory", async () => {
+  const workflow = await readFile(
+    path.join(root, "profiles", "next-supabase", "ci", "verify-lanes.example.yml"),
+    "utf8",
+  );
+
+  for (const jobName of ["Verify / Code", "Verify / Build", "Verify / Database"]) {
+    assert.ok(workflow.includes(`name: ${jobName}`), `missing job: ${jobName}`);
+  }
+  const jobNameCount = [...workflow.matchAll(/^\s{4}name: Verify \/ /gm)].length;
+  assert.equal(jobNameCount, 3, "must not fragment into more than the three documented lanes");
+
+  assert.ok(workflow.includes("npm run verify:code"));
+  assert.ok(workflow.includes("npm run verify:build"));
+  assert.ok(workflow.includes("npm run verify:database"));
+
+  // tooling/lib.mjs's qualityProfileSourceDirectory is scoped to
+  // profiles/next-supabase/quality only, so this example must live outside
+  // it to stay non-auto-distributed, per the profile README's own claim.
+  const lib = await readFile(path.join(root, "tooling", "lib.mjs"), "utf8");
+  assert.match(lib, /qualityProfileSourceDirectory\s*=\s*path\.join\(foundationRoot,\s*"profiles",\s*"next-supabase",\s*"quality"\)/);
+});


### PR DESCRIPTION
## Context

Closes #59（Issue本文をcanonical Task Contractとする）。fresh取得したexecution
checkpoint（main `05d377e`、open PR無し、#62/PR #63 landed済み）を起点に実装した。

stage-tracker#118 landing後の代表的な通常PR（#119, #120, #122, #126, #127, #129,
#130, #132）をfresh確認したpost-landing canary evidence:

- `Verify / Code`（~45-55s）・`Verify / Build`（~40-50s）・`Verify / Database`
  （~4-5min）の3 laneへ分離後、failure domainが一目で切り分けられる状態を確認。
  Database laneが支配的なwall-clockのため、並列化後もtotal wall-clockは旧単一
  `verify` job（PR #120実測 5m23s）と同程度かそれ以上で、overheadの明確な悪化は
  観測されなかった。
- PR #120（#118 landing前、旧`.coderabbit.yaml`）では
  `CodeRabbit pass "Review skipped: automatic reviews are disabled"`という
  misleading green statusが残っていたが、`review_progress: false` /
  `commit_status: false`追加後の#122以降のPRではこのcheck自体が出現しなくなった
  ことを確認（"CI green != reviewed"原則に沿う改善）。
- checks UIはVercel 2件 + Verify 3 laneで、10個以上への細粒度分裂は無い。
- 一方、config変更後にmanual `@coderabbitai review`が実際にtriggerされた
  representative PRはstage-tracker側で見つからず、manual acquisition capability
  の維持は本PR自身のreview acquisitionで検証する（下記）。

このcanary evidenceに基づき、trade-off込みでpromotionを支持すると判断した。

## 実装

- `.coderabbit.yaml` — `review_progress: false` / `commit_status: false`を追加し、
  stage-tracker#118と同じmisleading status removalをFoundation自身へ反映。
  `auto_review.enabled: false`と`review_status: false`は既存のまま維持。
- `profiles/next-supabase/quality/README.md` — `verify`を
  `verify:code && verify:build && verify:database`の3 lane合成として再定義。
  profile拡張点も`verify:profile:code`（DB runtime不要）/
  `verify:profile:database`（local Supabase runtime必要）へ分割し、
  migration collision checkはCode、Supabase types/RLS/client-role-privileges
  checkはDatabaseへ帰属させた。consumer local/agent向けone-command `verify`
  contractは維持。該当しないlaneは`verify`から省略する原則も明記。
- `profiles/next-supabase/ci/verify-lanes.example.yml` — `Verify / Code` /
  `Verify / Build` / `Verify / Database`の3 job reference workflow（新規、
  non-normative）。`sync` / `bootstrap-next-supabase.mjs`のどちらからも
  自動配布されないことをtestで担保。
- `skills/review-code.md` — 「Manual-on-demand review runtime preference」節を
  追加。Claude GitHub-native（既存） + CodeRabbit manualをprimary candidateとし、
  CodeRabbit rate-limit/unavailable/invalid時はSelection Contractを明示的に
  amendしてCodex manual acquisitionへfallbackできることを記録。Codex automatic
  reviewはdefault baselineの前提から外すが、Selectionでの明示的採用や
  reviewer pool除外は行わない。Codex Cloud ReviewのPR-open automatic設定は
  多くの場合operator/account側の設定であり、repository codeから完了を
  偽装しないoperator boundaryも明記。`policy/core.md` Kernelへはprovider名を
  追加していない。
- `test/review-runtime-preference.test.mjs`（新規） — 上記5点をdeterministicに
  guard: `.coderabbit.yaml`の4 key、review-code.mdのruntime preference文言、
  policy/core.mdのprovider-neutrality維持、profile READMEのlane合成と
  one-command契約、reference workflowの3 job限定と非自動配布。
- `test/consumer-verify.test.mjs` / `test/quality-profile-worktree-isolation.test.mjs`
  — verify lane再構成に合わせて既存invariant（migration checkのDB前実行順序、
  shared local stackのexclusive resource列挙）を新しいscript構成へ追従。
- fixture consumer（`test/fixtures/consumer/`）— `bootstrap-next-supabase.mjs` /
  `sync.mjs`で再展開し、profile README・review-code.md skill bundleのdriftを解消。

## #62 helper canary（review-evidence.mjs）

このPR自身のreview acquisitionで`tooling/review-evidence.mjs`を実用し、manual
multi-surface bookkeepingの削減・false-zero防止・frictionを観測する
（Issue #59 Required work 1 / execution checkpoint参照）。観測結果はPR/Issue上に
別途記録する。

## Verification

- `npm test`: 125 pass / 1 pre-existing skip（Windows symlink作成不可によるEPERM、
  本変更と無関係）/ 0 fail
- `npm run test:guardrails`: 8 guardrail fixture green

## Out of scope（Issue #59 Scope節に準拠）

provider固定順序のKernel化、全PR Claude+CodeRabbit mandatory化、Codexの
reviewer pool除外、release/repin、stage-tracker側の変更は行っていない。

merge-readyで停止し、authority escalationはしない（今回はimplementation ->
review -> merge-ready判定 -> merge/AC/Issue closeまでのauthorityあり）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate Code, Build, and Database verification lanes for clearer validation workflows.
  * Added an optional GitHub Actions workflow example covering all three verification lanes.
* **Documentation**
  * Updated setup guidance to reflect the new verification commands and Supabase database checks.
  * Documented current manual review runtime preferences and provider fallback behavior.
* **Configuration**
  * Disabled automated review progress and commit status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->