### PR TITLE
Review protocol thinning: review-evidence helperへmechanical acquisition bookkeepingを移す (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ item detail を含みません。
   head（`pr_metadata.head_sha`）のみを対象とします。reviewer が ancestor
   SHA の status/check にのみ review participation や finding を残していた
   場合、そのevidenceはこの snapshot に含まれません。
-- `check_runs` は `name` / `status` / `conclusion` / `started_at` /
-  `completed_at` / `locator`（`html_url`）のみを保持します。check run 本体の
+- `check_runs` は `name` / `status` / `conclusion` / `app_slug`（投稿元
+  GitHub App の slug） / `started_at` / `completed_at` /
+  `locator`（`html_url`）のみを保持します。check run 本体の
   `output.summary` / `output.text` や line-level annotation は取得しません。
 - `commit_status` は GitHub の combined-status endpoint（`context` ごとの
   最新 status のみを返す）を使います。同一 `(headSha, context)` に対して

--- a/README.md
+++ b/README.md
@@ -105,16 +105,19 @@ item detail を含みません。
   head（`pr_metadata.head_sha`）のみを対象とします。reviewer が ancestor
   SHA の status/check にのみ review participation や finding を残していた
   場合、そのevidenceはこの snapshot に含まれません。
-- `check_runs` は `name` / `status` / `conclusion` / `app_slug`（投稿元
-  GitHub App の slug） / `started_at` / `completed_at` /
-  `locator`（`html_url`）のみを保持します。check run 本体の
-  `output.summary` / `output.text` や line-level annotation は取得しません。
+- `check_runs` は GitHub API の既定 filter（`latest`）で取得するため、
+  同一 check が再実行されている場合、最新 run 以外は snapshot に含まれ
+  ません。また `name` / `status` / `conclusion` / `started_at` /
+  `completed_at` / `locator`（`html_url`）のみを保持し、check run 本体の
+  `output.summary` / `output.text` や line-level annotation、投稿元 App の
+  識別情報は取得しません。
 - `commit_status` は GitHub の combined-status endpoint（`context` ごとの
   最新 status のみを返す）を使います。同一 `(headSha, context)` に対して
   reviewer が finding を含む status を投稿した後、同じ context が別の
   status で上書きされた場合、その以前の status はこの snapshot から
   復元できません。この場合も `fetch_status` は `fetched`（成功）を報告する
-  ため、`fetch_status` の値だけではこの欠落を検知できません。
+  ため、`fetch_status` の値だけではこの欠落を検知できません。`commit_status`
+  も投稿者（`creator`）を保持しません。
 
 この helper は GitHub durable surface の mechanical acquisition に限定され、
 review completion / target Validity / finding triage / merge-readiness の

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ item detail を含みません。
 - `check_runs` は `name` / `status` / `conclusion` / `started_at` /
   `completed_at` / `locator`（`html_url`）のみを保持します。check run 本体の
   `output.summary` / `output.text` や line-level annotation は取得しません。
+- `commit_status` は GitHub の combined-status endpoint（`context` ごとの
+  最新 status のみを返す）を使います。同一 `(headSha, context)` に対して
+  reviewer が finding を含む status を投稿した後、同じ context が別の
+  status で上書きされた場合、その以前の status はこの snapshot から
+  復元できません。この場合も `fetch_status` は `fetched`（成功）を報告する
+  ため、`fetch_status` の値だけではこの欠落を検知できません。
 
 この helper は GitHub durable surface の mechanical acquisition に限定され、
 review completion / target Validity / finding triage / merge-readiness の

--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ GitHub token は `--token`、`GH_TOKEN`、`GITHUB_TOKEN`、`gh auth token` の�
 surfaceの `0` へ変換しません。paginationが途中で失敗した場合は `partial`
 として明示し、取得できたitemsはpartialなcountのまま返します。
 
+review completion / target Validity / finding triage / Resolution 等の
+判定材料として使う fresh acquisition（formal acquisition）では `--json`
+を使ってください。`--json` 無しの human-readable summary は surface ごとの
+count と fetch state のみを表示し、判定に必要な actor / body / locator 等の
+item detail を含みません。
+
+**現在の coverage の既知の限界**（呼び出し側は、この範囲外の evidence が
+必要な場合、Review Adapter boundary に従って追加で fresh acquisition する
+必要があります）:
+
+- `commit_status` / `check_runs` は、この snapshot が取得した時点の PR
+  head（`pr_metadata.head_sha`）のみを対象とします。reviewer が ancestor
+  SHA の status/check にのみ review participation や finding を残していた
+  場合、そのevidenceはこの snapshot に含まれません。
+- `check_runs` は `name` / `status` / `conclusion` / `started_at` /
+  `completed_at` / `locator`（`html_url`）のみを保持します。check run 本体の
+  `output.summary` / `output.text` や line-level annotation は取得しません。
+
 この helper は GitHub durable surface の mechanical acquisition に限定され、
 review completion / target Validity / finding triage / merge-readiness の
 判定は行いません。それらは `policy/core.md` の Review Protocol と

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -336,20 +336,16 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
 - `collectOutputs()`: GitHub 上の durable review surface の mechanical
-  acquisition は、ai-dev-foundation checkout を利用できる場合（例:
-  `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
-  `tooling/review-evidence.mjs --json`（Issue #62）に置き換えます。
-  `--json` 無しの human summary は count / fetch state のみで、
-  Completion / Validity / Resolution / triage の判定に必要な actor /
-  body / locator を含みません。fetch が failed / partial な場合は
-  empty や success へ変換しません。commit status / check runs は
-  helper では現在の head SHA のみが対象のため、ancestor target の
-  status/check は helper 対象外として扱います。Completion / Validity /
-  Resolution / triage の semantic judgment は helper ではなく本
-  Contract に従い agent が行います。helper が対象としない surface
-  （上記 ancestor target 分の status/check を含む。他は Review Adapter
-  boundary（`policy/core.md`）参照）は、この provider で確認できる
-  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  acquisition は、ai-dev-foundation checkout を利用できる場合、
+  `tooling/review-evidence.mjs --json`（Issue #62、使い方・現在の
+  coverage は同 tool の README 参照）に置き換えます。fetch が failed /
+  partial な場合、または snapshot が review target に必要な evidence を
+  カバーしない場合は、Review Adapter boundary（`policy/core.md`）に
+  従い不足分を fresh acquisition します。empty や success への変換は
+  しません。Completion / Validity / Resolution / triage の semantic
+  judgment は helper ではなく本 Contract に従い agent が行います。
+  helper を利用できない場合は、この provider で確認できる surface を
+  確認し、内容の有無にかかわらず「どの surface を確認したか」を
   記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -335,9 +335,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
-  inline/thread comment、review submission/summary、status/check、必要なら
-  workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
+- `collectOutputs()`: GitHub 上の durable review surface（Conversation
+  comment、review submission、inline review comment、review thread の
+  resolved 状態、combined commit status、check runs）については、
+  ai-dev-foundation checkout を利用できる場合（この repository 自身の
+  review 等）、`tooling/review-evidence.mjs`（Issue #62）で 1 command
+  fresh に取得でき、surface ごとの fetch state と pagination 完了を機械的に
+  報告します。この helper は review completion / target Validity /
+  finding triage を判定しないため、判定は本 Contract に従い agent が
+  行います。helper が利用できない場合、または helper が対象としない
+  surface（workflow log 等）については、この provider で確認できる
+  surface（top-level PR comment、inline/thread comment、review
+  submission/summary、status/check、必要なら workflow log、edited
+  comment）を確認し、内容の有無にかかわらず「どの surface を
   確認したか」を記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -335,26 +335,17 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: 収集対象の surface は Review Adapter boundary
-  （`policy/core.md`）が capability として定義するもの（top-level
-  comment、inline/thread、review submission、status/check、workflow
-  log、edited comment 等）です。このうち GitHub REST/GraphQL で取得
-  できる surface（top-level comment = Conversation comment、
-  inline/thread = inline review comment と review thread の resolved
-  状態、review submission、status/check = combined commit status と
-  check runs）は、ai-dev-foundation checkout（この repository 自身の
-  review、または consumer が保持する pinned Foundation checkout ——
-  実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
-  あります）を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）
-  の 1 command 実行に置き換え、surface ごとの fetch state と pagination
-  完了を機械的に取得します。これらの surface を agent が個別に見て回って
-  「確認したか」を手作業で記録する必要はありません。この helper は
-  review completion / target Validity / finding triage を判定しないため、
-  判定は本 Contract に従い agent が行います。
-  helper が利用できない、または対象としない残りの surface（workflow
-  log、edited comment）については、上記 capability のうち該当する
-  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
-  記録します。この surface から `policy/core.md` の
+- `collectOutputs()`: GitHub 上の durable review surface の mechanical
+  acquisition は、ai-dev-foundation checkout を利用できる場合（例:
+  `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
+  `tooling/review-evidence.mjs`（Issue #62）に置き換えます。fetch が
+  failed / partial な場合は empty や success へ変換しません。
+  Completion / Validity / Resolution / triage の semantic judgment は
+  helper ではなく本 Contract に従い agent が行います。helper が対象と
+  しない surface（Review Adapter boundary（`policy/core.md`）参照）は、
+  この provider で確認できる surface を確認し、内容の有無にかかわらず
+  「どの surface を確認したか」を記録します。この surface から
+  `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -338,14 +338,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: GitHub 上の durable review surface の mechanical
   acquisition は、ai-dev-foundation checkout を利用できる場合（例:
   `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
-  `tooling/review-evidence.mjs`（Issue #62）に置き換えます。fetch が
-  failed / partial な場合は empty や success へ変換しません。
-  Completion / Validity / Resolution / triage の semantic judgment は
-  helper ではなく本 Contract に従い agent が行います。helper が対象と
-  しない surface（Review Adapter boundary（`policy/core.md`）参照）は、
-  この provider で確認できる surface を確認し、内容の有無にかかわらず
-  「どの surface を確認したか」を記録します。この surface から
-  `policy/core.md` の
+  `tooling/review-evidence.mjs --json`（Issue #62）に置き換えます。
+  `--json` 無しの human summary は count / fetch state のみで、
+  Completion / Validity / Resolution / triage の判定に必要な actor /
+  body / locator を含みません。fetch が failed / partial な場合は
+  empty や success へ変換しません。commit status / check runs は
+  helper では現在の head SHA のみが対象のため、ancestor target の
+  status/check は helper 対象外として扱います。Completion / Validity /
+  Resolution / triage の semantic judgment は helper ではなく本
+  Contract に従い agent が行います。helper が対象としない surface
+  （上記 ancestor target 分の status/check を含む。他は Review Adapter
+  boundary（`policy/core.md`）参照）は、この provider で確認できる
+  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -335,20 +335,25 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: GitHub 上の durable review surface（Conversation
-  comment、review submission、inline review comment、review thread の
-  resolved 状態、combined commit status、check runs）については、
-  ai-dev-foundation checkout を利用できる場合（この repository 自身の
-  review 等）、`tooling/review-evidence.mjs`（Issue #62）で 1 command
-  fresh に取得でき、surface ごとの fetch state と pagination 完了を機械的に
-  報告します。この helper は review completion / target Validity /
-  finding triage を判定しないため、判定は本 Contract に従い agent が
-  行います。helper が利用できない場合、または helper が対象としない
-  surface（workflow log 等）については、この provider で確認できる
-  surface（top-level PR comment、inline/thread comment、review
-  submission/summary、status/check、必要なら workflow log、edited
-  comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。この surface から `policy/core.md` の
+- `collectOutputs()`: 収集対象の surface は Review Adapter boundary
+  （`policy/core.md`）が capability として定義するもの（top-level
+  comment、inline/thread、review submission、status/check、workflow
+  log、edited comment 等）です。このうち GitHub 上の durable review
+  surface（Conversation comment、review submission、inline review
+  comment、review thread の resolved 状態、combined commit status、
+  check runs）は、ai-dev-foundation checkout（この repository 自身の
+  review、または consumer が保持する pinned Foundation checkout ——
+  実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
+  あります）を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）
+  の 1 command 実行に置き換え、surface ごとの fetch state と pagination
+  完了を機械的に取得します。これらの surface を agent が個別に見て回って
+  「確認したか」を手作業で記録する必要はありません。この helper は
+  review completion / target Validity / finding triage を判定しないため、
+  判定は本 Contract に従い agent が行います。
+  helper が利用できない、または対象としない残りの surface（workflow
+  log、edited comment 等）については、上記 capability のうち該当する
+  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -338,9 +338,10 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: 収集対象の surface は Review Adapter boundary
   （`policy/core.md`）が capability として定義するもの（top-level
   comment、inline/thread、review submission、status/check、workflow
-  log、edited comment 等）です。このうち GitHub 上の durable review
-  surface（Conversation comment、review submission、inline review
-  comment、review thread の resolved 状態、combined commit status、
+  log、edited comment 等）です。このうち GitHub REST/GraphQL で取得
+  できる surface（top-level comment = Conversation comment、
+  inline/thread = inline review comment と review thread の resolved
+  状態、review submission、status/check = combined commit status と
   check runs）は、ai-dev-foundation checkout（この repository 自身の
   review、または consumer が保持する pinned Foundation checkout ——
   実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
@@ -351,7 +352,7 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   review completion / target Validity / finding triage を判定しないため、
   判定は本 Contract に従い agent が行います。
   helper が利用できない、または対象としない残りの surface（workflow
-  log、edited comment 等）については、上記 capability のうち該当する
+  log、edited comment）については、上記 capability のうち該当する
   surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
   記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -96,10 +96,8 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
-   GitHub 上の durable review surface の取得手順は `skills/review-code.md` の
-   Adapter boundary（`collectOutputs()`）に従います。ai-dev-foundation
-   checkout を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）で
-   機械的に取得できます。
+   GitHub 上の durable review surface の取得は `skills/review-code.md` の
+   Adapter boundary（`collectOutputs()`）に従います。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -96,8 +96,10 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
-   GitHub 上の durable review surface の取得は `skills/review-code.md` の
-   Adapter boundary（`collectOutputs()`）に従います。
+   GitHub 上の durable review surface の取得は、Foundation リポジトリの
+   `skills/review-code.md`（consumer には
+   `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
+   boundary（`collectOutputs()`）に従います。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -96,6 +96,10 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
+   GitHub 上の durable review surface の取得手順は `skills/review-code.md` の
+   Adapter boundary（`collectOutputs()`）に従います。ai-dev-foundation
+   checkout を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）で
+   機械的に取得できます。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -336,20 +336,16 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
 - `collectOutputs()`: GitHub 上の durable review surface の mechanical
-  acquisition は、ai-dev-foundation checkout を利用できる場合（例:
-  `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
-  `tooling/review-evidence.mjs --json`（Issue #62）に置き換えます。
-  `--json` 無しの human summary は count / fetch state のみで、
-  Completion / Validity / Resolution / triage の判定に必要な actor /
-  body / locator を含みません。fetch が failed / partial な場合は
-  empty や success へ変換しません。commit status / check runs は
-  helper では現在の head SHA のみが対象のため、ancestor target の
-  status/check は helper 対象外として扱います。Completion / Validity /
-  Resolution / triage の semantic judgment は helper ではなく本
-  Contract に従い agent が行います。helper が対象としない surface
-  （上記 ancestor target 分の status/check を含む。他は Review Adapter
-  boundary（`policy/core.md`）参照）は、この provider で確認できる
-  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  acquisition は、ai-dev-foundation checkout を利用できる場合、
+  `tooling/review-evidence.mjs --json`（Issue #62、使い方・現在の
+  coverage は同 tool の README 参照）に置き換えます。fetch が failed /
+  partial な場合、または snapshot が review target に必要な evidence を
+  カバーしない場合は、Review Adapter boundary（`policy/core.md`）に
+  従い不足分を fresh acquisition します。empty や success への変換は
+  しません。Completion / Validity / Resolution / triage の semantic
+  judgment は helper ではなく本 Contract に従い agent が行います。
+  helper を利用できない場合は、この provider で確認できる surface を
+  確認し、内容の有無にかかわらず「どの surface を確認したか」を
   記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -335,9 +335,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: この provider で確認できる surface（top-level PR comment、
-  inline/thread comment、review submission/summary、status/check、必要なら
-  workflow log、edited comment）を確認し、内容の有無にかかわらず「どの surface を
+- `collectOutputs()`: GitHub 上の durable review surface（Conversation
+  comment、review submission、inline review comment、review thread の
+  resolved 状態、combined commit status、check runs）については、
+  ai-dev-foundation checkout を利用できる場合（この repository 自身の
+  review 等）、`tooling/review-evidence.mjs`（Issue #62）で 1 command
+  fresh に取得でき、surface ごとの fetch state と pagination 完了を機械的に
+  報告します。この helper は review completion / target Validity /
+  finding triage を判定しないため、判定は本 Contract に従い agent が
+  行います。helper が利用できない場合、または helper が対象としない
+  surface（workflow log 等）については、この provider で確認できる
+  surface（top-level PR comment、inline/thread comment、review
+  submission/summary、status/check、必要なら workflow log、edited
+  comment）を確認し、内容の有無にかかわらず「どの surface を
   確認したか」を記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -335,26 +335,17 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: 収集対象の surface は Review Adapter boundary
-  （`policy/core.md`）が capability として定義するもの（top-level
-  comment、inline/thread、review submission、status/check、workflow
-  log、edited comment 等）です。このうち GitHub REST/GraphQL で取得
-  できる surface（top-level comment = Conversation comment、
-  inline/thread = inline review comment と review thread の resolved
-  状態、review submission、status/check = combined commit status と
-  check runs）は、ai-dev-foundation checkout（この repository 自身の
-  review、または consumer が保持する pinned Foundation checkout ——
-  実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
-  あります）を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）
-  の 1 command 実行に置き換え、surface ごとの fetch state と pagination
-  完了を機械的に取得します。これらの surface を agent が個別に見て回って
-  「確認したか」を手作業で記録する必要はありません。この helper は
-  review completion / target Validity / finding triage を判定しないため、
-  判定は本 Contract に従い agent が行います。
-  helper が利用できない、または対象としない残りの surface（workflow
-  log、edited comment）については、上記 capability のうち該当する
-  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
-  記録します。この surface から `policy/core.md` の
+- `collectOutputs()`: GitHub 上の durable review surface の mechanical
+  acquisition は、ai-dev-foundation checkout を利用できる場合（例:
+  `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
+  `tooling/review-evidence.mjs`（Issue #62）に置き換えます。fetch が
+  failed / partial な場合は empty や success へ変換しません。
+  Completion / Validity / Resolution / triage の semantic judgment は
+  helper ではなく本 Contract に従い agent が行います。helper が対象と
+  しない surface（Review Adapter boundary（`policy/core.md`）参照）は、
+  この provider で確認できる surface を確認し、内容の有無にかかわらず
+  「どの surface を確認したか」を記録します。この surface から
+  `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -338,14 +338,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: GitHub 上の durable review surface の mechanical
   acquisition は、ai-dev-foundation checkout を利用できる場合（例:
   `FOUNDATION_CHECKOUT` で参照する pinned checkout）、
-  `tooling/review-evidence.mjs`（Issue #62）に置き換えます。fetch が
-  failed / partial な場合は empty や success へ変換しません。
-  Completion / Validity / Resolution / triage の semantic judgment は
-  helper ではなく本 Contract に従い agent が行います。helper が対象と
-  しない surface（Review Adapter boundary（`policy/core.md`）参照）は、
-  この provider で確認できる surface を確認し、内容の有無にかかわらず
-  「どの surface を確認したか」を記録します。この surface から
-  `policy/core.md` の
+  `tooling/review-evidence.mjs --json`（Issue #62）に置き換えます。
+  `--json` 無しの human summary は count / fetch state のみで、
+  Completion / Validity / Resolution / triage の判定に必要な actor /
+  body / locator を含みません。fetch が failed / partial な場合は
+  empty や success へ変換しません。commit status / check runs は
+  helper では現在の head SHA のみが対象のため、ancestor target の
+  status/check は helper 対象外として扱います。Completion / Validity /
+  Resolution / triage の semantic judgment は helper ではなく本
+  Contract に従い agent が行います。helper が対象としない surface
+  （上記 ancestor target 分の status/check を含む。他は Review Adapter
+  boundary（`policy/core.md`）参照）は、この provider で確認できる
+  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -335,20 +335,25 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   使う comment / review submission は、判定するその時点で ID を指定して fresh に
   再取得した state / body を使います。会話内で既に見た comment の内容や、以前取得した
   snapshot をそのまま completion 判定の根拠にせず、pending 継続の理由にもしません。
-- `collectOutputs()`: GitHub 上の durable review surface（Conversation
-  comment、review submission、inline review comment、review thread の
-  resolved 状態、combined commit status、check runs）については、
-  ai-dev-foundation checkout を利用できる場合（この repository 自身の
-  review 等）、`tooling/review-evidence.mjs`（Issue #62）で 1 command
-  fresh に取得でき、surface ごとの fetch state と pagination 完了を機械的に
-  報告します。この helper は review completion / target Validity /
-  finding triage を判定しないため、判定は本 Contract に従い agent が
-  行います。helper が利用できない場合、または helper が対象としない
-  surface（workflow log 等）については、この provider で確認できる
-  surface（top-level PR comment、inline/thread comment、review
-  submission/summary、status/check、必要なら workflow log、edited
-  comment）を確認し、内容の有無にかかわらず「どの surface を
-  確認したか」を記録します。この surface から `policy/core.md` の
+- `collectOutputs()`: 収集対象の surface は Review Adapter boundary
+  （`policy/core.md`）が capability として定義するもの（top-level
+  comment、inline/thread、review submission、status/check、workflow
+  log、edited comment 等）です。このうち GitHub 上の durable review
+  surface（Conversation comment、review submission、inline review
+  comment、review thread の resolved 状態、combined commit status、
+  check runs）は、ai-dev-foundation checkout（この repository 自身の
+  review、または consumer が保持する pinned Foundation checkout ——
+  実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
+  あります）を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）
+  の 1 command 実行に置き換え、surface ごとの fetch state と pagination
+  完了を機械的に取得します。これらの surface を agent が個別に見て回って
+  「確認したか」を手作業で記録する必要はありません。この helper は
+  review completion / target Validity / finding triage を判定しないため、
+  判定は本 Contract に従い agent が行います。
+  helper が利用できない、または対象としない残りの surface（workflow
+  log、edited comment 等）については、上記 capability のうち該当する
+  surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
+  記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の
   要求事項を後続 session が独立に判定できれば、その surface 自体を同
   Contract の record の recoverable な representation として result

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -338,9 +338,10 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `collectOutputs()`: 収集対象の surface は Review Adapter boundary
   （`policy/core.md`）が capability として定義するもの（top-level
   comment、inline/thread、review submission、status/check、workflow
-  log、edited comment 等）です。このうち GitHub 上の durable review
-  surface（Conversation comment、review submission、inline review
-  comment、review thread の resolved 状態、combined commit status、
+  log、edited comment 等）です。このうち GitHub REST/GraphQL で取得
+  できる surface（top-level comment = Conversation comment、
+  inline/thread = inline review comment と review thread の resolved
+  状態、review submission、status/check = combined commit status と
   check runs）は、ai-dev-foundation checkout（この repository 自身の
   review、または consumer が保持する pinned Foundation checkout ——
   実例として `FOUNDATION_CHECKOUT` 環境変数で参照する consumer 実装が
@@ -351,7 +352,7 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   review completion / target Validity / finding triage を判定しないため、
   判定は本 Contract に従い agent が行います。
   helper が利用できない、または対象としない残りの surface（workflow
-  log、edited comment 等）については、上記 capability のうち該当する
+  log、edited comment）については、上記 capability のうち該当する
   surface を確認し、内容の有無にかかわらず「どの surface を確認したか」を
   記録します。この surface から `policy/core.md` の
   Acquisition & Validity Contract が定義する Completion と Validity の

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -96,10 +96,8 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
-   GitHub 上の durable review surface の取得手順は `skills/review-code.md` の
-   Adapter boundary（`collectOutputs()`）に従います。ai-dev-foundation
-   checkout を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）で
-   機械的に取得できます。
+   GitHub 上の durable review surface の取得は `skills/review-code.md` の
+   Adapter boundary（`collectOutputs()`）に従います。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -96,8 +96,10 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
-   GitHub 上の durable review surface の取得は `skills/review-code.md` の
-   Adapter boundary（`collectOutputs()`）に従います。
+   GitHub 上の durable review surface の取得は、Foundation リポジトリの
+   `skills/review-code.md`（consumer には
+   `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
+   boundary（`collectOutputs()`）に従います。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -96,6 +96,10 @@ acquisition routing」節に従います。この skill では重複定義しま
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
+   GitHub 上の durable review surface の取得手順は `skills/review-code.md` の
+   Adapter boundary（`collectOutputs()`）に従います。ai-dev-foundation
+   checkout を利用できる場合、`tooling/review-evidence.mjs`（Issue #62）で
+   機械的に取得できます。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -75,9 +75,7 @@ function emptyCommitStatusRoute() {
 
 function emptyCheckRunsRoute() {
   return {
-    // filter=all: check-runs must not silently drop earlier runs of a
-    // re-run check suite by relying on the GitHub API's "latest" default.
-    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs") && url.includes("filter=all"),
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
     handler: () => jsonResponse({ total_count: 0, check_runs: [] }),
   };
 }
@@ -154,7 +152,7 @@ test("collects a representative multi-surface snapshot with independent per-surf
       handler: () => jsonResponse({ state: "success", total_count: 2, statuses: [{ context: "ci/build", state: "success" }] }),
     },
     {
-      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs") && url.includes("filter=all"),
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
       handler: () => jsonResponse({ total_count: 1, check_runs: [{ id: 9, name: "test", status: "completed", conclusion: "success" }] }),
     },
   ];

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -75,7 +75,9 @@ function emptyCommitStatusRoute() {
 
 function emptyCheckRunsRoute() {
   return {
-    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
+    // filter=all: check-runs must not silently drop earlier runs of a
+    // re-run check suite by relying on the GitHub API's "latest" default.
+    match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs") && url.includes("filter=all"),
     handler: () => jsonResponse({ total_count: 0, check_runs: [] }),
   };
 }
@@ -152,7 +154,7 @@ test("collects a representative multi-surface snapshot with independent per-surf
       handler: () => jsonResponse({ state: "success", total_count: 2, statuses: [{ context: "ci/build", state: "success" }] }),
     },
     {
-      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs") && url.includes("filter=all"),
       handler: () => jsonResponse({ total_count: 1, check_runs: [{ id: 9, name: "test", status: "completed", conclusion: "success" }] }),
     },
   ];

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -327,6 +327,11 @@ function normalizeReviewThread(node) {
   };
 }
 
+// Keeps only name/status/conclusion/timestamps/locator. Does not capture
+// output.summary, output.text, or line-level annotations — a reviewer that
+// posts findings only in those fields is not represented here, and a caller
+// needing that content must fetch it separately (README "Review evidence
+// helper" documents this as a known coverage limit).
 function normalizeCheckRun(item) {
   return {
     id: item.id,
@@ -381,6 +386,11 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
     fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber),
   ]);
 
+  // commit_status/check_runs are fetched for this snapshot's headSha only —
+  // GitHub's status/check-runs endpoints are per-commit, with no "all
+  // commits in this PR" equivalent. A reviewer that left status/check
+  // evidence only on an earlier (ancestor) SHA is not represented here; a
+  // caller needing that must fetch it separately for that SHA.
   let commitStatus;
   let checkRuns;
   if (headSha) {

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -391,15 +391,23 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
   // commits in this PR" equivalent. A reviewer that left status/check
   // evidence only on an earlier (ancestor) SHA is not represented here; a
   // caller needing that must fetch it separately for that SHA.
+  //
+  // commit_status uses the combined-status endpoint, which GitHub defines
+  // as the *latest* status per context — an earlier status on the same
+  // (headSha, context) pair that a later status superseded is not
+  // recoverable from this surface, and fetch_status still reports "fetched"
+  // (this is a known coverage gap, not a fetch failure; see README).
   let commitStatus;
   let checkRuns;
   if (headSha) {
     [commitStatus, checkRuns] = await Promise.all([
       fetchCombinedStatusSurface(fetchImpl, token, `${restBase}/commits/${headSha}/status?per_page=100`),
+      // filter=all (not the API default "latest") so a re-run check suite's
+      // earlier runs on this headSha are included, not silently dropped.
       fetchPaginatedSurface(
         fetchImpl,
         token,
-        `${restBase}/commits/${headSha}/check-runs?per_page=100`,
+        `${restBase}/commits/${headSha}/check-runs?filter=all&per_page=100`,
         (body) => body?.check_runs ?? [],
       ),
     ]);

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -327,19 +327,17 @@ function normalizeReviewThread(node) {
   };
 }
 
-// Keeps name/status/conclusion/timestamps/locator plus the posting App's
-// slug (check runs are created by a GitHub App, not a user). Does not
-// capture output.summary, output.text, or line-level annotations — a
-// reviewer that posts findings only in those fields is not represented
-// here, and a caller needing that content must fetch it separately (README
-// "Review evidence helper" documents this as a known coverage limit).
+// Keeps only name/status/conclusion/timestamps/locator. Does not capture
+// output.summary, output.text, or line-level annotations — a reviewer that
+// posts findings only in those fields is not represented here, and a caller
+// needing that content must fetch it separately (README "Review evidence
+// helper" documents this as a known coverage limit).
 function normalizeCheckRun(item) {
   return {
     id: item.id,
     name: item.name ?? null,
     status: item.status ?? null,
     conclusion: item.conclusion ?? null,
-    app_slug: item.app?.slug ?? null,
     started_at: item.started_at ?? null,
     completed_at: item.completed_at ?? null,
     locator: item.html_url ?? null,
@@ -351,8 +349,6 @@ function normalizeStatus(status) {
     context: status.context ?? null,
     state: status.state ?? null,
     description: status.description ?? null,
-    actor: status.creator?.login ?? null,
-    actor_type: status.creator?.type ?? null,
     target_url: status.target_url ?? null,
     created_at: status.created_at ?? null,
     updated_at: status.updated_at ?? null,
@@ -406,12 +402,10 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
   if (headSha) {
     [commitStatus, checkRuns] = await Promise.all([
       fetchCombinedStatusSurface(fetchImpl, token, `${restBase}/commits/${headSha}/status?per_page=100`),
-      // filter=all (not the API default "latest") so a re-run check suite's
-      // earlier runs on this headSha are included, not silently dropped.
       fetchPaginatedSurface(
         fetchImpl,
         token,
-        `${restBase}/commits/${headSha}/check-runs?filter=all&per_page=100`,
+        `${restBase}/commits/${headSha}/check-runs?per_page=100`,
         (body) => body?.check_runs ?? [],
       ),
     ]);

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -327,17 +327,19 @@ function normalizeReviewThread(node) {
   };
 }
 
-// Keeps only name/status/conclusion/timestamps/locator. Does not capture
-// output.summary, output.text, or line-level annotations — a reviewer that
-// posts findings only in those fields is not represented here, and a caller
-// needing that content must fetch it separately (README "Review evidence
-// helper" documents this as a known coverage limit).
+// Keeps name/status/conclusion/timestamps/locator plus the posting App's
+// slug (check runs are created by a GitHub App, not a user). Does not
+// capture output.summary, output.text, or line-level annotations — a
+// reviewer that posts findings only in those fields is not represented
+// here, and a caller needing that content must fetch it separately (README
+// "Review evidence helper" documents this as a known coverage limit).
 function normalizeCheckRun(item) {
   return {
     id: item.id,
     name: item.name ?? null,
     status: item.status ?? null,
     conclusion: item.conclusion ?? null,
+    app_slug: item.app?.slug ?? null,
     started_at: item.started_at ?? null,
     completed_at: item.completed_at ?? null,
     locator: item.html_url ?? null,
@@ -349,6 +351,8 @@ function normalizeStatus(status) {
     context: status.context ?? null,
     state: status.state ?? null,
     description: status.description ?? null,
+    actor: status.creator?.login ?? null,
+    actor_type: status.creator?.type ?? null,
     target_url: status.target_url ?? null,
     created_at: status.created_at ?? null,
     updated_at: status.updated_at ?? null,


### PR DESCRIPTION
## Context

Origin: #66（Issue本文をcanonical Task Contractとする）。fresh取得したexecution
checkpoint（main `dc6af64`、open PR無し、#62/PR #63・#59/PR #65 landed済み）を
起点に実装した。

**Amendment履歴**:
1. 初版実装後、reviewerからinvocation boundaryの再検証を要求され、
   `reitojike/stage-tracker`の既存`FOUNDATION_CHECKOUT`経路をfresh確認した。
2. 続くreview指摘で、helper説明の追加によりinstruction量が純増している
   （dedupのつもりが実際にはthin化になっていない）という指摘を受け、
   `collectOutputs()`をsurface列挙の再掲を伴わないthin pointerへ再設計した。

以下は現時点（head `e8031a5`）の最終状態。

## 1. Fresh inventory / classification

- `policy/core.md`（878行）— Review Adapter boundary節は既に「Kernel は
  この boundary の形のみを定義し、provider固有の実装や恒久的なcapability
  台帳を持ちません」という薄い宣言に留まる。Kernelへ`tooling/review-evidence.mjs`
  等のFoundation固有実装を持ち込むことはこの設計と矛盾するため、
  **Kernelへは変更を加えない**。
- `AGENTS.md`（Foundation repo-local instructions）— Review節は20行の
  skillへのpointerのみ。thin化対象自体が無い。
- `skills/review-code.md` — `## Adapter boundary（manual pilot）`の
  `collectOutputs()` bulletが、`policy/core.md` Review Adapter boundaryと
  ほぼ同じsurface capability列挙（top-level comment、inline/thread、
  review submission、status/check、workflow log、edited comment）を
  そのまま再掲した上で、「この provider で確認できる surface を確認し、
  内容の有無にかかわらず『どの surface を確認したか』を記録します」という、
  まさに`tooling/review-evidence.mjs`（#62）が6 surfaceについてfetch/
  pagination/countをmechanicalに行っている作業のmanual instructionを
  持っていた。
- `skills/review-doc.md` — 独自のsurface列挙は無く、step 4が「どの
  surface itemをpositive completion evidenceとしたか...を記録すること」
  とのみ述べる。
- `tooling/review-evidence.mjs` / `review-evidence-lib.mjs` — PR metadata
  / Conversation comments / review submissions / inline review comments /
  review threads（resolved状態含む）/ combined commit status / check runs
  の6 surfaceを1 commandでfresh取得し、surfaceごとに`fetch_status`と
  countを独立報告する。Completion/Validity/triage/merge-readyの判定は
  一切行わない（`the helper's source stays free of Review Protocol
  judgment vocabulary` testで担保）。

## 2. Semantic safety invariantとmechanical procedureの責務境界

`policy/core.md`のReview Protocol（4 Contract、merge-ready fence、
`CI green != reviewed`、`0 findings`のpositive evidence要件、fetch
failureをempty/successへ潰さない契約、target binding safety等）は
すべて**無変更**。skillのsemantic Completion/Validity/Resolution判断
手順も無変更。`collectOutputs()`のthin pointerにも「Completion /
Validity / Resolution / triage の semantic judgment は helper ではなく
本 Contract に従い agent が行います」と明記している。

## 3. Invocation boundary — 実consumerでfresh確認 + bounded smoke

`reitojike/stage-tracker`に既に確立されたpinned Foundation checkout経路
（`scripts/foundation-checkout.mjs`が`FOUNDATION_CHECKOUT`環境変数を
解決し、`.ai-dev-foundation/foundation-pin.json`のpinned SHAとの一致を
検証してから利用、`.github/workflows/verify.yml`のVerify/Code jobが
CI上でこの経路を実際に使用）をfresh確認した。

加えて、この経路を模したbounded smoke testを実施した。

```
mkdir -p /tmp/consumer-sim2 && cd /tmp/consumer-sim2
export FOUNDATION_CHECKOUT=<ai-dev-foundation checkoutの絶対path>
node "$FOUNDATION_CHECKOUT/tooling/review-evidence.mjs" \
  --repo reitojike/ai-dev-foundation --pr 67 --json
# => pull_number: 67, head: <current head>, fetch_failures: 0
```

Foundation repository外の無関係なディレクトリ・プロセスから、
`FOUNDATION_CHECKOUT`解決のみで正しく動作することを確認した（ESM相対
importはscript自身の位置基準で解決されるため、呼び出し元cwdに依存しない）。

limitation（concrete、re-verified）:

- `tooling/`はFoundationのdistribution対象（`sync.mjs`/
  `bootstrap-next-supabase.mjs`）に含まれない。配布されるのは
  `.ai-dev-foundation/skills/`と生成`AGENTS.md`のみで、この点は変更
  していない。
- stage-trackerの現在のpinned SHA（`2cb4dff...`、v0.3.0リリース時点）は
  #62より前のため、現時点のpinをそのまま使ってもhelperはまだ利用できない。
  pin更新はstage-tracker側のexisting operational processであり、本Task
  のscopeでは行わない。
- stage-trackerの`scripts/run-foundation-tool.mjs`convenience wrapperは
  `check`/`sync`専用にhardcodeされており、`review-evidence.mjs`の
  `--repo`/`--pr`引数形状を受け付けない。helper自体を直接呼び出すこと
  （上記smoke testどおり）は妨げられない。stage-tracker側のwrapper拡張
  は本Taskのscope外（他repoへの変更）として行っていない。

新しいdistribution framework・consumer-local wrapperは作成していない。

## 4. 実装（bounded thinning、thin pointer優先）

reviewでの2回の指摘を踏まえ、最終的に次の設計へ収束した。

- `skills/review-code.md` `collectOutputs()` bulletを、surface名の
  詳細な再列挙・mapping・pinned checkoutの説明を展開せず、次の4点のみの
  thin pointerへ再設計した。
  1. GitHub durable review surfaceのmechanical acquisitionは、
     ai-dev-foundation checkoutを利用できる場合`tooling/review-evidence.mjs`
     （#62）へ**置き換える**（追加の選択肢ではない）
  2. fetchがfailed/partialならemptyやsuccessへ変換しない
  3. Completion/Validity/Resolution/triageのsemantic judgmentはhelperで
     はなくagentが本Contractに従い行う
  4. helperが対象としないsurfaceは、Kernelの`policy/core.md` Review
     Adapter boundaryを参照する（再列挙しない）
  surface capability列挙（top-level comment等6項目）とhelperのsurface
  名（Conversation comment等）の対応表は**完全に削除**した——
  helper自身がこのownershipを持つため、skill側で再度詳細列挙する必要は
  無いと判断した。
- `skills/review-doc.md`の追加は、helper名・Issue番号を再掲する4行から、
  「GitHub上のdurable review surfaceの取得は`skills/review-code.md`の
  Adapter boundary（`collectOutputs()`）に従います。」という1文の
  pointerへ縮小した（review-code.mdが既に完全な説明を持つため）。
- `test/fixtures/consumer/.ai-dev-foundation/skills/{review-code,review-doc}.md`
  — `npm run sync:fixture`で再展開しdriftを解消。
- `policy/core.md` / generated `AGENTS.md`は無変更。

### exact-wording testの再評価（reviewer指摘への回答）

除去した6項目のsurface列挙文（`top-level PR comment、inline/thread
comment、review submission/summary、status/check、必要なら workflow
log、edited comment`）が`test/review-protocol.test.mjs`のexact-match
assertionの対象になっていないかを確認した。結果、**この列挙文はどの
testにもpinされていなかった**（既存の厳密一致assertionは、この列挙とは
別の段落——`reviewer mechanism 自身が...`で始まる no-surface persistence
fallbackの記述——のみを保護していた）。したがって、test側の変更は不要
だった。これは「testがhistorical wordingを固定していたため冗長な文章を
残さざるを得なかった」という懸念に対する実測結果であり、test変更なしで
thin化を完了できた。

## 5. Regression protection

- helper failure/partialがgreenや`0 findings`にならない: 無変更、
  かつthin pointerにも明記
- semantic Completion/Validity/Resolutionがhelperへ移っていない: 無変更、
  かつ明記を維持
- unresolved finding obligation / `CI green != reviewed` / required
  reviewer semantics / target binding safety: `policy/core.md`無変更の
  ため維持
- generated artifacts current: `policy/core.md`無変更のため生成
  `AGENTS.md`の再生成は不要

## 6. Before / after measurement — 具体的に削除できたmechanical bookkeeping

| file | before (lines/chars) | after (lines/chars) | delta |
| --- | --- | --- | --- |
| `skills/review-code.md` | 481 / 35,108 | 488 / 35,561 | +7 / +453 |
| `skills/review-doc.md` | 190 / 13,162 | 192 / 13,305 | +2 / +143 |
| `policy/core.md` | 878 / 54,609 | 878 / 54,609 | 無変更 |
| `AGENTS.md`（repo-local） | 20 / 1,157 | 20 / 1,157 | 無変更 |

削除できたmechanical bookkeeping記述（agent-facing canonical instruction
から具体的に消えたもの）:

1. **6項目のsurface列挙の完全削除**: `collectOutputs()`が持っていた
   「top-level PR comment、inline/thread comment、review submission/
   summary、status/check、必要なら workflow log、edited comment を
   確認し、内容の有無にかかわらず『どのsurfaceを確認したか』を記録する」
   という具体的な列挙は、修正版では一切再掲していない（Kernelの
   Review Adapter boundaryへ委譲し、skill側は「この providerで確認
   できるsurfaceを確認し記録します」という一般文のみを残した）。
2. **surface-by-surfaceのmanual確認手順のprimary pathからの除去**:
   ai-dev-foundation checkoutが利用できる場合、Conversation comment /
   review submission / inline review comment / review thread（resolved
   状態含む）/ combined commit status / check runsの6 surfaceについて、
   agentが個別に見て回りfetch状態を記録する手作業は、
   `tooling/review-evidence.mjs`の1 command実行へ完全に置換された
   （「追加の選択肢」ではなく「置き換え」と明記）。
3. **review-doc.mdでのhelper詳細の重複記載を除去**: review-code.mdが
   既に持つhelper名・Issue番号・説明を再掲していた4行を、1文の
   pointerへ縮小した。

残したもの（safety net、意図的に不変更）:

- helper unavailable時のfallback義務（「この providerで確認できる
  surfaceを確認し記録する」という一般文）はKernel参照の形で維持
- helperが対象としないsurface（workflow log、edited comment等）は
  引き続きmanual確認が必要である旨を維持
- `reviewer mechanism自身が...`で始まる no-surface persistence
  fallback（実装session内subagent review等向け）は一字一句無変更

## Verification

- `npm test`: 126 tests / 125 pass / 1 pre-existing skip（Windows symlink
  作成不可によるEPERM、本変更と無関係）/ 0 fail
- `npm run test:guardrails`: 8 guardrail fixture green
- `FOUNDATION_CHECKOUT`環境変数によるbounded smoke test（本文3節参照）:
  Foundation repository外の別ディレクトリから実行し、fetch_failures: 0
  で成功

## Out of scope（Issue #66 Out of scope節に準拠）

review-evidence helperへのCompletion/Validity/triage/merge-ready logic
追加、provider-specific finding parser、polling daemon/webhook/dashboard、
automatic reviewer switching、#64のorchestration/authority delegation、
#39のworktree/runtime isolation、release/version bump/tag、stage-tracker
repin、stage-tracker側のwrapper拡張は行っていない。`policy/core.md`は
無変更のため、`Closes #N`等のauto-close keywordはPR本文に使用していない。

## Authority

implementation / verification / current Review Protocol / Resolutionを
完了し、merge-readyで停止する。PR merge / Issue close / Foundation
release・tag / stage-tracker repinのauthorityは持たない。
