### PR TITLE
Release v0.4.0: version bump・final verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-dev-foundation",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-foundation",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-dev-foundation",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "sync:fixture": "node tooling/sync.mjs --consumer test/fixtures/consumer",


### PR DESCRIPTION
## Context

Issue #68 (implementation agent, merge/tag authorityなし) のrelease preparation。
`v0.3.0`（tag target `2cb4dff3b111f54eba8b566b8c3f062698e98d98`）以降、
frozen semantic baseline `d050c00e440a8728f47e06724db063c21a5c71f3`
（= 現在の`origin/main` HEAD、fresh確認済み、`v0.3.0...main`は28 ahead / 0 behind）
までにlandしたFoundation改善をv0.4.0としてまとめる。

open PRは開始時0件、既存`v0.4.0` tagはlocal/remoteともに無し。

## Release delta（v0.3.0...frozen baseline、consumer-visible粒度）

**Review Protocol / policy正本**
- Skill routing contract: mixed-classification review target routing (#57) — 1つのreview targetがExecutable/Normative両方を含む場合の、複数skill load義務を明記

**Security guardrail（新規deterministic capability）**
- Next.js + Supabase profile: client-role residual privilege guardrail (#44) — anon/authenticated/PUBLICのTRUNCATE/REFERENCES/TRIGGER/MAINTAIN(PG17+)保持をDB上でdeterministicに検出。mixed-case/quoted table identifierのquote fix含む

**Profile / checker挙動fix**
- Next.js profile: `check-agent-rules-disabled`が`next.config.mts`（native TypeScript support環境）を候補に含むよう修正 (#56)

**Review acquisition tooling（新規helper）**
- GitHub durable review surface（comments/review submissions/inline comments/review threads/commit status/check runs）をfresh acquisitionするthin deterministic helper (`tooling/review-evidence.mjs`) を追加 (#62)。pagination完走・comment本文保持・description保持等のfollow-up fixを含む

**Review runtime / CI**
- stage-tracker #118 canaryをpromoteし、manual-on-demand review routing（Claude GitHub-native + CodeRabbit manual、CodeRabbit不可時はCodex manual fallback）へ更新 (#59)。Verify laneをCode/Build/Databaseへ分離するreference構成、`.coderabbit.yaml`のmisleading status除去を含む

**Review skill thinning**
- review-code.md / review-doc.mdの実装詳細ownershipをhelper/READMEへ移し、skillをcapability-basedなthin contractへ縮小 (#66)。過程で入ったhelper capability拡張（actor/actor_type、app_slug、filter=all）は明示的にrevertし、document-onlyへ戻している

この列挙は正本ではなく、`v0.3.0...main`のfresh diffがrelease delta確定の根拠。

## Version bump

- `package.json`: `0.3.0` -> `0.4.0`
- `package-lock.json`: `0.3.0` -> `0.4.0`（root package name/versionの2箇所）
- 上記以外のversion-bearing artifactは無し（他ファイルへの`0.3.0`直書き参照なし）
- unrelated dependency update / semantic implementation changeは混在させていない

## Final deterministic verification（final candidate: このPRのhead commit）

- `npm test`（`test/*.test.mjs` 126 tests + `test:guardrails`）: 125 pass / 0 fail / 1 skip（Windows symlink EPERM、既知のplatform limitationでFoundation defectではない）
- `npm run check:fixture`: generated adapters / quality profile / skill bundle currentを確認
- `npm run test:guardrails`: 8 guardrail fixture成功（`npm test`に含まれるが単独実行でも確認済み）
- `npm run test:client-role-table-privileges-guardrail`（Docker Postgres 17.6/15使用）: 13/13 pass
- lint/format/typecheck: `package.json`にscript未定義、config file（eslint/prettier/tsconfig）もrepo内に存在せず、applicableな追加static checkなし

## Review Protocol

このPRのartifact classificationは `package.json` / `package-lock.json` のversion-only diffのみ。Normative/Executableいずれの意味的変更も含まないため、Review ProtocolのInformational相当（mechanical diffのみ、open-ended AI reviewを通常のmerge gateにしない）として扱う。current Review Protocol（Selection/Execution/Acquisition & Validity/Resolution Contract）に従い、release delta integrity（release deltaの欠落/過大主張、version-bearing artifact整合、release boundaryへのscope外混入有無）を本PR bodyおよびIssue #68 completion reportで確認する。詳細はIssue #68側のreport参照。

## Out of scope（このPRに含めない）

- `v0.4.0` git tag作成
- GitHub Release公開
- stage-tracker repin
- #64 / #39
- 新規Foundation機能・guardrail実装
- unrelated cleanup / dependency update

## Authority note

本PRはmerge-ready評価の対象としてIssue #68で報告する。PR merge / `v0.4.0` tag作成 / Issue close はこのPRのauthorityに含まれない。