### PR TITLE
Phase 2: deterministic merge-ready fence を code へ移し Review Protocol の散文を縮退する

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,16 @@ node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
 
 JSON を stdout へ出力し、exit code は `pass` = 0、`fail` = 1、`unknown` = 2 です。
 fence の評価そのものへ到達できなかった場合（引数誤り、token 不在、reviewer capability
-record が読めない、`--artifacts-file` / `--acknowledged-file` が読めない、acquisition
-失敗）は setup error として **exit 2** とし、stderr へ message と usage を出力して
-stdout へは何も出しません。setup error を `fail`（= fence が到達した判定）と
+record が読めない、`--artifacts-file` / `--acknowledged-file` が読めない、acquisition が
+例外を送出した）は setup error として **exit 2** とし、stderr へ message と usage を
+出力して stdout へは何も出しません。setup error を `fail`（= fence が到達した判定）と
 区別するためです。
+
+**通常の acquisition failure は setup error ではありません。** GitHub API の失敗は
+`collectReviewEvidence()` が surface ごとの `fetch_status`（`failed` / `partial`）として
+返し、例外を送出しません。この場合 fence は評価へ到達し、`acquisition-coverage` が
+`unknown`（`coverage_incomplete`）となる JSON を stdout へ出力して exit 2 になります。
+exit 2 の 2 つの経路は stdout の有無で区別できます。
 集約規則は「1 つでも `fail` があれば `fail`、無ければ 1 つでも `unknown` があれば
 `unknown`、全部 `pass` なら `pass`」です。各 check は独立した `id` / `status` /
 `reason_codes` / `detail` を返します。

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
 見た evidence を渡す経路が存在しないことが、fresh acquisition の構造的な保証です。
 
 JSON を stdout へ出力し、exit code は `pass` = 0、`fail` = 1、`unknown` = 2 です。
+fence の評価そのものへ到達できなかった場合（引数誤り、token 不在、reviewer capability
+record が読めない、`--artifacts-file` / `--acknowledged-file` が読めない、acquisition
+失敗）は setup error として **exit 2** とし、stderr へ message と usage を出力して
+stdout へは何も出しません。setup error を `fail`（= fence が到達した判定）と
+区別するためです。
 集約規則は「1 つでも `fail` があれば `fail`、無ければ 1 つでも `unknown` があれば
 `unknown`、全部 `pass` なら `pass`」です。各 check は独立した `id` / `status` /
 `reason_codes` / `detail` を返します。

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ blocking checkで検知します。
 ## Review evidence helper
 
 `tooling/review-evidence.mjs` は、指定した GitHub PR について durable review
-surface（PR metadata / head SHA、Conversation comments、review submissions、
-inline review comments、review-thread comments、combined commit status、check
-runs）を fresh に取得し、pagination を完了した上で human-readable summary または
-`--json` machine-readable output を返す snapshot tool です。
+surface（PR metadata / head SHA / base SHA / body、Conversation comments、review
+submissions、inline review comments、review-thread comments とその resolution
+state、changed files、combined commit status、check runs）を fresh に取得し、
+pagination を完了した上で human-readable summary または `--json` machine-readable
+output を返す snapshot tool です。
 
 ```text
 node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> [--json]
@@ -195,6 +196,56 @@ binding candidates、および `{surface, surface_id}` の sources を持ちま�
 helper の acquisition と state projection はそれぞれ mechanical な取得と Issue #74 の
 target completion 判定だけを行います。finding の意味付け、Resolution、Selection、
 merge-ready 判定は `policy/core.md` と review skills が引き続き所有します。
+
+## Merge-ready fence
+
+`tooling/merge-ready-fence.mjs` は、merge-ready を宣言する直前に 1 回実行する
+deterministic checker です。CLI 引数として渡された frozen 宣言と、1 回の fresh
+acquisition で得た fact だけを照合します。
+
+```text
+node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+  --target-sha <frozen head SHA> [--base-sha <frozen base SHA>] \
+  [--artifacts-file <path list>] [--artifact <path>]... \
+  [--verify-sha <deterministic verify を実行した SHA>] \
+  [--required <reviewer-id>]... [--declared-skill review-code]... \
+  [--acknowledged-file <path>] [--acknowledged <canonical_id>=<body_digest>]... \
+  [--run-after <ISO timestamp>] [--run-anchor-id <id>] [--record <path>] [--token <token>]
+```
+
+`--artifacts-file` と `--acknowledged-file` はいずれも改行区切りの plain text です
+（`#` 始まりの行と空行は無視します）。**snapshot file を引数に取りません。** 会話内で
+見た evidence を渡す経路が存在しないことが、fresh acquisition の構造的な保証です。
+
+JSON を stdout へ出力し、exit code は `pass` = 0、`fail` = 1、`unknown` = 2 です。
+集約規則は「1 つでも `fail` があれば `fail`、無ければ 1 つでも `unknown` があれば
+`unknown`、全部 `pass` なら `pass`」です。各 check は独立した `id` / `status` /
+`reason_codes` / `detail` を返します。
+
+| check id | pass | fail | unknown |
+| --- | --- | --- | --- |
+| `target-head` | current head == `--target-sha` | 不一致 | 取得失敗 / 宣言なし |
+| `target-base` | current base == `--base-sha` | 不一致 | 取得失敗 / 宣言なし |
+| `artifact-set` | changed path 集合が frozen 集合と厳密一致 | 追加・削除いずれも | files surface 取得失敗 / 宣言なし |
+| `skill-routing` | derived required skills ⊆ declared skills | derived ⊄ declared | 分類不能 path（declared が mandatory skill を網羅していれば pass）/ 宣言なし |
+| `reviewer-completion` | required reviewer がすべて `completed@target` | `not-bound` / `rate-limited` / `failed` / `declined` | `in-flight` / `unknown` / record に無い id |
+| `result-revision-coherence` | 到着済み result の current `body_digest` が acknowledged と一致 | 未 acknowledge / digest 変化 | coverage incomplete / identity 不明 |
+| `acquisition-coverage` | `coverage_complete == true` | — | `false` |
+| `review-threads` | unresolved thread 0 件 | 1 件以上（outdated でも同じ） | resolution state 未取得 |
+| `verify-coherence` | `--verify-sha == --target-sha` | 不一致 | `--verify-sha` 未指定 |
+| `autoclose-hygiene` | current PR body に closing keyword 無し | 有り | metadata 取得失敗 |
+
+`reviewer-completion` は Issue #74 の `evaluateReviewerTargetStates()` の出力を消費
+するだけで、provider marker parser を持ちません。`result-revision-coherence` は
+「triage 対象にした版と現在版が同じか」だけを判定し、finding の意味や Resolution の
+完了は判断しません。対象は required reviewer の current completed result と、fresh
+acquisition 時点で既に到着している advisory / optional reviewer の result です
+（未到着の advisory reviewer は block しません）。
+
+fence output は tool output であり、validation される durable record schema では
+ありません。`pass` は machine-checkable な precondition の成立のみを述べ、merge-ready
+の成立そのものではありません。merge-ready の成立条件と merge execution authority は
+`policy/core.md` の Merge readiness and merge authority が定めます。
 
 ## Next.js + Supabase quality profile
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -667,23 +667,16 @@ SHA / commit range が不変でも target artifact set が変わった場合も�
 precondition evidence、discovery evidence、closure
 evidence はいずれも target-specific であり、確定した target と一致しない evidence を
 review / closure / merge の根拠にしません。
-review / closure / merge の根拠として使う precondition evidence は、review 対象
-として確定した（freeze / Selection された）target と一致していなければなりません。
-一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
-check を再実行します。
+target / range / artifact set の drift と、precondition evidence が確定した target SHA
+を指しているかは deterministic であり、Merge-ready completion fence が参照する checker
+が機械判定します。照合手順を本節に置きません。
 
-この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。
-Selection で確定した target artifact set が、その precondition check の対象 scope に
-含まれることを確認します。precondition check を Selection より前に実行した場合は、
-Selection 後にこの binding を確認します。selected artifact set を precondition
+checker が判定しないのは、precondition check がどの artifact scope を対象としたかです。
+これは check ごとに異なるため、Selection で確定した target artifact set がその scope に
+含まれることの確認は agent が行います。precondition check を Selection より前に実行した
+場合は、Selection 後にこの binding を確認します。selected artifact set を precondition
 evidence がカバーしていると確認できない場合は、確定した target に対して precondition
 check を再実行してから先へ進みます。
-
-このうち target / range / artifact set の drift と、precondition evidence が確定した
-target SHA を指しているかは deterministic であり、Merge-ready completion fence が
-参照する checker が機械判定します。照合手順を本節に置きません。precondition check が
-どの artifact scope を対象としたかは check ごとに異なるため、その scope が selected
-artifact set をカバーしているかの確認は引き続き agent が行います。
 
 valid な discovery の後、accepted-fix による closure target の変更以外の理由で review
 target が変わった場合、その discovery を新しい target の merge / completion evidence

--- a/policy/core.md
+++ b/policy/core.md
@@ -404,19 +404,17 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
-Validity の判定は、reviewed target を確定させた上で、Selection Contract の
-expected target と比較して行います。reviewed target は次のように確定します。
+reviewed target をどの field / surface から確定するか、複数表現の間でどの binding を
+優先するか、および確定した reviewed target を expected target と照合する手順は、
+Foundation-owned な deterministic evaluator が所有します。その手順を本節に置きません。
+本節が定めるのは次の invariant です。
 
-- record の `target_sha` と acquired evidence 上の reviewed target が
-  両方存在する場合、両者は一致していなければなりません。
-  一致しない場合は invalid です。
-- reviewed target を Validity 判定に必要な精度で確認できない場合は unknown
-  です。
-
-確定した reviewed target が expected target と一致しない場合、
-completion していても invalid です。この場合、record は `status: completed`
-かつ `validity: invalid` として表現します。
-intended artifact set が review されていない場合も invalid です。
+- **reviewed target を Validity 判定に必要な精度で確認できない場合、その binding は
+  成立しておらず、判定結果は `unknown` です。** review target の移動に追随して値が
+  変化する field / surface を binding の根拠にしてはいけません。
+- 確定した reviewed target が expected target と一致しない場合、completion していても
+  invalid です。この場合、record は `status: completed` かつ `validity: invalid` として
+  表現します。intended artifact set が review されていない場合も invalid です。
 
 **acquisition の record は、後続 session から独立に recoverable な場所へ
 persist されて初めて durable evidence です。** review を行った
@@ -430,9 +428,7 @@ agent/session が終了した後、別の後続 session が session の記憶に
 別途 record を post し直す必要はありません。含まれていない場合
 （reviewer mechanism 自身がそのような surface へ結果を残さない場合、
 例えば実装 session 内で動く subagent review を含む）は、上記の record
-schema の各 field に加え、Completion と Validity の要求事項（reviewed
-target の一致、target artifact set の coverage、required context への
-アクセス可否、finding 内容、completion 状態を含む）を独立に判定できる
+schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
 情報を、そのような場所へ明示的に persist しない限り、session 終了後には
 recoverable な evidence として扱いません。record schema 自体（特に
 `validity` field）は判定結果の要約であり、その根拠情報の代わりには
@@ -443,35 +439,35 @@ parser 0 件、status success のみを `no findings` へ変換してはいけ�
 completion evidence のない empty output は `unknown` として扱います。
 
 **run record state と target completion state は別の対象です。** 上記の record schema の
-`status` / `validity` は、**個々の review run** の状態を表します。`unknown` / `failure`
-の語は本 Contract 内で複数の対象について現れるため、どちらの対象について述べているかを
-必ず明示します。これとは別に、
+`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
 **ある reviewer が、確定した review target について現在どこまで完了しているか**を
-**target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
-`failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
+**target completion state** と呼びます。両者は同じ語で呼ばず、混同してはいけません。
 ancestor target に対する run は、run record としては `status: completed` かつ
 `validity: invalid` であり、同時にその reviewer の current target に対する target
 completion state は `not-bound` です。この 2 つは矛盾しません。
 
 **positive completion evidence は target-bound です。** ある reviewer の target
-completion state を `completed@target` とできるのは、取得済み surface item のうち、
-その target への resolvable な参照を持つ positive completion evidence が存在する場合に
-限ります。そのような evidence が無い場合、その state は `unknown`（または、reviewed
-target を確定できた上で一致しない場合は `not-bound`）であり、`0 findings` へ変換しては
-いけません。
+completion state を「current target について完了した」とできるのは、取得済み surface
+item のうち、その target への resolvable な参照を持つ positive completion evidence が
+存在する場合に限ります。そのような evidence が無い場合、その state は `unknown`
+（または、reviewed target を確定できた上で一致しない場合は `not-bound`）であり、
+`0 findings` へ変換してはいけません。
 
-reviewed target を確定させる evidence には、**その review run が実際に review した
-target を安定して表す field / surface** を使います。review target の移動に追随して
-値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
-が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
-**binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
-場合、その binding は成立しておらず、target completion state は `unknown` です。**
+**triage した review result の revision は、判断の対象です。** review result は
+in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
+その reviewer の target completion state は変わりません。したがって、ある run を
+merge / review completion の根拠とするには、triage / Resolution の対象とした result の
+revision が、判断時点の current revision と同一であることを確認します。この確認は
+deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+current revision が異なる場合、その result はまだ triage されていない result として
+扱います。
 
 本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
-membership class とその根拠、target completion state とその binding の根拠、および
-current target の clean / discovery evidence として採用した run——は、個々の run record
-schema ではなく、その review stage の Selection / fence 記録として persist します。
-これらは run 単位ではなく reviewer 単位・stage 単位の情報であるためです。
+membership class とその根拠、target completion state とその binding の根拠、triage の
+対象とした result の revision、および current target の clean / discovery evidence として
+採用した run——は、個々の run record schema ではなく、その review stage の Selection /
+fence 記録として persist します。これらは run 単位ではなく reviewer 単位・stage 単位の
+情報であるためです。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -529,24 +525,32 @@ merge authority が明示されていない場合、または別 authority の�
 
 #### Merge-ready completion fence
 
-merge-ready を宣言する前に、次を最後の action として評価します。この fence は Review
-stopping rules を置き換えず、参照します。
+merge-ready を宣言する前に、次の fence を最後の action として評価します。この fence は
+Review stopping rules を置き換えず、参照します。fence は 2 つの部分からなります。
 
-1. 確定した final candidate target を freeze する。
-2. Selection Contract に従って expected review set を閉じる。observed review
-   participation は、この評価時点の fresh acquisition で判定する。
-3. set の各 member について、fresh acquisition で target completion state を判定する。
-   positive completion evidence が無い member を `0 findings` へ変換しない。
-4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
-   帰属させる。
-5. finding を Resolution Contract に従って triage する。ancestor target で発見された
-   finding も対象とする。
-6. triage されていない finding が review surface 上に残っていないことを確認する。
-7. merge-ready は、**expected review set の各 member（optional / advisory を含む）の
-   review obligation が satisfied している**ことをもって成立する。
+**1. machine-checkable な precondition。** 確定した target / base / target artifact set
+が現在も同じであること、required reviewer の target completion state、acquisition の
+coverage、triage した review result の revision が現在も同じであること、review surface 上に
+未解決として残っている review conversation の有無、deterministic verification target との
+一致、changed artifact set が要求する skill routing、および merge 前に機械判定できる
+repository hygiene。これらは Foundation-owned な deterministic checker が
+**1 回の fresh acquisition** に対して評価します。どの surface がこれらを表すかの識別は
+Review Adapter boundary の責務であり、Kernel は provider 固有の surface 名を持ちません。
+判定手順は checker が canonical source であり、本節には置きません。checker は finding の
+意味、Resolution の完了、merge authority を判断しません。
 
-**review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
-判定対象です。
+**2. semantic judgment。** finding の意味と triage、Resolution の完了、および expected
+review set の各 member の review obligation が満たされたかどうか。これは agent が
+所有します。
+
+**checker の pass は merge-ready の成立ではありません。** checker が述べるのは
+machine-checkable な precondition が成立していることだけです。merge-ready は、それに
+加えて **expected review set の各 member（optional / advisory を含む）の review
+obligation が satisfied している**ことをもって成立します。checker が `pass` 以外
+（`fail` / `unknown` のいずれか）を返す間は merge-ready ではありません。`unknown` を
+`pass` として扱ってはいけません。
+
+**review obligation** は、member の class ごとに次を指します。
 
 - **required member**: Selection Contract の required review 数を満たす valid な run が
   揃っていること、およびその finding の Resolution が完了していること。ここでの
@@ -570,11 +574,10 @@ stopping rules を置き換えず、参照します。
 この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
 義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
 義務は免除しません。** current target に対する run が observed で in-flight なら、
-その run が terminate する（run record が `status` の終端値として確定する）まで
-待ちます。ここで待つ対象は run record state であり、target completion state では
-ありません。run が終端した結果 `validity: invalid` であっても、待機義務としては
-充足です。一度も `completed@target` になっていない member へこの例外を適用しては
-いけません。この例外に依拠する場合、上記 3 点の充足を記録します。
+その run が terminate するまで待ちます。ここで待つ対象は run record state であり、
+target completion state ではありません。run が終端した結果 `validity: invalid` で
+あっても、待機義務としては充足です。一度も `completed@target` になっていない member へ
+この例外を適用してはいけません。この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
@@ -589,7 +592,7 @@ bounded retry でも解消しない恒久的な `unknown` である場合、条�
 形だけ行って恒久 failure と宣言したり、待機を避けるために class を再宣言したりする
 ことは、この route の用途ではありません。
 
-手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
+merge-ready は、accepted fix による target 変更のたびに、全 member へ final target の
 full re-review を新たに要求するものではありません。どこまで再 review が必要かは
 Review stopping rules に従い、上記の例外がその範囲を定めます。
 
@@ -654,42 +657,46 @@ precondition の evidence は自動的に持ち越しません。target 変更�
 review / closure / merge の根拠とする前に、artifact classification が要求する
 precondition check（Executable の deterministic verify、Normative の mechanical
 check）を新しい target に対して再成立させます。
+
+この節における review target は、Selection Contract で確定した expected target
+SHA / commit range と target artifact set の組を指します。**どれか 1 つでも変われば
+review target の変更です。**
+head SHA が不変でも commit range の endpoint が変わった場合、また expected target
+SHA / commit range が不変でも target artifact set が変わった場合も、review target の
+変更として同じ scope です。
+precondition evidence、discovery evidence、closure
+evidence はいずれも target-specific であり、確定した target と一致しない evidence を
+review / closure / merge の根拠にしません。
 review / closure / merge の根拠として使う precondition evidence は、review 対象
 として確定した（freeze / Selection された）target と一致していなければなりません。
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
-この一致確認は SHA / range だけでなく、selected target artifact set にも
-及びます。Selection で確定した target artifact set が、その precondition
-check の対象 scope に含まれることを確認します。precondition check を
-Selection より前に実行した場合は、Selection 後にこの binding を確認し
-ます。selected artifact set を precondition evidence がカバーしていると
-確認できない場合は、確定した target に対して precondition check を
-再実行してから先へ進みます。
+この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。
+Selection で確定した target artifact set が、その precondition check の対象 scope に
+含まれることを確認します。precondition check を Selection より前に実行した場合は、
+Selection 後にこの binding を確認します。selected artifact set を precondition
+evidence がカバーしていると確認できない場合は、確定した target に対して precondition
+check を再実行してから先へ進みます。
 
-precondition evidence だけでなく、discovery / closure evidence も target-specific
-です。valid な discovery の後、accepted-fix による closure target の変更以外の
-理由で review target が変わった場合、その discovery を新しい target の
-merge / completion evidence として使いません。新しい target について artifact
-classification が要求する precondition check を再成立させ、Selection / Execution
-を再確立した上で、その target に必要な discovery を行います。accepted fix による
-target 変更は、既存の targeted closure（Executable）/ closure verification
+このうち target / range / artifact set の drift と、precondition evidence が確定した
+target SHA を指しているかは deterministic であり、Merge-ready completion fence が
+参照する checker が機械判定します。照合手順を本節に置きません。precondition check が
+どの artifact scope を対象としたかは check ごとに異なるため、その scope が selected
+artifact set をカバーしているかの確認は引き続き agent が行います。
+
+valid な discovery の後、accepted-fix による closure target の変更以外の理由で review
+target が変わった場合、その discovery を新しい target の merge / completion evidence
+として使いません。新しい target について precondition check を再成立させ、Selection /
+Execution を再確立した上で、その target に必要な discovery を行います。accepted fix に
+よる target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
-この節における review target は、Selection Contract で確定した expected
-target SHA / commit range と target artifact set の組を指します。どちらか
-一方でも変われば review target の変更です。head SHA が不変でも commit
-range の endpoint が変わった場合、また expected target SHA / commit range
-が不変でも target artifact set が変わった場合も、review target の変更と
-して同じ scope です。この場合も、old discovery / closure evidence を
-新しい target の merge / completion evidence として使いません。
-
-closure Resolution で accepted fix が生じ、その fix を closure review で
-確認する cycle（Executable の targeted closure、Normative の closure
-verification のいずれも）が繰り返し発生する場合、無制限に継続せず、
-upstream task/design または policy/document 自体の instability を疑い、
-必要に応じて escalate します。これは Failure / retry の retry count とは
-別の stopping semantics です。
+closure Resolution で accepted fix が生じ、その fix を closure review で確認する
+cycle（Executable の targeted closure、Normative の closure verification のいずれも）が
+繰り返し発生する場合、無制限に継続せず、upstream task/design または policy/document
+自体の instability を疑い、必要に応じて escalate します。これは Failure / retry の
+retry count とは別の stopping semantics です。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
@@ -731,35 +738,26 @@ provider 名や provider 固有の skill 機構（特定 CLI の skill directory
 することは **MUST** です。skill は本節の規範的なルールを複製せず、手順を説明します。
 skill を load せずに review 手順を進めることは、この routing contract への違反です。
 
-#### Mixed-classification review target
+1 つの review target が、mandatory review skill を持つ classification（Executable と
+Normative）を複数含む場合（mixed-classification review target）、**該当する
+classification すべてに対応する skill を load することを MUST とします。** いずれか
+1 つの classification の skill だけを load し、他の classification に属する artifact も
+それで代替したことにしてはいけません。各 classification の手続き的 obligation
+（stopping rule、discovery round 数、required review 数、closure / verification 手順）
+は、その classification に属する artifact subset にのみ適用し、他の classification へ
+流用しません。複数の skill を load した場合、各 skill の discovery / closure /
+stopping semantics は classification ごとに独立した review flow として並行に適用して
+よく、単一の flow へ統合することを要求しません。
 
-1 つの review target が、異なる artifact classification に属する artifact を同時に
-含む場合（mixed-classification review target）、上記の table は 1 つの skill だけを
-選べば足りるという意味ではありません。
+target に Informational な artifact が同時に含まれていても、Informational に mandatory
+review skill が無いという Artifact classification の定義は変わりません。
 
-- target に含まれる artifact classification のうち、mandatory review skill を持つ
-  classification（上記 table の Executable および Normative）が複数含まれる場合、
-  該当する classification すべてに対応する skill を load することを MUST とします。
-  いずれか 1 つの classification の skill だけを load し、他の classification に
-  属する artifact もそれで代替したことにしてはいけません。
-- 各 classification の手続き的 obligation（stopping rule、discovery round 数、
-  required review 数、closure / verification 手順を含む）は、その classification に
-  属する artifact subset にのみ適用します。ある classification の rule を、他の
-  classification に属する artifact へ流用してはいけません（例: Normative の
-  1 round discovery を Executable の artifact へ適用しない、Executable の
-  discovery -> triage -> batch fix -> verify -> targeted closure を Normative の
-  artifact へ適用しない）。
-- target に Informational な artifact が同時に含まれていても、Informational に
-  mandatory review skill が無いという Artifact classification の定義は変わりません。
-  Informational の artifact subset は、他の classification の skill が定義する
-  手続きの対象に含めません。
-- 複数の skill を load した場合、各 skill が定義する discovery / closure /
-  stopping semantics は、classification ごとに独立した review flow として並行に
-  適用してよく、単一の flow へ統合することを要求しません。
-
-この routing は Skill routing contract の 1:1 table を置き換えません。target が
-単一の classification のみで構成される場合は、上記 table のとおり単一の skill を
-load します。
+**changed artifact set から required skill を導出する判定は、agent の自己申告だけで
+決めません。** Foundation-owned な deterministic checker が changed artifact set から
+required skill を導出し、Selection が宣言した routing がそれを満たしているかを照合
+します。path から class を確実に導出できない artifact を、checker が勝手に特定の class
+へ分類することはありません。その場合の扱いは checker の出力に従い、classification の
+確定そのものは Selection Contract が所有します。
 
 `.ai-dev-foundation/skills/` は Foundation-owned な配布物です。consumer はこの path
 を編集しません。canonical source は Foundation リポジトリの `skills/` であり、

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -27,12 +27,13 @@ review でも同じ意味で適用します。
 
 迷ったらこの順に進めます。各 step の詳細・分岐・例外は `## 手順` にあります。
 
-1. repository が定義する deterministic verify（`npm test` 等）を実行する。
-2. review 対象の commit SHA を freeze する。
+1. repository が定義する deterministic verify（`npm test` 等）を実行し、**どの SHA に
+   対して実行したかを記録する**。
+2. review 対象の commit SHA と target artifact set を freeze する。
 3. reviewer capability record（`.ai-dev-foundation/reviewers.json`）を読む。無ければ
    Selection へ進まず停止して escalate する。
-4. record の `required_selection` に従って required slot を埋め、expected review set を
-   確定して Selection を記録する。
+4. record の `required_selection` に従って required slot を埋め、expected review set と
+   required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
 6. 状態は会話内の記憶ではなく、fresh 取得で確認する。
 
@@ -40,15 +41,23 @@ review でも同じ意味で適用します。
    node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --json
    ```
 
-7. fresh snapshot を state evaluator へ渡して target completion state を読む。
-   `completed@target` は current target に binding があり、coverage が complete な場合だけ
-   required review completion として扱います。`not-bound` は別 target の完了です。
-   `rate-limited` / `failed` / `declined` は明示された signal と complete coverage が
-   必要です。`unknown` と `in-flight` は terminal failure ではなく、沈黙、preamble、
-   acknowledgement、fetch incomplete、marker 不明を positive/negative に変換しません。
-   finding の意味付け、Resolution、fallback の policy は `policy/core.md` に従います。
+7. fresh snapshot を state evaluator へ渡して target completion state を読み、
+   **triage の対象にした result の `canonical_id` と `body_digest` を記録する**。
+   `completed@target` は current target に binding があり、coverage が complete な場合
+   だけです。`not-bound` は別 target の完了です。`unknown` と `in-flight` は terminal
+   failure ではなく、沈黙、preamble、acknowledgement、fetch incomplete、marker 不明を
+   positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
+   は `policy/core.md` に従います。
 8. accepted finding を batch で fix し、target が動いたら targeted closure を回す。
-9. merge-ready fence を評価してから merge-ready を宣言する。merge の実行は authority に従う。
+9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
+   authority に従う。
+
+   ```text
+   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+     --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
+     --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
+     --acknowledged-file <path>
+   ```
 
 ## reviewer capability record
 
@@ -90,31 +99,27 @@ required/expected review の消化根拠にしてはいけません。この区�
 
 ## 手順
 
-1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
-   と、その verify が対象とした artifact / package / repository scope を
-   必要な精度で記録した上で、repository が定義する verify（`npm test` / `npm
-run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
-   応じたもの）を実行します。repository 全体を対象とする verify であれば
-   repo-wide として記録すれば十分です。
-2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
-   commit range を review target として使う場合は、対象となる range も
-   同時に freeze し、以降 SHA について述べる target mutation semantics を
-   range にも同じ意味で適用します。
-   手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致する
-   ことを確認します。一致しない場合は、freeze した SHA に対して手順 1 の
-   deterministic verify を再実行し、成功してから先へ進みます。
-   discovery の completion / validity が確定する前にこの SHA が変わった場合、
-   その旧 review target / run を現在 target の evidence として扱いません。
-   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
-   re-freeze して必要な discovery をやり直します。
-   valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
-   re-freeze はしますが手順を最初からやり直さず、
-   手順 8〜13（deterministic verify -> targeted closure -> merge）に進みます。
-   手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
-   scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
-   その旧 review target / run を現在 target の evidence として扱いません。
-   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
-   re-freeze して必要な discovery をやり直します。
+1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA と、
+   その verify が対象とした artifact / package / repository scope を必要な精度で記録した上で、
+   repository が定義する verify（`npm test` / `npm run check:fixture` / consumer
+   `verify` / `git diff --check` 等、Task に応じたもの）を実行します。repository 全体を
+   対象とする verify であれば repo-wide として記録すれば十分です。
+   記録した SHA と freeze した target の一致は手順 13 の fence が機械判定するため、
+   手順の各所で手作業の SHA 照合を繰り返しません。scope が selected artifact set を
+   カバーしているかは fence の対象外で、手順 3 で確認します。target が動いたら verify を
+   やり直し、記録した SHA と scope を更新します。
+2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。commit range を
+   review target として使う場合は対象 range も、target artifact set も同時に freeze し、
+   以降 SHA について述べる target mutation semantics を range と artifact set にも同じ
+   意味で適用します。
+   target が動いたときにどう扱うかは、その動いた理由で決まります。
+   - discovery の completion / validity が確定する前に動いた場合、または **手順 7 の
+     batch fix 以外**の理由で動いた場合（並行作業、scope 追加、fix と無関係な commit
+     等）は、旧 review target / run を現在 target の evidence として扱いません。新しい
+     SHA に対して手順 1 の verify をやり直し、re-freeze して必要な discovery をやり直
+     します。
+   - valid な discovery の後、**手順 7 の batch fix によって**動いた場合は、re-freeze は
+     しますが手順を最初からやり直さず、手順 8〜13 へ進みます。
 3. **Selection** — 最初に reviewer capability record を読みます。record が存在しない、
    または parse / 最小妥当性 check を通らない場合は、Selection へ進まず停止して
    escalate します。record の `required_selection` に従って required slot を埋め、
@@ -123,9 +128,6 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    capability、required review 数、target artifact set、expected target
    SHA / applicable な commit range を決めます。commit range を使う場合は、
    対象範囲が曖昧にならない形で確定します。
-   target artifact set を確定した時点から、その artifact set も review
-   target の一部として扱い、手順 2 の target mutation semantics を
-   artifact set にも同じ意味で適用します。
    target artifact set を確定したら、直近の successful deterministic
    verify evidence が、確定した SHA / range と target artifact set の
    両方をカバーしているかを確認します。selected artifact set をその
@@ -133,6 +135,8 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
+   **Mixed classification の場合は、required な review skill をすべて宣言します。**
+   宣言した skill と changed artifact set の整合は手順 13 の fence が照合します。
    あわせて expected review set を確定します。自分が trigger した reviewer だけを
    set に入れて終わりにしません。membership の境界（何が member になり、presence
    だけでは何が member にならないか）と class ごとの扱いは Selection Contract
@@ -161,24 +165,19 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
    fresh に実行し、必要なら `--state --target-sha <sha> --run-after <timestamp>`
    （または `--run-anchor-id <id>`）で state evaluator を実行します。
-   evaluator は `review`、`review_comment`、`conversation_comment` の canonical
-   object と current body / revision / sources を返します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
+   **あわせて、triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
+   され得るため、この revision は手順 13 の fence が current revision と照合します
+   （`policy/core.md` の Acquisition & Validity Contract）。
    target-bound completion、run state、coverage、および binding の規範的な扱いは、いずれも
-   `policy/core.md` が定めます。
-   `completed@target` は current target に target-bound evidence があり、coverage が
-   complete な場合だけです。draft / pending ownership、actor attribution 不明、
-   binding 不明、または fetch incomplete は positive completion に使いません。
-   `not-bound` は別 target の完了です。`rate-limited` / `failed` / `declined` は
+   `policy/core.md` が定めます。`completed@target` は current target に target-bound
+   evidence があり、coverage が complete な場合だけです。draft / pending ownership、
+   actor attribution 不明、binding 不明、または fetch incomplete は positive completion に
+   使いません。`not-bound` は別 target の完了です。`rate-limited` / `failed` / `declined` は
    explicit signal と complete coverage が必要です。`in-flight` と `unknown` は
    terminal failure ではありません。preamble、acknowledgement、silence、空の snapshot
    を 0 findings や failure に変換しません。
-   同一 object の編集は current body、`updated_at`、body digest の snapshot projection
-   で扱い、履歴を保存しません。record の actor login と exact match する observation
-   から得た stable actor ID は同じ snapshot 内の login drift の補助にだけ使います。
-   completion と validity は独立した判定とし、target SHA / artifact set 等が一致しない
-   completed run は invalid として表現できます。`none` / `unknown` / `failure` は
-   completion / validity と混同せず、Acquisition & Validity Contract に従って記録します。
 6. **Required review gate & aggregate / triage** — state と run record を
    `policy/core.md` の Acquisition & Validity Contract に照合します。state は finding
    の有無を表しません。required run が揃った後の finding の集約と Resolution は同
@@ -199,61 +198,41 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    し、必要な deterministic verify と targeted closure を行います。state evaluator
    は fallback を実行せず、fallback policy は `policy/core.md` に委ねます。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
-   変更された場合のみ、fix 後に手順 1 の verify を再実行します。
+   変更された場合のみ、fix 後に手順 1 の verify を再実行し、記録した verify SHA を
+   更新します。
 9. **Second full discovery（条件付き）** — Review stopping rules
    （`policy/core.md`）に従って 2nd full discovery が必要と判断された
-   場合のみ、targeted closure の前に行います。
-   1. 現在の post-fix SHA を second discovery target として re-freeze
-      し、直近の successful deterministic verify target との
-      consistency を確認します。一致しない場合は、その verify evidence
-      を使わず、確定した second discovery target に対して
-      deterministic verify を行い、成功したら re-freeze して
-      Selection / Execution へ進みます。
-   2. Selection Contract をこの second discovery stage へ適用し、確定
-      した target artifact set まで直近の successful deterministic
-      verify evidence がカバーしているかを確認します。カバーしていると
-      確認できない場合は、確定した second discovery target に対して
-      deterministic verify を再実行し、成功してから Execution へ
-      進みます。
-   3. Execution Contract に従って full discovery（独立 reviewer）を
-      起動します。
-   4. Acquisition & Validity Contract をこの discovery run に適用します。
-   5. Selection で required とした review 数ぶんの valid run が揃うまで
-      triage へ進みません。揃わない run の扱いは Failure / retry
-      （`policy/core.md`）に従います。
-   6. finding を Resolution Contract で triage します。手順 6 と同じく、
-      集約対象は valid な run に限りません。`validity: valid` でない run で
-      既に発見された finding も Resolution Contract の対象です。
-   7. accepted finding があれば、手順 7 と同じ batch fix semantics で
-      まとめて fix します。
-   8. その fix によって target が変わった場合、手順 8 と同じ
-      deterministic verify を行います。
-      fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint や
-      target artifact set が accepted fix と無関係に変わった場合）、その独立した変更分は
-      手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。
-
-   second discovery の実行中、または completion / validity 確定前後に
-   accepted fix 以外の理由で target が変わった場合は、手順 2 と同じ
-   target-specific evidence の扱いに従います。
-   この second discovery の accepted finding の fix について、さらに
-   追加の discovery round が必要と判断される場合、3rd full discovery は
-   起動せず merge もせず、Review stopping rules（`policy/core.md`）に
-   従って upstream task/design の不安定さを疑い、必要に応じて escalate
-   します。
-
+   場合のみ、targeted closure の前に行います。現在の post-fix SHA を second discovery
+   target として re-freeze し、Selection Contract をこの second discovery stage へ適用し、
+   確定した target artifact set まで直近の successful deterministic verify evidence が
+   カバーしているかを確認します。カバーしていると確認できない場合は、確定した
+   second discovery target に対して deterministic verify を再実行し、成功してから
+   Execution へ進みます。その上で Execution Contract に従って full discovery
+   （独立 reviewer）を起動します。
+   Acquisition & Validity Contract をこの discovery run に適用します。Selection で required
+   とした review 数ぶんの valid run が揃うまで triage へ進みません。揃わない run の
+   扱いは Failure / retry（`policy/core.md`）に従います。finding は Resolution Contract で
+   triage し、手順 6 と同じく集約対象は valid な run に限りません。accepted finding が
+   あれば、手順 7 と同じ batch fix semantics でまとめて fix し、その fix によって
+   target が変わった場合、手順 8 と同じ deterministic verify を行います。
+   fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint や
+   target artifact set が accepted fix と無関係に変わった場合）、その独立した変更分は
+   手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。
+   second discovery の実行中、または completion / validity 確定前後に accepted fix 以外の
+   理由で target が変わった場合も同じ扱いです。
+   この second discovery の accepted finding の fix について、さらに追加の discovery
+   round が必要と判断される場合、3rd full discovery は起動せず merge もせず、Review
+   stopping rules（`policy/core.md`）に従って upstream task/design の不安定さを疑い、
+   必要に応じて escalate します。
 10. **Targeted closure** — この review flow で accepted finding の fix
     によって target が変更された場合のみ（手順 9 の second full
     discovery を挟んだ場合を含む）行います。最終的な post-fix SHA を
-    closure target として re-freeze し、直近の successful deterministic
-    verify target との consistency を確認します。一致しない場合は、その
-    verify evidence を使わず、確定した closure target に対して
-    deterministic verify を行い、成功したら re-freeze します。
-    Selection Contract に従ってこの closure target を expected target
-    として確定し、確定した closure artifact set まで直近の successful
-    deterministic verify evidence がカバーしているかを確認します。
-    カバーしていると確認できない場合は、確定した closure target に対
-    して deterministic verify を再実行し、成功してから Execution
-    Contract に従って closure run を起動します。
+    closure target として re-freeze し、Selection Contract に従ってこの closure target
+    を expected target として確定し、確定した closure artifact set まで直近の
+    successful deterministic verify evidence がカバーしているかを確認します。
+    カバーしていると確認できない場合は、確定した closure target に対して
+    deterministic verify を再実行し、成功してから Execution Contract に従って
+    closure run を起動します。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted
@@ -294,29 +273,31 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     のみ行います。authority が明示されていない、または別 authority の
     承認が必要な場合は merge を実行せず、merge-ready の状態を報告して
     停止し、authority escalation / handoff します。
-    この review flow で accepted finding の fix による
-    target 変更が一度も発生していなければ、required review 数の valid
-    discovery と Resolution（手順 6）が完了した時点で merge-ready と
-    判定します。
-    target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
-    discovery Resolution（手順 9 を使った場合はその Resolution も含む）
-    と、Closure Acquisition & Validity・Closure Resolution が完了した
-    時点で merge-ready と判定します。discovery Resolution と closure の
-    完了順序は
-    問いません。
+    この review flow で accepted finding の fix による target 変更が一度も発生して
+    いなければ、required review 数の valid discovery と Resolution（手順 6）が完了した
+    時点で semantic な条件が揃います。target 変更が発生していれば（手順 9 を挟んだ
+    場合を含む）、手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も
+    含む）と、Closure Acquisition & Validity・Closure Resolution の完了が必要です。
+    discovery Resolution と closure の完了順序は問いません。
 
-    そのうえで、merge-ready を宣言する直前の最後の action として、
-    `policy/core.md` の Merge-ready completion fence を評価します。
-    merge-ready の成立条件、review obligation の定義、および
-    review-relevant な state 変化による fence の無効化は `policy/core.md`
-    が定めます。
-    この skill で行う実務は次です。宣言の直前に expected review set を
-    fresh acquisition で閉じ直し、各 member の target completion state を
-    fresh に判定し、finding を安定 evidence 由来の reviewed target へ
-    帰属させ、triage されていない finding が review surface 上に残って
-    いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
-    しません。provider が thread の resolution 状態を持つ場合は、その
-    surface も未 triage finding の確認に使えます。
+    そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
+
+    ```text
+    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+      --target-sha <frozen target> --base-sha <frozen base> \
+      --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
+      --required <reviewer-id> --declared-skill review-code \
+      --acknowledged-file <手順 5 で記録した canonical_id=body_digest>
+    ```
+
+    fence は machine-checkable な precondition だけを評価します。`pass`（exit 0）の
+    場合にのみ merge-ready を宣言できます。`fail`（exit 1）と `unknown`（exit 2）は
+    どちらも merge-ready ではありません。`unknown` を `pass` として扱わないでください。
+    fence output はそのまま durable evidence として記録します。
+    fence が pass しても、それは merge-ready の成立そのものではありません。expected /
+    optional member を含む review obligation の充足と Resolution の完了は semantic な
+    判断であり、`policy/core.md` の Merge-ready completion fence が定めます。
+    review-relevant な state 変化があった場合の fence 無効化も同節が定めます。
 
 ## 停止条件
 
@@ -330,7 +311,6 @@ Executable artifact の review flow を、`policy/core.md` の Review stopping r
 ```text
 deterministic verify
   -> freeze candidate SHA
-  -> verify target と freeze target の consistency 確認
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
@@ -368,30 +348,13 @@ deterministic verify
             -> 追加の full discovery が不要な場合:
                  targeted closure を再実行する
        -> required discovery stage(s) の Resolution 完了
+       -> merge-ready fence
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
+       -> merge-ready fence
        -> merge
 ```
-
-accepted finding の batch fix によって review target が変更された場合のみ
-targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。targeted closure
-の finding も Resolution Contract の対象とし、Resolution が完了するまで
-merge しません。
-targeted closure の Resolution に加えて、この review flow で実行した
-discovery stage（2nd full discovery を含む）すべての Resolution が
-完了していることも merge の条件です。完了順序は問いません。
-targeted closure の finding に accepted fix がある場合も、fix 後の
-deterministic verify を経て Review stopping rules を再評価します。2nd
-full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
-に targeted closure を再実行します。2nd full discovery を使用済みでなお
-full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
-upstream task/design の不安定さを疑い、必要に応じて escalate します。
-追加の full discovery が不要なら、targeted closure を再実行します。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid discovery と Resolution の完了をもって、
-新たな closure run を要求せずに merge できます。
 
 ## Adapter boundary（manual pilot）
 
@@ -401,29 +364,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `trigger()`: record の `trigger` に従って起動し、どう起動したかを記録します。
 - `pollCompletion()`: `tooling/review-evidence.mjs --state` を fresh target と
   run anchor 付きで実行し、reduced state output と canonical object の sources /
-  current revision を記録します。どの field / surface を安定と判断して binding の根拠に
-  したかを残し、安定性を必要な精度で確認できないまま binding が成立したものとして
-  扱わないでください。`completed@target` だけを target-bound completion として扱い、
-  `unknown` / `in-flight` を terminal failure にしません。
+  current revision を記録します。`completed@target` だけを target-bound completion
+  として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存
-  します。fetch incomplete や actor / binding ambiguity は state を positive にせず、
-  追加取得が必要なら Review Adapter boundary（`policy/core.md`）に従います。reviewer
-  mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装
-  session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、
-  `policy/core.md` の record schema の各 field に加え、後続 session が Completion / Validity
-  を独立に判定できる根拠を durable に persist します。
-  この surface から `policy/core.md` の Acquisition & Validity Contract が定義する Completion
-  と Validity の要求事項を後続 session が独立に判定できれば、その surface 自体を同
-  Contract の record の recoverable な representation として result locator に使えます。
-  それらの要求事項のいずれかを surface から判定できない場合は、`policy/core.md` の
-  record schema の各 field に加え、上記の Completion / Validity 要求事項を独立に判定できる
-  情報を persist します。
+  します。reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合
+  （例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition &
+  Validity Contract が定める durable evidence の要求を、その手段で満たします。何を
+  persist すれば足りるかは同 Contract が定めます。
 - `normalizeFindings()`: finding の意味付けと Resolution はこの skill の機械判定へ
   複製せず、`policy/core.md` の Resolution Contract に従います。
 
 record が、結果を durable な GitHub surface へ残す trigger 経路を宣言している場合は、
 その経路を preferred route として使います。宣言された経路が unavailable / unsuitable で、
 in-session / subagent review を formal acquisition として使う場合は、上記
-`collectOutputs()` の persist 手順を完了することがその条件です。persist を完了するまで
+`collectOutputs()` の persist を完了することがその条件です。persist を完了するまで
 その run は formal acquisition になりません。この fallback は durable evidence
 requirement を免除しません。

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -51,29 +51,24 @@ record」節および「Adapter boundary」節に従います。この skill で
    および expected review set を確定します。expected review set は自分が
    trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
    記録は Selection Contract（`policy/core.md`）に従います。
-   手順 1 で記録した mechanical check 対象の target と、ここで確定する
-   target が一致することを確認します。一致しない場合は、確定した target に
-   対して手順 1 の mechanical check を再実行してから先へ進みます。
-   target artifact set を確定したら、直近の successful mechanical-check
-   evidence が、確定した target SHA / range と target artifact set の
-   両方をカバーしているかを確認します。selected artifact set をその
-   mechanical check evidence がカバーしていると確認できない場合は、
-   確定した target に対して手順 1 の mechanical check を再実行してから
-   手順 3（semantic discovery）へ進みます。
-   手順 3 の semantic discovery の completion / validity が確定する前に
-   target SHA / range または target artifact set が変わった場合、その
-   review target / run を現在 target の evidence として扱いません。
-   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
-   Selection をやり直し、手順 3 の semantic discovery を新しい target に
-   対して行います。
-   valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
-   batch fix 以外の理由で target SHA / range または target artifact set が
-   変わった場合（並行作業や scope 追加、finding 対応ではない文書変更、
-   無関係な commit 等）は、
-   旧 review target / run を現在 target の evidence として扱いません。
-   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
-   re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic
-   discovery を新しい target に対して行います。
+   **Mixed classification の場合は、required な review skill をすべて宣言します。**
+   手順 1 の mechanical check 対象と確定した target の一致、および宣言した routing と
+   changed artifact set の整合は、手順 9 の fence が機械判定します。手順の各所で
+   手作業の照合を繰り返しません。target が動いたら mechanical check をやり直し、
+   記録した check SHA を更新します。
+   check evidence がどの artifact scope をカバーしたかは fence の対象外です。
+   target artifact set を確定したら、直近の successful mechanical-check evidence が、
+   確定した target SHA / range と target artifact set の両方をカバーしているかを
+   確認します。selected artifact set をその mechanical check evidence がカバーして
+   いると確認できない場合は、確定した target に対して手順 1 の mechanical check を
+   再実行してから手順 3（semantic discovery）へ進みます。
+   target が動いたときにどう扱うかは、その動いた理由で決まります。手順 3 の semantic
+   discovery の completion / validity が確定する前に動いた場合、または手順 6 の accepted
+   finding batch fix 以外の理由で target SHA / range または target artifact set が
+   変わった場合（並行作業、scope 追加、finding 対応ではない文書変更、無関係な commit
+   等）は、旧 review target / run を現在 target の evidence として扱いません。新しい
+   target に対して手順 1 の mechanical check を再実行し、Selection をやり直して、
+   手順 3 の semantic discovery を新しい target に対して行います。
 3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い、
    Selection で確定した target SHA / range と target artifact set を
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -98,6 +93,9 @@ record」節および「Adapter boundary」節に従います。この skill で
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
+   **あわせて、triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
+   され得るため、この revision は手順 9 の fence が current revision と照合します。
    GitHub 上の durable review surface の取得は、Foundation リポジトリの
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
@@ -109,13 +107,13 @@ record」節および「Adapter boundary」節に従います。この skill で
    fix します。
 7. **Closure** — accepted finding の fix によって target SHA / range または
    target artifact set が変わった場合のみ行います。修正後の target に
-   対して手順 1 の mechanical check を再実行し、成功したらその SHA /
-   range を closure target として re-freeze し、Selection Contract
-   （`policy/core.md`）をこの closure review run に適用します。確定した
-   closure artifact set を、直近の mechanical-check evidence がカバー
-   していることを確認します。確認できない場合は、確定した closure
-   target に対して mechanical check を再実行してから、Execution
-   Contract（`policy/core.md`）を closure review run に適用します。
+   対して手順 1 の mechanical check を再実行し、成功したらその SHA / range を
+   closure target として re-freeze し、Selection Contract（`policy/core.md`）を
+   この closure review run に適用します。
+   確定した closure artifact set を、直近の mechanical-check evidence が
+   カバーしていることを確認します。確認できない場合は、確定した closure target に
+   対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
+   closure review run に適用します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
@@ -144,12 +142,21 @@ record」節および「Adapter boundary」節に従います。この skill で
    SHA / range も target artifact set も変更されていない場合）、この
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
-   宣言する場合は、宣言の直前の最後の action として、Merge-ready completion
-   fence（`policy/core.md`）を評価します。会話内で既に見た snapshot をこの
-   判定の根拠にせず、expected review set と各 member の target completion
-   state を fresh acquisition で判定し直します。merge-ready の成立条件と、
-   review-relevant な state 変化による fence の無効化は `policy/core.md` に
-   従います。
+   宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
+
+   ```text
+   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+     --target-sha <frozen target> --base-sha <frozen base> \
+     --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
+     --required <reviewer-id> --declared-skill review-doc \
+     --acknowledged-file <手順 4 で記録した canonical_id=body_digest>
+   ```
+
+   Mixed classification の target では、`--declared-skill` に該当する skill を
+   すべて渡します。`pass`（exit 0）の場合にのみ merge-ready を宣言できます。
+   `fail`（exit 1）と `unknown`（exit 2）はどちらも merge-ready ではありません。
+   merge-ready の成立条件と、review-relevant な state 変化による fence の無効化は
+   `policy/core.md` の Merge-ready completion fence に従います。
 
 ## 停止条件
 
@@ -166,7 +173,6 @@ Normative artifact の review flow を、`policy/core.md` の Review stopping ru
 
 ```text
 mechanical check
-  -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で review target が変更された場合:
@@ -176,21 +182,9 @@ mechanical check
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
        -> semantic discovery の Resolution 完了
+       -> merge-ready fence（merge-ready を宣言する場合）
        -> 完了
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
        -> 完了
 ```
-
-accepted finding の fix によって review target が変更された場合のみ、
-新しい target に対して mechanical check を再実行してから closure
-verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。closure
-verification の finding も Resolution Contract の対象とし、Resolution が
-完了するまで review を完了しません。
-closure verification の Resolution に加えて、semantic discovery（手順 3）
-の Resolution が完了していることも review completion の条件です。完了
-順序は問いません。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid semantic discovery と Resolution の完了をもって、
-新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -27,12 +27,13 @@ review でも同じ意味で適用します。
 
 迷ったらこの順に進めます。各 step の詳細・分岐・例外は `## 手順` にあります。
 
-1. repository が定義する deterministic verify（`npm test` 等）を実行する。
-2. review 対象の commit SHA を freeze する。
+1. repository が定義する deterministic verify（`npm test` 等）を実行し、**どの SHA に
+   対して実行したかを記録する**。
+2. review 対象の commit SHA と target artifact set を freeze する。
 3. reviewer capability record（`.ai-dev-foundation/reviewers.json`）を読む。無ければ
    Selection へ進まず停止して escalate する。
-4. record の `required_selection` に従って required slot を埋め、expected review set を
-   確定して Selection を記録する。
+4. record の `required_selection` に従って required slot を埋め、expected review set と
+   required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
 6. 状態は会話内の記憶ではなく、fresh 取得で確認する。
 
@@ -40,15 +41,23 @@ review でも同じ意味で適用します。
    node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --json
    ```
 
-7. fresh snapshot を state evaluator へ渡して target completion state を読む。
-   `completed@target` は current target に binding があり、coverage が complete な場合だけ
-   required review completion として扱います。`not-bound` は別 target の完了です。
-   `rate-limited` / `failed` / `declined` は明示された signal と complete coverage が
-   必要です。`unknown` と `in-flight` は terminal failure ではなく、沈黙、preamble、
-   acknowledgement、fetch incomplete、marker 不明を positive/negative に変換しません。
-   finding の意味付け、Resolution、fallback の policy は `policy/core.md` に従います。
+7. fresh snapshot を state evaluator へ渡して target completion state を読み、
+   **triage の対象にした result の `canonical_id` と `body_digest` を記録する**。
+   `completed@target` は current target に binding があり、coverage が complete な場合
+   だけです。`not-bound` は別 target の完了です。`unknown` と `in-flight` は terminal
+   failure ではなく、沈黙、preamble、acknowledgement、fetch incomplete、marker 不明を
+   positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
+   は `policy/core.md` に従います。
 8. accepted finding を batch で fix し、target が動いたら targeted closure を回す。
-9. merge-ready fence を評価してから merge-ready を宣言する。merge の実行は authority に従う。
+9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
+   authority に従う。
+
+   ```text
+   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+     --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
+     --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
+     --acknowledged-file <path>
+   ```
 
 ## reviewer capability record
 
@@ -90,31 +99,27 @@ required/expected review の消化根拠にしてはいけません。この区�
 
 ## 手順
 
-1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA
-   と、その verify が対象とした artifact / package / repository scope を
-   必要な精度で記録した上で、repository が定義する verify（`npm test` / `npm
-run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
-   応じたもの）を実行します。repository 全体を対象とする verify であれば
-   repo-wide として記録すれば十分です。
-2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。
-   commit range を review target として使う場合は、対象となる range も
-   同時に freeze し、以降 SHA について述べる target mutation semantics を
-   range にも同じ意味で適用します。
-   手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致する
-   ことを確認します。一致しない場合は、freeze した SHA に対して手順 1 の
-   deterministic verify を再実行し、成功してから先へ進みます。
-   discovery の completion / validity が確定する前にこの SHA が変わった場合、
-   その旧 review target / run を現在 target の evidence として扱いません。
-   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
-   re-freeze して必要な discovery をやり直します。
-   valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、
-   re-freeze はしますが手順を最初からやり直さず、
-   手順 8〜13（deterministic verify -> targeted closure -> merge）に進みます。
-   手順 7 の batch fix 以外の理由で candidate SHA が変わった場合（並行作業や
-   scope 追加、fix と無関係な commit 等）は、valid な discovery の後であっても
-   その旧 review target / run を現在 target の evidence として扱いません。
-   新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら
-   re-freeze して必要な discovery をやり直します。
+1. **Deterministic verify** — AI review を要求する前に、その時点の candidate SHA と、
+   その verify が対象とした artifact / package / repository scope を必要な精度で記録した上で、
+   repository が定義する verify（`npm test` / `npm run check:fixture` / consumer
+   `verify` / `git diff --check` 等、Task に応じたもの）を実行します。repository 全体を
+   対象とする verify であれば repo-wide として記録すれば十分です。
+   記録した SHA と freeze した target の一致は手順 13 の fence が機械判定するため、
+   手順の各所で手作業の SHA 照合を繰り返しません。scope が selected artifact set を
+   カバーしているかは fence の対象外で、手順 3 で確認します。target が動いたら verify を
+   やり直し、記録した SHA と scope を更新します。
+2. **Freeze candidate SHA** — review 対象の commit SHA を確定します。commit range を
+   review target として使う場合は対象 range も、target artifact set も同時に freeze し、
+   以降 SHA について述べる target mutation semantics を range と artifact set にも同じ
+   意味で適用します。
+   target が動いたときにどう扱うかは、その動いた理由で決まります。
+   - discovery の completion / validity が確定する前に動いた場合、または **手順 7 の
+     batch fix 以外**の理由で動いた場合（並行作業、scope 追加、fix と無関係な commit
+     等）は、旧 review target / run を現在 target の evidence として扱いません。新しい
+     SHA に対して手順 1 の verify をやり直し、re-freeze して必要な discovery をやり直
+     します。
+   - valid な discovery の後、**手順 7 の batch fix によって**動いた場合は、re-freeze は
+     しますが手順を最初からやり直さず、手順 8〜13 へ進みます。
 3. **Selection** — 最初に reviewer capability record を読みます。record が存在しない、
    または parse / 最小妥当性 check を通らない場合は、Selection へ進まず停止して
    escalate します。record の `required_selection` に従って required slot を埋め、
@@ -123,9 +128,6 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    capability、required review 数、target artifact set、expected target
    SHA / applicable な commit range を決めます。commit range を使う場合は、
    対象範囲が曖昧にならない形で確定します。
-   target artifact set を確定した時点から、その artifact set も review
-   target の一部として扱い、手順 2 の target mutation semantics を
-   artifact set にも同じ意味で適用します。
    target artifact set を確定したら、直近の successful deterministic
    verify evidence が、確定した SHA / range と target artifact set の
    両方をカバーしているかを確認します。selected artifact set をその
@@ -133,6 +135,8 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    target に対して手順 1 の deterministic verify を再実行し、成功して
    から手順 4（Execution）へ進みます。
    Executable artifact では原則として独立 reviewer を使います。
+   **Mixed classification の場合は、required な review skill をすべて宣言します。**
+   宣言した skill と changed artifact set の整合は手順 13 の fence が照合します。
    あわせて expected review set を確定します。自分が trigger した reviewer だけを
    set に入れて終わりにしません。membership の境界（何が member になり、presence
    だけでは何が member にならないか）と class ごとの扱いは Selection Contract
@@ -161,24 +165,19 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
    fresh に実行し、必要なら `--state --target-sha <sha> --run-after <timestamp>`
    （または `--run-anchor-id <id>`）で state evaluator を実行します。
-   evaluator は `review`、`review_comment`、`conversation_comment` の canonical
-   object と current body / revision / sources を返します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
+   **あわせて、triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
+   され得るため、この revision は手順 13 の fence が current revision と照合します
+   （`policy/core.md` の Acquisition & Validity Contract）。
    target-bound completion、run state、coverage、および binding の規範的な扱いは、いずれも
-   `policy/core.md` が定めます。
-   `completed@target` は current target に target-bound evidence があり、coverage が
-   complete な場合だけです。draft / pending ownership、actor attribution 不明、
-   binding 不明、または fetch incomplete は positive completion に使いません。
-   `not-bound` は別 target の完了です。`rate-limited` / `failed` / `declined` は
+   `policy/core.md` が定めます。`completed@target` は current target に target-bound
+   evidence があり、coverage が complete な場合だけです。draft / pending ownership、
+   actor attribution 不明、binding 不明、または fetch incomplete は positive completion に
+   使いません。`not-bound` は別 target の完了です。`rate-limited` / `failed` / `declined` は
    explicit signal と complete coverage が必要です。`in-flight` と `unknown` は
    terminal failure ではありません。preamble、acknowledgement、silence、空の snapshot
    を 0 findings や failure に変換しません。
-   同一 object の編集は current body、`updated_at`、body digest の snapshot projection
-   で扱い、履歴を保存しません。record の actor login と exact match する observation
-   から得た stable actor ID は同じ snapshot 内の login drift の補助にだけ使います。
-   completion と validity は独立した判定とし、target SHA / artifact set 等が一致しない
-   completed run は invalid として表現できます。`none` / `unknown` / `failure` は
-   completion / validity と混同せず、Acquisition & Validity Contract に従って記録します。
 6. **Required review gate & aggregate / triage** — state と run record を
    `policy/core.md` の Acquisition & Validity Contract に照合します。state は finding
    の有無を表しません。required run が揃った後の finding の集約と Resolution は同
@@ -199,61 +198,41 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
    し、必要な deterministic verify と targeted closure を行います。state evaluator
    は fallback を実行せず、fallback policy は `policy/core.md` に委ねます。
 8. **Deterministic verify** — 手順 7 の batch fix によって candidate SHA が
-   変更された場合のみ、fix 後に手順 1 の verify を再実行します。
+   変更された場合のみ、fix 後に手順 1 の verify を再実行し、記録した verify SHA を
+   更新します。
 9. **Second full discovery（条件付き）** — Review stopping rules
    （`policy/core.md`）に従って 2nd full discovery が必要と判断された
-   場合のみ、targeted closure の前に行います。
-   1. 現在の post-fix SHA を second discovery target として re-freeze
-      し、直近の successful deterministic verify target との
-      consistency を確認します。一致しない場合は、その verify evidence
-      を使わず、確定した second discovery target に対して
-      deterministic verify を行い、成功したら re-freeze して
-      Selection / Execution へ進みます。
-   2. Selection Contract をこの second discovery stage へ適用し、確定
-      した target artifact set まで直近の successful deterministic
-      verify evidence がカバーしているかを確認します。カバーしていると
-      確認できない場合は、確定した second discovery target に対して
-      deterministic verify を再実行し、成功してから Execution へ
-      進みます。
-   3. Execution Contract に従って full discovery（独立 reviewer）を
-      起動します。
-   4. Acquisition & Validity Contract をこの discovery run に適用します。
-   5. Selection で required とした review 数ぶんの valid run が揃うまで
-      triage へ進みません。揃わない run の扱いは Failure / retry
-      （`policy/core.md`）に従います。
-   6. finding を Resolution Contract で triage します。手順 6 と同じく、
-      集約対象は valid な run に限りません。`validity: valid` でない run で
-      既に発見された finding も Resolution Contract の対象です。
-   7. accepted finding があれば、手順 7 と同じ batch fix semantics で
-      まとめて fix します。
-   8. その fix によって target が変わった場合、手順 8 と同じ
-      deterministic verify を行います。
-      fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint や
-      target artifact set が accepted fix と無関係に変わった場合）、その独立した変更分は
-      手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。
-
-   second discovery の実行中、または completion / validity 確定前後に
-   accepted fix 以外の理由で target が変わった場合は、手順 2 と同じ
-   target-specific evidence の扱いに従います。
-   この second discovery の accepted finding の fix について、さらに
-   追加の discovery round が必要と判断される場合、3rd full discovery は
-   起動せず merge もせず、Review stopping rules（`policy/core.md`）に
-   従って upstream task/design の不安定さを疑い、必要に応じて escalate
-   します。
-
+   場合のみ、targeted closure の前に行います。現在の post-fix SHA を second discovery
+   target として re-freeze し、Selection Contract をこの second discovery stage へ適用し、
+   確定した target artifact set まで直近の successful deterministic verify evidence が
+   カバーしているかを確認します。カバーしていると確認できない場合は、確定した
+   second discovery target に対して deterministic verify を再実行し、成功してから
+   Execution へ進みます。その上で Execution Contract に従って full discovery
+   （独立 reviewer）を起動します。
+   Acquisition & Validity Contract をこの discovery run に適用します。Selection で required
+   とした review 数ぶんの valid run が揃うまで triage へ進みません。揃わない run の
+   扱いは Failure / retry（`policy/core.md`）に従います。finding は Resolution Contract で
+   triage し、手順 6 と同じく集約対象は valid な run に限りません。accepted finding が
+   あれば、手順 7 と同じ batch fix semantics でまとめて fix し、その fix によって
+   target が変わった場合、手順 8 と同じ deterministic verify を行います。
+   fix による変更を超えて target が動いた場合（例えば commit range の一方の endpoint や
+   target artifact set が accepted fix と無関係に変わった場合）、その独立した変更分は
+   手順 2 の non-fix target mutation semantics に従い、targeted closure だけでは扱いません。
+   second discovery の実行中、または completion / validity 確定前後に accepted fix 以外の
+   理由で target が変わった場合も同じ扱いです。
+   この second discovery の accepted finding の fix について、さらに追加の discovery
+   round が必要と判断される場合、3rd full discovery は起動せず merge もせず、Review
+   stopping rules（`policy/core.md`）に従って upstream task/design の不安定さを疑い、
+   必要に応じて escalate します。
 10. **Targeted closure** — この review flow で accepted finding の fix
     によって target が変更された場合のみ（手順 9 の second full
     discovery を挟んだ場合を含む）行います。最終的な post-fix SHA を
-    closure target として re-freeze し、直近の successful deterministic
-    verify target との consistency を確認します。一致しない場合は、その
-    verify evidence を使わず、確定した closure target に対して
-    deterministic verify を行い、成功したら re-freeze します。
-    Selection Contract に従ってこの closure target を expected target
-    として確定し、確定した closure artifact set まで直近の successful
-    deterministic verify evidence がカバーしているかを確認します。
-    カバーしていると確認できない場合は、確定した closure target に対
-    して deterministic verify を再実行し、成功してから Execution
-    Contract に従って closure run を起動します。
+    closure target として re-freeze し、Selection Contract に従ってこの closure target
+    を expected target として確定し、確定した closure artifact set まで直近の
+    successful deterministic verify evidence がカバーしているかを確認します。
+    カバーしていると確認できない場合は、確定した closure target に対して
+    deterministic verify を再実行し、成功してから Execution Contract に従って
+    closure run を起動します。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted
@@ -294,29 +273,31 @@ run check:fixture` / consumer `verify` / `git diff --check` 等、Task に
     のみ行います。authority が明示されていない、または別 authority の
     承認が必要な場合は merge を実行せず、merge-ready の状態を報告して
     停止し、authority escalation / handoff します。
-    この review flow で accepted finding の fix による
-    target 変更が一度も発生していなければ、required review 数の valid
-    discovery と Resolution（手順 6）が完了した時点で merge-ready と
-    判定します。
-    target 変更が発生していれば（手順 9 を挟んだ場合を含む）、手順 6 の
-    discovery Resolution（手順 9 を使った場合はその Resolution も含む）
-    と、Closure Acquisition & Validity・Closure Resolution が完了した
-    時点で merge-ready と判定します。discovery Resolution と closure の
-    完了順序は
-    問いません。
+    この review flow で accepted finding の fix による target 変更が一度も発生して
+    いなければ、required review 数の valid discovery と Resolution（手順 6）が完了した
+    時点で semantic な条件が揃います。target 変更が発生していれば（手順 9 を挟んだ
+    場合を含む）、手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も
+    含む）と、Closure Acquisition & Validity・Closure Resolution の完了が必要です。
+    discovery Resolution と closure の完了順序は問いません。
 
-    そのうえで、merge-ready を宣言する直前の最後の action として、
-    `policy/core.md` の Merge-ready completion fence を評価します。
-    merge-ready の成立条件、review obligation の定義、および
-    review-relevant な state 変化による fence の無効化は `policy/core.md`
-    が定めます。
-    この skill で行う実務は次です。宣言の直前に expected review set を
-    fresh acquisition で閉じ直し、各 member の target completion state を
-    fresh に判定し、finding を安定 evidence 由来の reviewed target へ
-    帰属させ、triage されていない finding が review surface 上に残って
-    いないことを確認します。会話内で既に見た snapshot をこの判定の根拠に
-    しません。provider が thread の resolution 状態を持つ場合は、その
-    surface も未 triage finding の確認に使えます。
+    そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
+
+    ```text
+    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+      --target-sha <frozen target> --base-sha <frozen base> \
+      --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
+      --required <reviewer-id> --declared-skill review-code \
+      --acknowledged-file <手順 5 で記録した canonical_id=body_digest>
+    ```
+
+    fence は machine-checkable な precondition だけを評価します。`pass`（exit 0）の
+    場合にのみ merge-ready を宣言できます。`fail`（exit 1）と `unknown`（exit 2）は
+    どちらも merge-ready ではありません。`unknown` を `pass` として扱わないでください。
+    fence output はそのまま durable evidence として記録します。
+    fence が pass しても、それは merge-ready の成立そのものではありません。expected /
+    optional member を含む review obligation の充足と Resolution の完了は semantic な
+    判断であり、`policy/core.md` の Merge-ready completion fence が定めます。
+    review-relevant な state 変化があった場合の fence 無効化も同節が定めます。
 
 ## 停止条件
 
@@ -330,7 +311,6 @@ Executable artifact の review flow を、`policy/core.md` の Review stopping r
 ```text
 deterministic verify
   -> freeze candidate SHA
-  -> verify target と freeze target の consistency 確認
   -> discovery（独立 reviewer）
   -> completion / acquisition / validity 確認
   -> aggregate / triage
@@ -368,30 +348,13 @@ deterministic verify
             -> 追加の full discovery が不要な場合:
                  targeted closure を再実行する
        -> required discovery stage(s) の Resolution 完了
+       -> merge-ready fence
        -> merge
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid discovery と Resolution の完了
+       -> merge-ready fence
        -> merge
 ```
-
-accepted finding の batch fix によって review target が変更された場合のみ
-targeted closure を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。targeted closure
-の finding も Resolution Contract の対象とし、Resolution が完了するまで
-merge しません。
-targeted closure の Resolution に加えて、この review flow で実行した
-discovery stage（2nd full discovery を含む）すべての Resolution が
-完了していることも merge の条件です。完了順序は問いません。
-targeted closure の finding に accepted fix がある場合も、fix 後の
-deterministic verify を経て Review stopping rules を再評価します。2nd
-full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後
-に targeted closure を再実行します。2nd full discovery を使用済みでなお
-full discovery が必要なら、3rd full discovery は起動せず、merge もせず、
-upstream task/design の不安定さを疑い、必要に応じて escalate します。
-追加の full discovery が不要なら、targeted closure を再実行します。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid discovery と Resolution の完了をもって、
-新たな closure run を要求せずに merge できます。
 
 ## Adapter boundary（manual pilot）
 
@@ -401,29 +364,19 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 - `trigger()`: record の `trigger` に従って起動し、どう起動したかを記録します。
 - `pollCompletion()`: `tooling/review-evidence.mjs --state` を fresh target と
   run anchor 付きで実行し、reduced state output と canonical object の sources /
-  current revision を記録します。どの field / surface を安定と判断して binding の根拠に
-  したかを残し、安定性を必要な精度で確認できないまま binding が成立したものとして
-  扱わないでください。`completed@target` だけを target-bound completion として扱い、
-  `unknown` / `in-flight` を terminal failure にしません。
+  current revision を記録します。`completed@target` だけを target-bound completion
+  として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存
-  します。fetch incomplete や actor / binding ambiguity は state を positive にせず、
-  追加取得が必要なら Review Adapter boundary（`policy/core.md`）に従います。reviewer
-  mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装
-  session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、
-  `policy/core.md` の record schema の各 field に加え、後続 session が Completion / Validity
-  を独立に判定できる根拠を durable に persist します。
-  この surface から `policy/core.md` の Acquisition & Validity Contract が定義する Completion
-  と Validity の要求事項を後続 session が独立に判定できれば、その surface 自体を同
-  Contract の record の recoverable な representation として result locator に使えます。
-  それらの要求事項のいずれかを surface から判定できない場合は、`policy/core.md` の
-  record schema の各 field に加え、上記の Completion / Validity 要求事項を独立に判定できる
-  情報を persist します。
+  します。reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合
+  （例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition &
+  Validity Contract が定める durable evidence の要求を、その手段で満たします。何を
+  persist すれば足りるかは同 Contract が定めます。
 - `normalizeFindings()`: finding の意味付けと Resolution はこの skill の機械判定へ
   複製せず、`policy/core.md` の Resolution Contract に従います。
 
 record が、結果を durable な GitHub surface へ残す trigger 経路を宣言している場合は、
 その経路を preferred route として使います。宣言された経路が unavailable / unsuitable で、
 in-session / subagent review を formal acquisition として使う場合は、上記
-`collectOutputs()` の persist 手順を完了することがその条件です。persist を完了するまで
+`collectOutputs()` の persist を完了することがその条件です。persist を完了するまで
 その run は formal acquisition になりません。この fallback は durable evidence
 requirement を免除しません。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -51,29 +51,24 @@ record」節および「Adapter boundary」節に従います。この skill で
    および expected review set を確定します。expected review set は自分が
    trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
    記録は Selection Contract（`policy/core.md`）に従います。
-   手順 1 で記録した mechanical check 対象の target と、ここで確定する
-   target が一致することを確認します。一致しない場合は、確定した target に
-   対して手順 1 の mechanical check を再実行してから先へ進みます。
-   target artifact set を確定したら、直近の successful mechanical-check
-   evidence が、確定した target SHA / range と target artifact set の
-   両方をカバーしているかを確認します。selected artifact set をその
-   mechanical check evidence がカバーしていると確認できない場合は、
-   確定した target に対して手順 1 の mechanical check を再実行してから
-   手順 3（semantic discovery）へ進みます。
-   手順 3 の semantic discovery の completion / validity が確定する前に
-   target SHA / range または target artifact set が変わった場合、その
-   review target / run を現在 target の evidence として扱いません。
-   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
-   Selection をやり直し、手順 3 の semantic discovery を新しい target に
-   対して行います。
-   valid な semantic discovery（手順 3）の後、手順 6 の accepted finding
-   batch fix 以外の理由で target SHA / range または target artifact set が
-   変わった場合（並行作業や scope 追加、finding 対応ではない文書変更、
-   無関係な commit 等）は、
-   旧 review target / run を現在 target の evidence として扱いません。
-   新しい target に対して手順 1 の mechanical check を再実行し、成功したら
-   re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic
-   discovery を新しい target に対して行います。
+   **Mixed classification の場合は、required な review skill をすべて宣言します。**
+   手順 1 の mechanical check 対象と確定した target の一致、および宣言した routing と
+   changed artifact set の整合は、手順 9 の fence が機械判定します。手順の各所で
+   手作業の照合を繰り返しません。target が動いたら mechanical check をやり直し、
+   記録した check SHA を更新します。
+   check evidence がどの artifact scope をカバーしたかは fence の対象外です。
+   target artifact set を確定したら、直近の successful mechanical-check evidence が、
+   確定した target SHA / range と target artifact set の両方をカバーしているかを
+   確認します。selected artifact set をその mechanical check evidence がカバーして
+   いると確認できない場合は、確定した target に対して手順 1 の mechanical check を
+   再実行してから手順 3（semantic discovery）へ進みます。
+   target が動いたときにどう扱うかは、その動いた理由で決まります。手順 3 の semantic
+   discovery の completion / validity が確定する前に動いた場合、または手順 6 の accepted
+   finding batch fix 以外の理由で target SHA / range または target artifact set が
+   変わった場合（並行作業、scope 追加、finding 対応ではない文書変更、無関係な commit
+   等）は、旧 review target / run を現在 target の evidence として扱いません。新しい
+   target に対して手順 1 の mechanical check を再実行し、Selection をやり直して、
+   手順 3 の semantic discovery を新しい target に対して行います。
 3. **Execution & Semantic discovery（1 round）** — Execution Contract に従い、
    Selection で確定した target SHA / range と target artifact set を
    reviewer の trigger へ渡して起動します。trigger 方法、実際に渡した
@@ -98,6 +93,9 @@ record」節および「Adapter boundary」節に従います。この skill で
    いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます。
    この skill で行う実務は、どの surface item を positive completion evidence とし、
    どの field / surface を安定と判断して binding の根拠にしたかを記録することです。
+   **あわせて、triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
+   され得るため、この revision は手順 9 の fence が current revision と照合します。
    GitHub 上の durable review surface の取得は、Foundation リポジトリの
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
@@ -109,13 +107,13 @@ record」節および「Adapter boundary」節に従います。この skill で
    fix します。
 7. **Closure** — accepted finding の fix によって target SHA / range または
    target artifact set が変わった場合のみ行います。修正後の target に
-   対して手順 1 の mechanical check を再実行し、成功したらその SHA /
-   range を closure target として re-freeze し、Selection Contract
-   （`policy/core.md`）をこの closure review run に適用します。確定した
-   closure artifact set を、直近の mechanical-check evidence がカバー
-   していることを確認します。確認できない場合は、確定した closure
-   target に対して mechanical check を再実行してから、Execution
-   Contract（`policy/core.md`）を closure review run に適用します。
+   対して手順 1 の mechanical check を再実行し、成功したらその SHA / range を
+   closure target として re-freeze し、Selection Contract（`policy/core.md`）を
+   この closure review run に適用します。
+   確定した closure artifact set を、直近の mechanical-check evidence が
+   カバーしていることを確認します。確認できない場合は、確定した closure target に
+   対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
+   closure review run に適用します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
@@ -144,12 +142,21 @@ record」節および「Adapter boundary」節に従います。この skill で
    SHA / range も target artifact set も変更されていない場合）、この
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
-   宣言する場合は、宣言の直前の最後の action として、Merge-ready completion
-   fence（`policy/core.md`）を評価します。会話内で既に見た snapshot をこの
-   判定の根拠にせず、expected review set と各 member の target completion
-   state を fresh acquisition で判定し直します。merge-ready の成立条件と、
-   review-relevant な state 変化による fence の無効化は `policy/core.md` に
-   従います。
+   宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
+
+   ```text
+   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+     --target-sha <frozen target> --base-sha <frozen base> \
+     --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
+     --required <reviewer-id> --declared-skill review-doc \
+     --acknowledged-file <手順 4 で記録した canonical_id=body_digest>
+   ```
+
+   Mixed classification の target では、`--declared-skill` に該当する skill を
+   すべて渡します。`pass`（exit 0）の場合にのみ merge-ready を宣言できます。
+   `fail`（exit 1）と `unknown`（exit 2）はどちらも merge-ready ではありません。
+   merge-ready の成立条件と、review-relevant な state 変化による fence の無効化は
+   `policy/core.md` の Merge-ready completion fence に従います。
 
 ## 停止条件
 
@@ -166,7 +173,6 @@ Normative artifact の review flow を、`policy/core.md` の Review stopping ru
 
 ```text
 mechanical check
-  -> mechanical check target と Selection target の consistency 確認
   -> semantic discovery（1 round）
   -> triage / fix
   -> accepted finding の fix で review target が変更された場合:
@@ -176,21 +182,9 @@ mechanical check
        -> closure completion / acquisition / validity 確認
        -> closure finding の Resolution
        -> semantic discovery の Resolution 完了
+       -> merge-ready fence（merge-ready を宣言する場合）
        -> 完了
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
        -> 完了
 ```
-
-accepted finding の fix によって review target が変更された場合のみ、
-新しい target に対して mechanical check を再実行してから closure
-verification を行い、その review run も Acquisition & Validity Contract
-に従って completion / acquisition / validity を確認します。closure
-verification の finding も Resolution Contract の対象とし、Resolution が
-完了するまで review を完了しません。
-closure verification の Resolution に加えて、semantic discovery（手順 3）
-の Resolution が完了していることも review completion の条件です。完了
-順序は問いません。
-accepted fix が無く review target が変更されていない場合は、
-required review 数の valid semantic discovery と Resolution の完了をもって、
-新たな closure run を要求せずに review を完了できます。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -675,23 +675,16 @@ SHA / commit range が不変でも target artifact set が変わった場合も�
 precondition evidence、discovery evidence、closure
 evidence はいずれも target-specific であり、確定した target と一致しない evidence を
 review / closure / merge の根拠にしません。
-review / closure / merge の根拠として使う precondition evidence は、review 対象
-として確定した（freeze / Selection された）target と一致していなければなりません。
-一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
-check を再実行します。
+target / range / artifact set の drift と、precondition evidence が確定した target SHA
+を指しているかは deterministic であり、Merge-ready completion fence が参照する checker
+が機械判定します。照合手順を本節に置きません。
 
-この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。
-Selection で確定した target artifact set が、その precondition check の対象 scope に
-含まれることを確認します。precondition check を Selection より前に実行した場合は、
-Selection 後にこの binding を確認します。selected artifact set を precondition
+checker が判定しないのは、precondition check がどの artifact scope を対象としたかです。
+これは check ごとに異なるため、Selection で確定した target artifact set がその scope に
+含まれることの確認は agent が行います。precondition check を Selection より前に実行した
+場合は、Selection 後にこの binding を確認します。selected artifact set を precondition
 evidence がカバーしていると確認できない場合は、確定した target に対して precondition
 check を再実行してから先へ進みます。
-
-このうち target / range / artifact set の drift と、precondition evidence が確定した
-target SHA を指しているかは deterministic であり、Merge-ready completion fence が
-参照する checker が機械判定します。照合手順を本節に置きません。precondition check が
-どの artifact scope を対象としたかは check ごとに異なるため、その scope が selected
-artifact set をカバーしているかの確認は引き続き agent が行います。
 
 valid な discovery の後、accepted-fix による closure target の変更以外の理由で review
 target が変わった場合、その discovery を新しい target の merge / completion evidence

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -412,19 +412,17 @@ Validity はさらに次を要求します。
 - required context へアクセスできた
 - execution / acquisition が途中で欠落していない
 
-Validity の判定は、reviewed target を確定させた上で、Selection Contract の
-expected target と比較して行います。reviewed target は次のように確定します。
+reviewed target をどの field / surface から確定するか、複数表現の間でどの binding を
+優先するか、および確定した reviewed target を expected target と照合する手順は、
+Foundation-owned な deterministic evaluator が所有します。その手順を本節に置きません。
+本節が定めるのは次の invariant です。
 
-- record の `target_sha` と acquired evidence 上の reviewed target が
-  両方存在する場合、両者は一致していなければなりません。
-  一致しない場合は invalid です。
-- reviewed target を Validity 判定に必要な精度で確認できない場合は unknown
-  です。
-
-確定した reviewed target が expected target と一致しない場合、
-completion していても invalid です。この場合、record は `status: completed`
-かつ `validity: invalid` として表現します。
-intended artifact set が review されていない場合も invalid です。
+- **reviewed target を Validity 判定に必要な精度で確認できない場合、その binding は
+  成立しておらず、判定結果は `unknown` です。** review target の移動に追随して値が
+  変化する field / surface を binding の根拠にしてはいけません。
+- 確定した reviewed target が expected target と一致しない場合、completion していても
+  invalid です。この場合、record は `status: completed` かつ `validity: invalid` として
+  表現します。intended artifact set が review されていない場合も invalid です。
 
 **acquisition の record は、後続 session から独立に recoverable な場所へ
 persist されて初めて durable evidence です。** review を行った
@@ -438,9 +436,7 @@ agent/session が終了した後、別の後続 session が session の記憶に
 別途 record を post し直す必要はありません。含まれていない場合
 （reviewer mechanism 自身がそのような surface へ結果を残さない場合、
 例えば実装 session 内で動く subagent review を含む）は、上記の record
-schema の各 field に加え、Completion と Validity の要求事項（reviewed
-target の一致、target artifact set の coverage、required context への
-アクセス可否、finding 内容、completion 状態を含む）を独立に判定できる
+schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
 情報を、そのような場所へ明示的に persist しない限り、session 終了後には
 recoverable な evidence として扱いません。record schema 自体（特に
 `validity` field）は判定結果の要約であり、その根拠情報の代わりには
@@ -451,35 +447,35 @@ parser 0 件、status success のみを `no findings` へ変換してはいけ�
 completion evidence のない empty output は `unknown` として扱います。
 
 **run record state と target completion state は別の対象です。** 上記の record schema の
-`status` / `validity` は、**個々の review run** の状態を表します。`unknown` / `failure`
-の語は本 Contract 内で複数の対象について現れるため、どちらの対象について述べているかを
-必ず明示します。これとは別に、
+`status` / `validity` は、**個々の review run** の状態を表します。これとは別に、
 **ある reviewer が、確定した review target について現在どこまで完了しているか**を
-**target completion state** と呼び、`completed@target` / `not-bound` / `declined` /
-`failed` / `unknown` で表現します。両者は同じ語で呼ばず、混同してはいけません。
+**target completion state** と呼びます。両者は同じ語で呼ばず、混同してはいけません。
 ancestor target に対する run は、run record としては `status: completed` かつ
 `validity: invalid` であり、同時にその reviewer の current target に対する target
 completion state は `not-bound` です。この 2 つは矛盾しません。
 
 **positive completion evidence は target-bound です。** ある reviewer の target
-completion state を `completed@target` とできるのは、取得済み surface item のうち、
-その target への resolvable な参照を持つ positive completion evidence が存在する場合に
-限ります。そのような evidence が無い場合、その state は `unknown`（または、reviewed
-target を確定できた上で一致しない場合は `not-bound`）であり、`0 findings` へ変換しては
-いけません。
+completion state を「current target について完了した」とできるのは、取得済み surface
+item のうち、その target への resolvable な参照を持つ positive completion evidence が
+存在する場合に限ります。そのような evidence が無い場合、その state は `unknown`
+（または、reviewed target を確定できた上で一致しない場合は `not-bound`）であり、
+`0 findings` へ変換してはいけません。
 
-reviewed target を確定させる evidence には、**その review run が実際に review した
-target を安定して表す field / surface** を使います。review target の移動に追随して
-値が変化する field / surface を binding の根拠にしてはいけません。どの field / surface
-が安定であるかの識別は Review Adapter boundary の責務であり、Kernel は安定性の要求と、
-**binding の根拠を記録すること**を定めます。**どちらが安定かを必要な精度で確認できない
-場合、その binding は成立しておらず、target completion state は `unknown` です。**
+**triage した review result の revision は、判断の対象です。** review result は
+in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
+その reviewer の target completion state は変わりません。したがって、ある run を
+merge / review completion の根拠とするには、triage / Resolution の対象とした result の
+revision が、判断時点の current revision と同一であることを確認します。この確認は
+deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+current revision が異なる場合、その result はまだ triage されていない result として
+扱います。
 
 本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
-membership class とその根拠、target completion state とその binding の根拠、および
-current target の clean / discovery evidence として採用した run——は、個々の run record
-schema ではなく、その review stage の Selection / fence 記録として persist します。
-これらは run 単位ではなく reviewer 単位・stage 単位の情報であるためです。
+membership class とその根拠、target completion state とその binding の根拠、triage の
+対象とした result の revision、および current target の clean / discovery evidence として
+採用した run——は、個々の run record schema ではなく、その review stage の Selection /
+fence 記録として persist します。これらは run 単位ではなく reviewer 単位・stage 単位の
+情報であるためです。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -537,24 +533,32 @@ merge authority が明示されていない場合、または別 authority の�
 
 #### Merge-ready completion fence
 
-merge-ready を宣言する前に、次を最後の action として評価します。この fence は Review
-stopping rules を置き換えず、参照します。
+merge-ready を宣言する前に、次の fence を最後の action として評価します。この fence は
+Review stopping rules を置き換えず、参照します。fence は 2 つの部分からなります。
 
-1. 確定した final candidate target を freeze する。
-2. Selection Contract に従って expected review set を閉じる。observed review
-   participation は、この評価時点の fresh acquisition で判定する。
-3. set の各 member について、fresh acquisition で target completion state を判定する。
-   positive completion evidence が無い member を `0 findings` へ変換しない。
-4. 各 member の finding を収集し、それぞれを安定 evidence 由来の reviewed target へ
-   帰属させる。
-5. finding を Resolution Contract に従って triage する。ancestor target で発見された
-   finding も対象とする。
-6. triage されていない finding が review surface 上に残っていないことを確認する。
-7. merge-ready は、**expected review set の各 member（optional / advisory を含む）の
-   review obligation が satisfied している**ことをもって成立する。
+**1. machine-checkable な precondition。** 確定した target / base / target artifact set
+が現在も同じであること、required reviewer の target completion state、acquisition の
+coverage、triage した review result の revision が現在も同じであること、review surface 上に
+未解決として残っている review conversation の有無、deterministic verification target との
+一致、changed artifact set が要求する skill routing、および merge 前に機械判定できる
+repository hygiene。これらは Foundation-owned な deterministic checker が
+**1 回の fresh acquisition** に対して評価します。どの surface がこれらを表すかの識別は
+Review Adapter boundary の責務であり、Kernel は provider 固有の surface 名を持ちません。
+判定手順は checker が canonical source であり、本節には置きません。checker は finding の
+意味、Resolution の完了、merge authority を判断しません。
 
-**review obligation** は、member の class ごとに次を指します。この定義が、手順 7 の
-判定対象です。
+**2. semantic judgment。** finding の意味と triage、Resolution の完了、および expected
+review set の各 member の review obligation が満たされたかどうか。これは agent が
+所有します。
+
+**checker の pass は merge-ready の成立ではありません。** checker が述べるのは
+machine-checkable な precondition が成立していることだけです。merge-ready は、それに
+加えて **expected review set の各 member（optional / advisory を含む）の review
+obligation が satisfied している**ことをもって成立します。checker が `pass` 以外
+（`fail` / `unknown` のいずれか）を返す間は merge-ready ではありません。`unknown` を
+`pass` として扱ってはいけません。
+
+**review obligation** は、member の class ごとに次を指します。
 
 - **required member**: Selection Contract の required review 数を満たす valid な run が
   揃っていること、およびその finding の Resolution が完了していること。ここでの
@@ -578,11 +582,10 @@ stopping rules を置き換えず、参照します。
 この例外が免除するのは、その member から**新たな** completion evidence を取得しに行く
 義務だけです。**既に走っている run の終端を待つ義務と、その member の初回 completion
 義務は免除しません。** current target に対する run が observed で in-flight なら、
-その run が terminate する（run record が `status` の終端値として確定する）まで
-待ちます。ここで待つ対象は run record state であり、target completion state では
-ありません。run が終端した結果 `validity: invalid` であっても、待機義務としては
-充足です。一度も `completed@target` になっていない member へこの例外を適用しては
-いけません。この例外に依拠する場合、上記 3 点の充足を記録します。
+その run が terminate するまで待ちます。ここで待つ対象は run record state であり、
+target completion state ではありません。run が終端した結果 `validity: invalid` で
+あっても、待機義務としては充足です。一度も `completed@target` になっていない member へ
+この例外を適用してはいけません。この例外に依拠する場合、上記 3 点の充足を記録します。
 
 expected member の条件 2 を、agent の内心の申告（「この member の沈黙には依拠して
 いない」等）で満たしたことにしてはいけません。判定は observable な target completion
@@ -597,7 +600,7 @@ bounded retry でも解消しない恒久的な `unknown` である場合、条�
 形だけ行って恒久 failure と宣言したり、待機を避けるために class を再宣言したりする
 ことは、この route の用途ではありません。
 
-手順 7 は、accepted fix による target 変更のたびに、全 member へ final target の
+merge-ready は、accepted fix による target 変更のたびに、全 member へ final target の
 full re-review を新たに要求するものではありません。どこまで再 review が必要かは
 Review stopping rules に従い、上記の例外がその範囲を定めます。
 
@@ -662,42 +665,46 @@ precondition の evidence は自動的に持ち越しません。target 変更�
 review / closure / merge の根拠とする前に、artifact classification が要求する
 precondition check（Executable の deterministic verify、Normative の mechanical
 check）を新しい target に対して再成立させます。
+
+この節における review target は、Selection Contract で確定した expected target
+SHA / commit range と target artifact set の組を指します。**どれか 1 つでも変われば
+review target の変更です。**
+head SHA が不変でも commit range の endpoint が変わった場合、また expected target
+SHA / commit range が不変でも target artifact set が変わった場合も、review target の
+変更として同じ scope です。
+precondition evidence、discovery evidence、closure
+evidence はいずれも target-specific であり、確定した target と一致しない evidence を
+review / closure / merge の根拠にしません。
 review / closure / merge の根拠として使う precondition evidence は、review 対象
 として確定した（freeze / Selection された）target と一致していなければなりません。
 一致しない場合はその evidence を根拠にせず、確定した target に対して precondition
 check を再実行します。
 
-この一致確認は SHA / range だけでなく、selected target artifact set にも
-及びます。Selection で確定した target artifact set が、その precondition
-check の対象 scope に含まれることを確認します。precondition check を
-Selection より前に実行した場合は、Selection 後にこの binding を確認し
-ます。selected artifact set を precondition evidence がカバーしていると
-確認できない場合は、確定した target に対して precondition check を
-再実行してから先へ進みます。
+この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。
+Selection で確定した target artifact set が、その precondition check の対象 scope に
+含まれることを確認します。precondition check を Selection より前に実行した場合は、
+Selection 後にこの binding を確認します。selected artifact set を precondition
+evidence がカバーしていると確認できない場合は、確定した target に対して precondition
+check を再実行してから先へ進みます。
 
-precondition evidence だけでなく、discovery / closure evidence も target-specific
-です。valid な discovery の後、accepted-fix による closure target の変更以外の
-理由で review target が変わった場合、その discovery を新しい target の
-merge / completion evidence として使いません。新しい target について artifact
-classification が要求する precondition check を再成立させ、Selection / Execution
-を再確立した上で、その target に必要な discovery を行います。accepted fix による
-target 変更は、既存の targeted closure（Executable）/ closure verification
+このうち target / range / artifact set の drift と、precondition evidence が確定した
+target SHA を指しているかは deterministic であり、Merge-ready completion fence が
+参照する checker が機械判定します。照合手順を本節に置きません。precondition check が
+どの artifact scope を対象としたかは check ごとに異なるため、その scope が selected
+artifact set をカバーしているかの確認は引き続き agent が行います。
+
+valid な discovery の後、accepted-fix による closure target の変更以外の理由で review
+target が変わった場合、その discovery を新しい target の merge / completion evidence
+として使いません。新しい target について precondition check を再成立させ、Selection /
+Execution を再確立した上で、その target に必要な discovery を行います。accepted fix に
+よる target 変更は、既存の targeted closure（Executable）/ closure verification
 （Normative）の扱いに従います。
 
-この節における review target は、Selection Contract で確定した expected
-target SHA / commit range と target artifact set の組を指します。どちらか
-一方でも変われば review target の変更です。head SHA が不変でも commit
-range の endpoint が変わった場合、また expected target SHA / commit range
-が不変でも target artifact set が変わった場合も、review target の変更と
-して同じ scope です。この場合も、old discovery / closure evidence を
-新しい target の merge / completion evidence として使いません。
-
-closure Resolution で accepted fix が生じ、その fix を closure review で
-確認する cycle（Executable の targeted closure、Normative の closure
-verification のいずれも）が繰り返し発生する場合、無制限に継続せず、
-upstream task/design または policy/document 自体の instability を疑い、
-必要に応じて escalate します。これは Failure / retry の retry count とは
-別の stopping semantics です。
+closure Resolution で accepted fix が生じ、その fix を closure review で確認する
+cycle（Executable の targeted closure、Normative の closure verification のいずれも）が
+繰り返し発生する場合、無制限に継続せず、upstream task/design または policy/document
+自体の instability を疑い、必要に応じて escalate します。これは Failure / retry の
+retry count とは別の stopping semantics です。
 
 full discovery は原則 1 round です。fix が behavior / blast radius を materially
 変えた場合のみ 2 round 目を許容します。それ以上必要な場合は review loop を増やさず、
@@ -739,35 +746,26 @@ provider 名や provider 固有の skill 機構（特定 CLI の skill directory
 することは **MUST** です。skill は本節の規範的なルールを複製せず、手順を説明します。
 skill を load せずに review 手順を進めることは、この routing contract への違反です。
 
-#### Mixed-classification review target
+1 つの review target が、mandatory review skill を持つ classification（Executable と
+Normative）を複数含む場合（mixed-classification review target）、**該当する
+classification すべてに対応する skill を load することを MUST とします。** いずれか
+1 つの classification の skill だけを load し、他の classification に属する artifact も
+それで代替したことにしてはいけません。各 classification の手続き的 obligation
+（stopping rule、discovery round 数、required review 数、closure / verification 手順）
+は、その classification に属する artifact subset にのみ適用し、他の classification へ
+流用しません。複数の skill を load した場合、各 skill の discovery / closure /
+stopping semantics は classification ごとに独立した review flow として並行に適用して
+よく、単一の flow へ統合することを要求しません。
 
-1 つの review target が、異なる artifact classification に属する artifact を同時に
-含む場合（mixed-classification review target）、上記の table は 1 つの skill だけを
-選べば足りるという意味ではありません。
+target に Informational な artifact が同時に含まれていても、Informational に mandatory
+review skill が無いという Artifact classification の定義は変わりません。
 
-- target に含まれる artifact classification のうち、mandatory review skill を持つ
-  classification（上記 table の Executable および Normative）が複数含まれる場合、
-  該当する classification すべてに対応する skill を load することを MUST とします。
-  いずれか 1 つの classification の skill だけを load し、他の classification に
-  属する artifact もそれで代替したことにしてはいけません。
-- 各 classification の手続き的 obligation（stopping rule、discovery round 数、
-  required review 数、closure / verification 手順を含む）は、その classification に
-  属する artifact subset にのみ適用します。ある classification の rule を、他の
-  classification に属する artifact へ流用してはいけません（例: Normative の
-  1 round discovery を Executable の artifact へ適用しない、Executable の
-  discovery -> triage -> batch fix -> verify -> targeted closure を Normative の
-  artifact へ適用しない）。
-- target に Informational な artifact が同時に含まれていても、Informational に
-  mandatory review skill が無いという Artifact classification の定義は変わりません。
-  Informational の artifact subset は、他の classification の skill が定義する
-  手続きの対象に含めません。
-- 複数の skill を load した場合、各 skill が定義する discovery / closure /
-  stopping semantics は、classification ごとに独立した review flow として並行に
-  適用してよく、単一の flow へ統合することを要求しません。
-
-この routing は Skill routing contract の 1:1 table を置き換えません。target が
-単一の classification のみで構成される場合は、上記 table のとおり単一の skill を
-load します。
+**changed artifact set から required skill を導出する判定は、agent の自己申告だけで
+決めません。** Foundation-owned な deterministic checker が changed artifact set から
+required skill を導出し、Selection が宣言した routing がそれを満たしているかを照合
+します。path から class を確実に導出できない artifact を、checker が勝手に特定の class
+へ分類することはありません。その場合の扱いは checker の出力に従い、classification の
+確定そのものは Selection Contract が所有します。
 
 `.ai-dev-foundation/skills/` は Foundation-owned な配布物です。consumer はこの path
 を編集しません。canonical source は Foundation リポジトリの `skills/` であり、

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -117,16 +117,20 @@ test("core policy separates merge-readiness from merge execution authority", asy
     /時点でmergeします/,
     "review-code.md Step 13 must not phrase review completion as an unqualified merge instruction",
   );
+  // Both branches must read as a semantic precondition being satisfied, not as
+  // a merge. Since Issue #76 the declaration additionally requires the
+  // deterministic fence to pass; the fence's own behavior is owned by
+  // test/merge-ready-fence-lib.test.mjs.
   assert.ok(
     containsText(
       reviewCode,
-      "required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge-ready と判定します。",
+      "required review 数の valid discovery と Resolution（手順 6）が完了した時点で semantic な条件が揃います。",
     ),
   );
   assert.ok(
     containsText(
       reviewCode,
-      "Closure Acquisition & Validity・Closure Resolution が完了した時点で merge-ready と判定します。",
+      "Closure Acquisition & Validity・Closure Resolution の完了が必要です。",
     ),
   );
 });

--- a/test/merge-ready-fence-lib.test.mjs
+++ b/test/merge-ready-fence-lib.test.mjs
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { evaluateReviewerTargetStates } from "../tooling/review-evidence-state-lib.mjs";
 import {
+  CLASS_REQUIRED_SKILL,
   FENCE_CHECK_IDS,
+  MANDATORY_REVIEW_SKILLS,
   MERGE_READY_FENCE_SCHEMA_ID,
   classifyArtifactPath,
   classifyArtifactPaths,
@@ -12,6 +17,8 @@ import {
   parseAcknowledgedRevisions,
   parseMergeReadyFenceArgs,
 } from "../tooling/merge-ready-fence-lib.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 // ---------------------------------------------------------------------------
 // Behavior fixtures for the deterministic merge-ready fence (Issue #76).
@@ -751,4 +758,45 @@ test("a fence pass is not a merge-ready claim: findings can be present and every
   });
   const { fence } = runFence({ snapshot });
   assert.equal(fence.status, "pass");
+});
+
+// The routing table is the single source of "which skills are mandatory".
+test("the mandatory skill set is the routing table's, not a second hand-written list", () => {
+  assert.deepEqual(
+    MANDATORY_REVIEW_SKILLS,
+    [...new Set(Object.values(CLASS_REQUIRED_SKILL).filter(Boolean))].sort(),
+  );
+  // Informational is a class with no mandatory skill, which is why the table's
+  // null entries are dropped rather than treated as a skill name.
+  assert.equal(CLASS_REQUIRED_SKILL.Informational, null);
+  assert.ok(!MANDATORY_REVIEW_SKILLS.includes(null));
+});
+
+// A setup failure must not be reported as a fence verdict: `fail` (exit 1) is a
+// judgment the fence reached, and an unreadable input file is not one. The CLI
+// is spawned here because the exit code is the contract, and it is reached
+// before any network call.
+test("a CLI setup failure exits 2 with no JSON on stdout, never exit 1", async () => {
+  const cli = path.join(root, "tooling", "merge-ready-fence.mjs");
+  const result = spawnSync(
+    process.execPath,
+    [cli, "--repo", "org/repo", "--pr", "1", "--target-sha", "abc1234", "--token", "dummy",
+     "--record", path.join(root, ".ai-dev-foundation", "reviewers.json"),
+     "--artifacts-file", path.join(root, "no-such-artifacts-file.txt")],
+    { encoding: "utf8", cwd: root },
+  );
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /no-such-artifacts-file/);
+  assert.match(result.stderr, /Usage: node tooling\/merge-ready-fence\.mjs/);
+});
+
+// The same rule for an argument error, which is the other way a caller reaches
+// the CLI without reaching a verdict.
+test("an unrecognized argument exits 2 with usage, not a verdict", () => {
+  const cli = path.join(root, "tooling", "merge-ready-fence.mjs");
+  const result = spawnSync(process.execPath, [cli, "--nope"], { encoding: "utf8", cwd: root });
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /Unrecognized argument: --nope/);
 });

--- a/test/merge-ready-fence-lib.test.mjs
+++ b/test/merge-ready-fence-lib.test.mjs
@@ -1,0 +1,754 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateReviewerTargetStates } from "../tooling/review-evidence-state-lib.mjs";
+import {
+  FENCE_CHECK_IDS,
+  MERGE_READY_FENCE_SCHEMA_ID,
+  classifyArtifactPath,
+  classifyArtifactPaths,
+  evaluateMergeReadyFence,
+  findClosingKeywordReferences,
+  normalizeSkillName,
+  parseAcknowledgedRevisions,
+  parseMergeReadyFenceArgs,
+} from "../tooling/merge-ready-fence-lib.mjs";
+
+// ---------------------------------------------------------------------------
+// Behavior fixtures for the deterministic merge-ready fence (Issue #76).
+//
+// These replace the test-only decision model that previously stood in for a
+// production fence: every rule asserted here is executed by tooling/ code that
+// ships, and the reviewer-state half is evaluated by the real #74 evaluator
+// rather than a re-implementation. Fixtures are written as behavior classes —
+// no provider name and no provider's current wording appears in an assertion.
+// ---------------------------------------------------------------------------
+
+const TARGET = "abcdef1234567890abcdef1234567890abcdef12";
+const OTHER_TARGET = "1234567890abcdef1234567890abcdef12345678";
+const BASE = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f";
+const OTHER_BASE = "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e";
+const ANCHOR = "2026-09-03T00:00:00.000Z";
+const OBSERVED = "2026-09-03T01:00:00.000Z";
+
+// Two distinct marker vocabularies, so a fixture never accidentally matches
+// the other reviewer's completion marker and the clean path stays clean.
+const PRIMARY_TARGET_PATTERN = "Reviewed commit:[^0-9a-fA-F]*([0-9a-fA-F]{7,40})";
+const ADVISOR_TARGET_PATTERN = "Advisory target:[^0-9a-fA-F]*([0-9a-fA-F]{7,40})";
+
+const RECORD = {
+  reviewers: [
+    {
+      id: "primary",
+      actors: ["primary-bot"],
+      completion_marker: { any_of: ["Reviewed commit:"], target_pattern: PRIMARY_TARGET_PATTERN },
+      rate_limit_marker: { any_of: ["Review rate limited"] },
+      failure_marker: { any_of: ["run encountered an error"] },
+      non_participation_marker: { any_of: ["Skipping this review"] },
+      in_flight_marker: { any_of: ["Review is working"] },
+    },
+    {
+      id: "advisor",
+      actors: ["advisor-bot"],
+      completion_marker: { any_of: ["Actionable comments posted:"], target_pattern: ADVISOR_TARGET_PATTERN },
+      rate_limit_marker: null,
+      failure_marker: null,
+      non_participation_marker: null,
+      in_flight_marker: null,
+    },
+  ],
+};
+
+function comment(id, login, body, fields = {}) {
+  return {
+    id,
+    actor: login,
+    actor_database_id: `db-${login}`,
+    actor_node_id: `node-${login}`,
+    body,
+    created_at: OBSERVED,
+    updated_at: OBSERVED,
+    locator: `conversation-${id}`,
+    ...fields,
+  };
+}
+
+function completionComment(id, login, targetSha, extra = "") {
+  const body =
+    login === "advisor-bot"
+      ? `Actionable comments posted: 0\nAdvisory target: ${targetSha}`
+      : `Review complete\nReviewed commit: ${targetSha}`;
+  return comment(id, login, `${body}${extra}`);
+}
+
+function surface(items, fetchStatus = "fetched") {
+  return { fetch_status: fetchStatus, count: items.length, items };
+}
+
+function thread(id, isResolved, isOutdated = false) {
+  return { id, is_resolved: isResolved, is_outdated: isOutdated, comments: [] };
+}
+
+function file(path, status = "modified") {
+  return { path, status, previous_path: null };
+}
+
+function evidence({
+  headSha = TARGET,
+  baseSha = BASE,
+  body = "Refs #76",
+  metadataStatus = "fetched",
+  comments = [completionComment(1, "primary-bot", TARGET), completionComment(2, "advisor-bot", TARGET)],
+  threads = [],
+  threadsStatus = "fetched",
+  files = [file("src/app.ts")],
+  filesStatus = "fetched",
+  reviewSubmissionsStatus = "fetched",
+} = {}) {
+  return {
+    repo: "org/repo",
+    pull_number: 76,
+    generated_at: OBSERVED,
+    pr_metadata:
+      metadataStatus === "fetched"
+        ? { fetch_status: "fetched", failure: null, head_sha: headSha, base_sha: baseSha, base_ref: "main", state: "open", html_url: null, updated_at: OBSERVED, body }
+        : { fetch_status: "failed", failure: { status: 500, message: "boom" }, head_sha: null, base_sha: null, base_ref: null, state: null, html_url: null, updated_at: null, body: null },
+    surfaces: {
+      conversation_comments: surface(comments),
+      review_submissions: surface([], reviewSubmissionsStatus),
+      inline_review_comments: surface([]),
+      review_threads: surface(threads, threadsStatus),
+      pull_request_files: surface(files, filesStatus),
+    },
+    fetch_failures: 0,
+  };
+}
+
+function stateFor(snapshot) {
+  return evaluateReviewerTargetStates(snapshot, {
+    record: RECORD,
+    target: { sha: TARGET },
+    runAnchor: { ids: [], after: ANCHOR },
+  });
+}
+
+/** Acknowledge every result revision exactly as it currently stands. */
+function acknowledgeAll(state) {
+  return state.reviewer_states.flatMap((entry) =>
+    (entry.evidence ?? []).map((item) => ({
+      canonical_id: item.canonical_id,
+      body_digest: item.revision.body_digest,
+    })),
+  );
+}
+
+function baseInputs(overrides = {}) {
+  return {
+    targetSha: TARGET,
+    baseSha: BASE,
+    artifacts: ["src/app.ts"],
+    verifySha: TARGET,
+    requiredReviewers: ["primary"],
+    declaredSkills: ["review-code"],
+    ...overrides,
+  };
+}
+
+/** Build snapshot -> #74 state -> fence, auto-acknowledging unless told otherwise. */
+function runFence({ snapshot = evidence(), inputs = {}, acknowledged } = {}) {
+  const state = stateFor(snapshot);
+  const resolved = baseInputs(inputs);
+  return {
+    state,
+    fence: evaluateMergeReadyFence({
+      evidence: snapshot,
+      state,
+      inputs: { ...resolved, acknowledged: acknowledged === undefined ? acknowledgeAll(state) : acknowledged },
+    }),
+  };
+}
+
+function checkOf(fence, id) {
+  const found = fence.checks.find((entry) => entry.id === id);
+  assert.ok(found, `fence is missing check ${id}`);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Output shape (Issue #76: the CLI output shape is a production contract, not
+// a durable record schema — so it is pinned here rather than validated at
+// runtime by a schema validator)
+// ---------------------------------------------------------------------------
+
+test("fence output shape is stable: schema, ordered checks, tri-state status", () => {
+  const { fence } = runFence();
+  assert.equal(fence.schema, MERGE_READY_FENCE_SCHEMA_ID);
+  assert.equal(fence.repo, "org/repo");
+  assert.equal(fence.pull_number, 76);
+  assert.equal(fence.captured_at, OBSERVED);
+  assert.deepEqual(fence.target, { sha: TARGET, base_sha: BASE });
+  assert.deepEqual(
+    fence.checks.map((entry) => entry.id),
+    FENCE_CHECK_IDS,
+  );
+  for (const entry of fence.checks) {
+    assert.ok(["pass", "fail", "unknown"].includes(entry.status));
+    assert.ok(Array.isArray(entry.reason_codes));
+    assert.equal(typeof entry.detail, "object");
+  }
+  assert.equal(fence.status, "pass");
+  assert.deepEqual(fence.reason_codes, []);
+});
+
+test("fixture 1 (clean path): current target, complete review, no thread, correct routing", () => {
+  const { fence } = runFence();
+  assert.equal(fence.status, "pass");
+  for (const entry of fence.checks) assert.equal(entry.status, "pass", `${entry.id} was ${entry.status}`);
+});
+
+test("fail outranks unknown when both are present", () => {
+  const { fence } = runFence({
+    snapshot: evidence({ headSha: OTHER_TARGET }),
+    inputs: { verifySha: null },
+  });
+  assert.equal(checkOf(fence, "target-head").status, "fail");
+  assert.equal(checkOf(fence, "verify-coherence").status, "unknown");
+  assert.equal(fence.status, "fail");
+});
+
+// ---------------------------------------------------------------------------
+// Target drift
+// ---------------------------------------------------------------------------
+
+test("fixture 2: head moved away from the frozen target -> fail", () => {
+  const { fence } = runFence({ snapshot: evidence({ headSha: OTHER_TARGET }) });
+  const check = checkOf(fence, "target-head");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["target_head_moved"]);
+  assert.equal(fence.status, "fail");
+});
+
+test("an abbreviated frozen SHA still matches the full current head", () => {
+  const { fence } = runFence({ inputs: { targetSha: TARGET.slice(0, 7) } });
+  assert.equal(checkOf(fence, "target-head").status, "pass");
+});
+
+test("fixture 3: base moved under the frozen range -> fail", () => {
+  const { fence } = runFence({ snapshot: evidence({ baseSha: OTHER_BASE }) });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["target_base_moved"]);
+});
+
+test("a frozen base that was never recorded is unknown, never a silent pass", () => {
+  const { fence } = runFence({ inputs: { baseSha: null } });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["frozen_base_missing"]);
+});
+
+test("fixture 4: an artifact appearing outside the frozen set -> fail", () => {
+  const { fence } = runFence({
+    snapshot: evidence({ files: [file("src/app.ts"), file("src/extra.ts")] }),
+  });
+  const check = checkOf(fence, "artifact-set");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["artifact_set_expanded"]);
+  assert.deepEqual(check.detail.added, ["src/extra.ts"]);
+});
+
+test("fixture 4b: an artifact disappearing from the frozen set -> fail (no subset tolerance)", () => {
+  const { fence } = runFence({
+    inputs: { artifacts: ["src/app.ts", "src/gone.ts"] },
+  });
+  const check = checkOf(fence, "artifact-set");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["artifact_set_reduced"]);
+  assert.deepEqual(check.detail.removed, ["src/gone.ts"]);
+});
+
+test("a changed-file surface that did not complete its fetch is unknown, not an empty set", () => {
+  const { fence } = runFence({ snapshot: evidence({ files: [], filesStatus: "failed" }) });
+  assert.equal(checkOf(fence, "artifact-set").status, "unknown");
+  assert.deepEqual(checkOf(fence, "artifact-set").reason_codes, ["changed_files_unavailable"]);
+  assert.equal(checkOf(fence, "skill-routing").status, "unknown");
+});
+
+// ---------------------------------------------------------------------------
+// Required reviewer completion (evaluated by the #74 evaluator, not re-parsed)
+// ---------------------------------------------------------------------------
+
+test("fixture 5: completed@target is the only state that satisfies a required reviewer", () => {
+  const { state, fence } = runFence();
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "primary").state, "completed@target");
+  assert.equal(checkOf(fence, "reviewer-completion").status, "pass");
+});
+
+test("fixture 6: not-bound (completed at another target) -> fail", () => {
+  const snapshot = evidence({
+    comments: [completionComment(1, "primary-bot", OTHER_TARGET), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { state, fence } = runFence({ snapshot });
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "primary").state, "not-bound");
+  const check = checkOf(fence, "reviewer-completion");
+  assert.equal(check.status, "fail");
+  assert.ok(check.reason_codes.includes("required_reviewer_not_completed_at_target"));
+});
+
+test("fixture 7: in-flight is unknown, never a terminal failure and never a pass", () => {
+  const snapshot = evidence({
+    comments: [comment(1, "primary-bot", "Review is working on it"), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { state, fence } = runFence({ snapshot });
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "primary").state, "in-flight");
+  const check = checkOf(fence, "reviewer-completion");
+  assert.equal(check.status, "unknown");
+  assert.ok(check.reason_codes.includes("required_reviewer_incomplete"));
+  assert.equal(fence.status, "unknown");
+});
+
+test("fixture 8: silence is unknown and is never converted to 0 findings", () => {
+  const snapshot = evidence({
+    comments: [comment(1, "primary-bot", "Thanks, taking a look"), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { state, fence } = runFence({ snapshot });
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "primary").state, "unknown");
+  assert.equal(checkOf(fence, "reviewer-completion").status, "unknown");
+  assert.equal(fence.status, "unknown");
+});
+
+test("fixture 23: a required reviewer declaring non-participation does not pass the gate", () => {
+  const snapshot = evidence({
+    comments: [comment(1, "primary-bot", "Skipping this review"), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { state, fence } = runFence({ snapshot });
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "primary").state, "declined");
+  const check = checkOf(fence, "reviewer-completion");
+  assert.equal(check.status, "fail");
+  assert.ok(check.reason_codes.includes("required_reviewer_not_completed_at_target"));
+});
+
+test("a rate-limited required reviewer is not a pass and not a silent skip", () => {
+  const snapshot = evidence({
+    comments: [comment(1, "primary-bot", "Review rate limited"), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { fence } = runFence({ snapshot });
+  assert.equal(checkOf(fence, "reviewer-completion").status, "fail");
+});
+
+test("the fence never infers the required set from the record's portfolio defaults", () => {
+  const { fence } = runFence({ inputs: { requiredReviewers: [] } });
+  const check = checkOf(fence, "reviewer-completion");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["required_reviewers_missing"]);
+});
+
+test("a required id absent from the record is unknown, not vacuously satisfied", () => {
+  const { fence } = runFence({ inputs: { requiredReviewers: ["nobody"] } });
+  const check = checkOf(fence, "reviewer-completion");
+  assert.equal(check.status, "unknown");
+  assert.ok(check.reason_codes.includes("required_reviewer_unknown_id"));
+});
+
+test("the evaluator's own reason codes are propagated rather than re-derived", () => {
+  const snapshot = evidence({
+    comments: [comment(1, "primary-bot", "Thanks, taking a look"), completionComment(2, "advisor-bot", TARGET)],
+  });
+  const { state, fence } = runFence({ snapshot });
+  const evaluatorCodes = state.reviewer_states.find((entry) => entry.reviewer === "primary").reason_codes;
+  assert.ok(evaluatorCodes.length > 0);
+  for (const code of evaluatorCodes) {
+    assert.ok(checkOf(fence, "reviewer-completion").reason_codes.includes(`reviewer_completion:${code}`));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Acquisition coverage and result revision coherence
+// ---------------------------------------------------------------------------
+
+test("fixture 9: an incomplete acquisition is unknown, on its own check", () => {
+  const { fence } = runFence({ snapshot: evidence({ reviewSubmissionsStatus: "partial" }) });
+  const check = checkOf(fence, "acquisition-coverage");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["coverage_incomplete"]);
+  assert.ok(check.detail.incomplete_surfaces.includes("surface:review_submissions"));
+  assert.equal(fence.status, "unknown");
+});
+
+test("fixture 10: a result edited in place after triage fails, even though it is still completed@target", () => {
+  // The canary #270 class: the completion marker survives the edit, so the
+  // reviewer state is unchanged — only the body digest moves.
+  const before = evidence();
+  const stateBefore = stateFor(before);
+  const acknowledged = acknowledgeAll(stateBefore);
+
+  const after = evidence({
+    comments: [
+      completionComment(1, "primary-bot", TARGET, "\n\nP1: this was added by an in-place edit"),
+      completionComment(2, "advisor-bot", TARGET),
+    ],
+  });
+  const stateAfter = stateFor(after);
+  assert.equal(stateAfter.reviewer_states.find((entry) => entry.reviewer === "primary").state, "completed@target");
+
+  const fence = evaluateMergeReadyFence({
+    evidence: after,
+    state: stateAfter,
+    inputs: { ...baseInputs(), acknowledged },
+  });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "fail");
+  assert.ok(check.reason_codes.includes("review_result_changed_after_triage"));
+  assert.equal(checkOf(fence, "reviewer-completion").status, "pass");
+  assert.equal(fence.status, "fail");
+});
+
+test("fixture 10b: an arrived result with no acknowledged revision at all -> fail", () => {
+  const { fence } = runFence({ acknowledged: null });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "fail");
+  assert.ok(check.reason_codes.includes("result_revision_unacknowledged"));
+});
+
+test("an advisory reviewer whose result has already arrived owes revision coherence", () => {
+  const state = stateFor(evidence());
+  const advisorEvidence = state.reviewer_states.find((entry) => entry.reviewer === "advisor").evidence;
+  assert.equal(advisorEvidence.length, 1);
+  const onlyPrimary = acknowledgeAll(state).filter(
+    (entry) => entry.canonical_id !== advisorEvidence[0].canonical_id,
+  );
+  const { fence } = runFence({ acknowledged: onlyPrimary });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "fail");
+  assert.ok(check.detail.required.some((row) => row.reviewer === "advisor" && row.result === "unacknowledged"));
+});
+
+test("an advisory reviewer that has not reported yet does not block", () => {
+  const snapshot = evidence({ comments: [completionComment(1, "primary-bot", TARGET)] });
+  const { state, fence } = runFence({ snapshot });
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "advisor").state, "unknown");
+  assert.equal(checkOf(fence, "result-revision-coherence").status, "pass");
+  assert.equal(fence.status, "pass");
+});
+
+test("a completed run bound to another target still owes revision coherence", () => {
+  const snapshot = evidence({
+    comments: [completionComment(1, "primary-bot", TARGET), completionComment(2, "advisor-bot", OTHER_TARGET)],
+  });
+  const state = stateFor(snapshot);
+  assert.equal(state.reviewer_states.find((entry) => entry.reviewer === "advisor").state, "not-bound");
+  const fence = evaluateMergeReadyFence({
+    evidence: snapshot,
+    state,
+    inputs: { ...baseInputs(), acknowledged: [] },
+  });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "fail");
+  assert.ok(check.detail.required.some((row) => row.reviewer === "advisor"));
+});
+
+test("revision coherence is unknown, not pass, while the acquisition is incomplete", () => {
+  const { fence } = runFence({ snapshot: evidence({ reviewSubmissionsStatus: "partial" }) });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["coverage_incomplete"]);
+});
+
+test("an acknowledgement for an id that is not a current result is reported, not silently accepted", () => {
+  const state = stateFor(evidence());
+  const acknowledged = [...acknowledgeAll(state), { canonical_id: "github://org/repo/pull/76/review/database:999", body_digest: "sha256:deadbeef" }];
+  const { fence } = runFence({ acknowledged });
+  const check = checkOf(fence, "result-revision-coherence");
+  assert.equal(check.status, "pass");
+  assert.deepEqual(check.detail.unmatched_acknowledgements, ["github://org/repo/pull/76/review/database:999"]);
+});
+
+test("revision coherence judges only sameness — it never inspects the result's content", () => {
+  // Two results whose bodies differ only in findings text both pass, as long
+  // as each was acknowledged at its current revision. The check says nothing
+  // about what the findings mean; that stays with the agent.
+  const snapshot = evidence({
+    comments: [
+      completionComment(1, "primary-bot", TARGET, "\n\nP0: unresolved authorization gap"),
+      completionComment(2, "advisor-bot", TARGET),
+    ],
+  });
+  const { fence } = runFence({ snapshot });
+  assert.equal(checkOf(fence, "result-revision-coherence").status, "pass");
+});
+
+// ---------------------------------------------------------------------------
+// Review threads
+// ---------------------------------------------------------------------------
+
+test("fixture 11: an unresolved thread blocks even when the finding was semantically fixed", () => {
+  const { fence } = runFence({ snapshot: evidence({ threads: [thread("T1", false)] }) });
+  const check = checkOf(fence, "review-threads");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["unresolved_review_thread"]);
+  assert.deepEqual(check.detail.unresolved_thread_ids, ["T1"]);
+});
+
+test("fixture 11b: an outdated unresolved thread is still unresolved", () => {
+  const { fence } = runFence({ snapshot: evidence({ threads: [thread("T1", false, true)] }) });
+  const check = checkOf(fence, "review-threads");
+  assert.equal(check.status, "fail");
+  assert.equal(check.detail.unresolved_outdated_count, 1);
+});
+
+test("fixture 12: resolved threads pass", () => {
+  const { fence } = runFence({ snapshot: evidence({ threads: [thread("T1", true), thread("T2", true)] }) });
+  assert.equal(checkOf(fence, "review-threads").status, "pass");
+  assert.equal(fence.status, "pass");
+});
+
+test("a thread whose resolution state was not returned is unknown, never resolved", () => {
+  const { fence } = runFence({ snapshot: evidence({ threads: [thread("T1", null)] }) });
+  const check = checkOf(fence, "review-threads");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["thread_resolution_unknown"]);
+});
+
+test("a review-thread surface that did not complete its fetch is unknown, not zero threads", () => {
+  const { fence } = runFence({ snapshot: evidence({ threads: [], threadsStatus: "failed" }) });
+  assert.equal(checkOf(fence, "review-threads").status, "unknown");
+});
+
+// ---------------------------------------------------------------------------
+// Artifact classification and skill routing
+// ---------------------------------------------------------------------------
+
+test("fixture 13: an Executable-only target routes to review-code", () => {
+  const classification = classifyArtifactPaths(["src/app.ts", "supabase/migrations/1_init.sql", "package.json"]);
+  assert.deepEqual(classification.classes, ["Executable"]);
+  assert.deepEqual(classification.required_skills, ["review-code"]);
+  assert.deepEqual(classification.unresolved_paths, []);
+});
+
+test("fixture 14: a Normative-only target routes to review-doc", () => {
+  const classification = classifyArtifactPaths([
+    "policy/core.md",
+    "AGENTS.md",
+    ".ai-dev-foundation/product-rules.md",
+    "docs/ADR-0004-review.md",
+  ]);
+  assert.deepEqual(classification.classes, ["Normative"]);
+  assert.deepEqual(classification.required_skills, ["review-doc"]);
+});
+
+test("fixture 15: a Mixed target requires both skills", () => {
+  const classification = classifyArtifactPaths(["src/app.ts", "policy/core.md"]);
+  assert.deepEqual(classification.classes, ["Executable", "Normative"]);
+  assert.deepEqual(classification.required_skills, ["review-code", "review-doc"]);
+});
+
+test("fixture 16: Informational artifacts add no mandatory review skill", () => {
+  const classification = classifyArtifactPaths(["README.md", "CHANGELOG.md"]);
+  assert.deepEqual(classification.classes, ["Informational"]);
+  assert.deepEqual(classification.required_skills, []);
+});
+
+test("fixture 17: an added artifact turning Executable into Mixed is caught by routing, not only by drift", () => {
+  const { fence } = runFence({
+    snapshot: evidence({ files: [file("src/app.ts"), file("policy/core.md")] }),
+    inputs: { artifacts: ["src/app.ts", "policy/core.md"], declaredSkills: ["review-code"] },
+  });
+  const check = checkOf(fence, "skill-routing");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["required_skill_missing"]);
+  assert.deepEqual(check.detail.missing_skills, ["review-doc"]);
+  assert.equal(checkOf(fence, "artifact-set").status, "pass");
+});
+
+test("declaring more skills than derived is safe and passes", () => {
+  const { fence } = runFence({ inputs: { declaredSkills: ["review-code", "review-doc"] } });
+  assert.equal(checkOf(fence, "skill-routing").status, "pass");
+});
+
+test("the declared skill accepts the distributed skill path form", () => {
+  assert.equal(normalizeSkillName(".ai-dev-foundation/skills/review-code.md"), "review-code");
+  assert.equal(normalizeSkillName("skills/review-doc.md"), "review-doc");
+  assert.equal(normalizeSkillName("review-code"), "review-code");
+  const { fence } = runFence({ inputs: { declaredSkills: [".ai-dev-foundation/skills/review-code.md"] } });
+  assert.equal(checkOf(fence, "skill-routing").status, "pass");
+});
+
+test("fixture 17b: a path the table cannot place is unresolved, never guessed into a class", () => {
+  assert.equal(classifyArtifactPath("test/cold-start-validation.md"), null);
+  assert.equal(classifyArtifactPath("Dockerfile"), null);
+  const { fence } = runFence({
+    snapshot: evidence({ files: [file("src/app.ts"), file("test/cold-start-validation.md")] }),
+    inputs: { artifacts: ["src/app.ts", "test/cold-start-validation.md"] },
+  });
+  const check = checkOf(fence, "skill-routing");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["artifact_class_unresolved"]);
+  assert.deepEqual(check.detail.unresolved_paths, ["test/cold-start-validation.md"]);
+});
+
+test("an unresolved path cannot under-route a Selection that already declared every mandatory skill", () => {
+  const { fence } = runFence({
+    snapshot: evidence({ files: [file("src/app.ts"), file("test/cold-start-validation.md")] }),
+    inputs: {
+      artifacts: ["src/app.ts", "test/cold-start-validation.md"],
+      declaredSkills: ["review-code", "review-doc"],
+    },
+  });
+  const check = checkOf(fence, "skill-routing");
+  assert.equal(check.status, "pass");
+  assert.deepEqual(check.reason_codes, ["artifact_class_unresolved_covered_by_declaration"]);
+});
+
+test("a Selection that declared no skill at all is unknown, not vacuously routed", () => {
+  const { fence } = runFence({ inputs: { declaredSkills: null } });
+  assert.equal(checkOf(fence, "skill-routing").status, "unknown");
+  assert.deepEqual(checkOf(fence, "skill-routing").reason_codes, ["declared_skills_missing"]);
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic verification coherence
+// ---------------------------------------------------------------------------
+
+test("fixture 18: verify target equal to the frozen target passes", () => {
+  const { fence } = runFence();
+  assert.equal(checkOf(fence, "verify-coherence").status, "pass");
+});
+
+test("fixture 19: verify target different from the frozen target -> fail", () => {
+  const { fence } = runFence({ inputs: { verifySha: OTHER_TARGET } });
+  const check = checkOf(fence, "verify-coherence");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["verify_target_mismatch"]);
+});
+
+test("fixture 20: missing verification evidence is unknown, never assumed current", () => {
+  const { fence } = runFence({ inputs: { verifySha: null } });
+  const check = checkOf(fence, "verify-coherence");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["verify_evidence_missing"]);
+});
+
+// ---------------------------------------------------------------------------
+// Auto-close hygiene
+// ---------------------------------------------------------------------------
+
+test("fixture 21: a closing keyword in the current PR body -> fail", () => {
+  const { fence } = runFence({ snapshot: evidence({ body: "Implements the fence.\n\nCloses #76" }) });
+  const check = checkOf(fence, "autoclose-hygiene");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["autoclose_keyword_present"]);
+  assert.deepEqual(check.detail.references, [{ keyword: "closes", reference: "#76" }]);
+});
+
+test("fixture 22: a body that only references an issue passes", () => {
+  const { fence } = runFence({ snapshot: evidence({ body: "Refs #76\nDepends on #74" }) });
+  assert.equal(checkOf(fence, "autoclose-hygiene").status, "pass");
+});
+
+test("every documented closing keyword form is detected, and plain references are not", () => {
+  const detected = findClosingKeywordReferences(
+    [
+      "close #1",
+      "closes #2",
+      "closed: #3",
+      "fix #4",
+      "fixes #5",
+      "fixed #6",
+      "resolve #7",
+      "resolves #8",
+      "resolved #9",
+      "fixes org/repo#10",
+      "closes https://github.com/org/repo/issues/11",
+    ].join("\n"),
+  );
+  assert.equal(detected.length, 11);
+  assert.deepEqual(findClosingKeywordReferences("Refs #12\nSee #13\nPart of #14"), []);
+  assert.deepEqual(findClosingKeywordReferences("this closes the gap"), []);
+});
+
+test("an empty PR body passes and a failed metadata fetch is unknown", () => {
+  assert.equal(checkOf(runFence({ snapshot: evidence({ body: null }) }).fence, "autoclose-hygiene").status, "pass");
+  const { fence } = runFence({ snapshot: evidence({ metadataStatus: "failed" }) });
+  assert.equal(checkOf(fence, "autoclose-hygiene").status, "unknown");
+  assert.equal(checkOf(fence, "target-head").status, "unknown");
+  assert.equal(checkOf(fence, "target-base").status, "unknown");
+});
+
+// ---------------------------------------------------------------------------
+// Argument contract
+// ---------------------------------------------------------------------------
+
+test("the fence CLI accepts no snapshot argument, so stale evidence cannot be supplied", () => {
+  assert.throws(
+    () => parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1", "--target-sha", TARGET, "--snapshot", "x.json"]),
+    /Unrecognized argument: --snapshot/,
+  );
+});
+
+test("the mandatory arguments are exactly repo, pr and target-sha", () => {
+  assert.throws(() => parseMergeReadyFenceArgs(["--pr", "1", "--target-sha", TARGET]), /--repo/);
+  assert.throws(() => parseMergeReadyFenceArgs(["--repo", "o/r", "--target-sha", TARGET]), /--pr/);
+  assert.throws(() => parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1"]), /--target-sha/);
+  assert.throws(() => parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1", "--target-sha"]), /Missing value/);
+  const args = parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1", "--target-sha", TARGET]);
+  assert.equal(args.artifacts, null);
+  assert.equal(args.acknowledged, null);
+  assert.deepEqual(args.requiredReviewers, []);
+  assert.deepEqual(args.declaredSkills, []);
+});
+
+test("repeatable arguments accumulate", () => {
+  const args = parseMergeReadyFenceArgs([
+    "--repo", "o/r", "--pr", "1", "--target-sha", TARGET,
+    "--artifact", "a.ts", "--artifact", "b.md",
+    "--required", "primary", "--required", "second",
+    "--declared-skill", "review-code", "--declared-skill", "review-doc",
+    "--acknowledged", "id-1=sha256:aa", "--acknowledged", "id-2=sha256:bb",
+  ]);
+  assert.deepEqual(args.artifacts, ["a.ts", "b.md"]);
+  assert.deepEqual(args.requiredReviewers, ["primary", "second"]);
+  assert.deepEqual(args.declaredSkills, ["review-code", "review-doc"]);
+  assert.deepEqual(args.acknowledged, ["id-1=sha256:aa", "id-2=sha256:bb"]);
+});
+
+test("acknowledged revisions parse from either separator and report malformed lines", () => {
+  const parsed = parseAcknowledgedRevisions(
+    ["# comment", "", "github://org/repo/pull/76/review/database:1=sha256:aa", "github://org/repo/pull/76/conversation_comment/database:2 sha256:bb", "garbage"].join("\n"),
+  );
+  assert.deepEqual(parsed.entries, [
+    { canonical_id: "github://org/repo/pull/76/review/database:1", body_digest: "sha256:aa" },
+    { canonical_id: "github://org/repo/pull/76/conversation_comment/database:2", body_digest: "sha256:bb" },
+  ]);
+  assert.deepEqual(parsed.malformed, ["garbage"]);
+});
+
+// ---------------------------------------------------------------------------
+// Boundary: what the fence must never decide
+// ---------------------------------------------------------------------------
+
+test("the fence has no input by which an agent can assert that Resolution is complete", () => {
+  const accepted = parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1", "--target-sha", TARGET]);
+  for (const key of Object.keys(accepted)) {
+    assert.ok(
+      !/resolution|resolved|triage|merge_ready|mergeReady|approve/i.test(key),
+      `fence argument ${key} would let an agent assert a semantic judgment`,
+    );
+  }
+  assert.throws(
+    () => parseMergeReadyFenceArgs(["--repo", "o/r", "--pr", "1", "--target-sha", TARGET, "--resolution-complete"]),
+    /Unrecognized argument/,
+  );
+});
+
+test("a fence pass is not a merge-ready claim: findings can be present and every check still pass", () => {
+  // The clean-path fixture carries a result body with a P0 in it. The fence
+  // reports pass because every machine-checkable precondition holds; whether
+  // the finding is resolved is the agent's judgment, not the fence's.
+  const snapshot = evidence({
+    comments: [
+      completionComment(1, "primary-bot", TARGET, "\n\nP0: something the agent must still triage"),
+      completionComment(2, "advisor-bot", TARGET),
+    ],
+  });
+  const { fence } = runFence({ snapshot });
+  assert.equal(fence.status, "pass");
+});

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -17,11 +17,30 @@ function containsText(haystack, needle) {
 // ---------------------------------------------------------------------------
 // Decision model
 //
-// TEST-ONLY executable encoding of the Merge-ready completion fence
-// (policy/core.md, Merge readiness and merge authority). Not a production
-// mechanism; nothing in tooling/ depends on it. Its purpose is to prove that
-// the normative rules, as written, yield the intended verdict for the failure
-// modes recorded in Issue #45 — rather than only asserting that prose exists.
+// TEST-ONLY executable encoding of the SEMANTIC half of the Merge-ready
+// completion fence (policy/core.md, Merge readiness and merge authority). Not a
+// production mechanism; nothing in tooling/ depends on it. Its purpose is to
+// prove that the normative rules, as written, yield the intended verdict for
+// the failure modes recorded in Issue #45 — rather than only asserting that
+// prose exists.
+//
+// Issue #76 moved the machine-checkable half into production
+// (tooling/merge-ready-fence-lib.mjs). The rules below were re-examined one by
+// one against it:
+//   - R2's "which field stably represents the reviewed target, and how
+//     competing representations rank" is owned by the #74 evaluator, proved by
+//     test/review-evidence-state.test.mjs. What survives here is the abstract
+//     precondition (`reviewedTargetIsStable`), taken as an input rather than
+//     re-derived, because R3/R4 need it to state their own claims.
+//   - R6's *state* gate for a required member is now also machine-checked
+//     (test/merge-ready-fence-lib.test.mjs, fixture 23). What survives here is
+//     the part the fence does not judge: that a Selection amendment is the only
+//     other discharge, and that declining never discharges a finding already
+//     produced.
+//   - R1, R3, R4 and R5 are NOT productionized. Issue #76 decided that expected
+//     and optional membership closure, the finding axis, and per-class review
+//     obligation stay with the agent. Deleting them here would delete the only
+//     regression proof those Kernel invariants have.
 //
 // Encoded rules, and only these:
 //   R1 expected review set = required | expected(declared automatic, or observed

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -785,18 +785,18 @@ test("core policy requires target-bound positive completion evidence on stable f
   assert.ok(containsText(core, "その target への resolvable な参照を持つ positive completion evidence"));
   assert.ok(containsText(core, "`0 findings` へ変換してはいけません"));
 
-  assert.ok(containsText(core, "target を安定して表す field / surface"));
+  // Which field/surface stably represents the reviewed target, and how competing
+  // representations are ranked, is decided by the #74 evaluator
+  // (test/review-evidence-state.test.mjs owns those cases). What stays normative
+  // is the requirement, the recording duty, and the fail-safe fallback.
   assert.ok(
     containsText(core, "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません"),
   );
-  assert.ok(containsText(core, "binding の根拠を記録すること"));
-
-  // The fallback when stability cannot be confirmed is normative and must live
-  // in the Kernel, not only in the Executable-only skill.
+  assert.ok(containsText(core, "target completion state とその binding の根拠"));
   assert.ok(
     containsText(
       core,
-      "どちらが安定かを必要な精度で確認できない場合、その binding は成立しておらず、target completion state は `unknown` です",
+      "reviewed target を Validity 判定に必要な精度で確認できない場合、その binding は成立しておらず、判定結果は `unknown` です",
     ),
   );
 
@@ -823,17 +823,39 @@ test("core policy defines the merge-ready completion fence without overriding st
     "the fence must sit inside Merge readiness and merge authority",
   );
 
-  assert.ok(containsText(core, "merge-ready を宣言する前に、次を最後の action として評価します"));
+  assert.ok(containsText(core, "merge-ready を宣言する前に、次の fence を最後の action として評価します"));
   assert.ok(containsText(core, "この fence は Review stopping rules を置き換えず、参照します"));
-  assert.ok(containsText(core, "Selection Contract に従って expected review set を閉じる"));
-  assert.ok(containsText(core, "positive completion evidence が無い member を `0 findings` へ変換しない"));
-  assert.ok(containsText(core, "安定 evidence 由来の reviewed target へ帰属させる"));
-  assert.ok(containsText(core, "ancestor target で発見された finding も対象とする"));
 
-  // Step 6 must be provider-neutral: tied to triage, not to a provider's thread
-  // concept, and not stricter than the Resolution Contract.
-  assert.ok(containsText(core, "triage されていない finding が review surface 上に残っていないことを確認する"));
+  // The step-by-step comparisons this section used to enumerate (re-closing the
+  // set from a fresh acquisition, reading each member's completion state,
+  // attributing findings to a stable reviewed target, checking unresolved
+  // conversations) are executed by the checker; the behavior fixtures in
+  // test/merge-ready-fence-lib.test.mjs own them. What the Kernel keeps is the
+  // split between the two halves, and the rule that the checker's verdict is a
+  // precondition rather than the conclusion.
+  assert.ok(containsText(core, "**1. machine-checkable な precondition。**"));
+  assert.ok(containsText(core, "**2. semantic judgment。**"));
+  assert.ok(containsText(core, "**checker の pass は merge-ready の成立ではありません。**"));
+  assert.ok(containsText(core, "`unknown` を `pass` として扱ってはいけません"));
+  assert.ok(containsText(core, "checker は finding の意味、Resolution の完了、merge authority を判断しません"));
+
+  // Un-triaged findings still block; that rule stays with the Resolution
+  // Contract instead of being restated as a fence step.
+  assert.ok(
+    containsText(
+      core,
+      "unresolved の finding（未解決の needs-verification / technical-dispute / intent-question 等を含む）が残る間は",
+    ),
+  );
+  // Naming a provider's surface here would make the fence provider-shaped; the
+  // Kernel names the obligation and defers surface identification to the adapter.
   assert.ok(!core.includes("unresolved review thread"), "the Kernel must not name a provider thread concept");
+  assert.ok(
+    containsText(
+      core,
+      "どの surface がこれらを表すかの識別は Review Adapter boundary の責務であり、Kernel は provider 固有の surface 名を持ちません",
+    ),
+  );
 
   // R4: obligation satisfaction. Step 7 must span the WHOLE expected review
   // set — scoping it to `required ∪ expected` would leave the optional
@@ -986,7 +1008,11 @@ test("the Normative review procedure reaches the fence and the expected review s
   assert.ok(containsText(doc, "expected review set を確定します"));
   assert.ok(containsText(doc, "expected review set は自分が trigger した reviewer だけでは閉じません"));
   assert.ok(containsText(doc, "Merge-ready completion fence"));
-  assert.ok(containsText(doc, "会話内で既に見た snapshot をこの判定の根拠にせず"));
+  // Freshness is no longer a sentence the agent has to remember: the fence CLI
+  // accepts no snapshot argument, so a remembered snapshot cannot reach it.
+  // test/merge-ready-fence-lib.test.mjs owns that property.
+  assert.ok(containsText(doc, "node tooling/merge-ready-fence.mjs"));
+  assert.ok(containsText(doc, "`fail`（exit 1）と `unknown`（exit 2）はどちらも merge-ready ではありません"));
   assert.ok(containsText(doc, "target completion state"));
 });
 
@@ -998,14 +1024,17 @@ test("review-code skill carries the procedural detail for the fence", async () =
   assert.ok(containsText(skill, "自分が trigger した reviewer だけを set に入れて終わりにしません"));
   assert.ok(containsText(skill, "どの surface item を review participation とみなしたか"));
 
-  // Acquisition: record which evidence and which field backed the binding.
-  assert.ok(containsText(skill, "どの field / surface を安定と判断して binding の根拠にしたか"));
-  assert.ok(containsText(skill, "安定性を必要な精度で確認できないまま binding が成立したものとして扱わないでください"));
+  // Acquisition: the binding decision itself is the evaluator's; the skill's
+  // duty is to record its output, and to record the result revision it triaged
+  // so an in-place edit afterwards is detectable.
+  assert.ok(containsText(skill, "state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します"));
+  assert.ok(containsText(skill, "`canonical_id` と `evidence[].revision.body_digest` を記録します"));
 
-  // Merge-ready: fence evaluated last, from fresh acquisition.
-  assert.ok(containsText(skill, "merge-ready を宣言する直前の最後の action として"));
-  assert.ok(containsText(skill, "会話内で既に見た snapshot をこの判定の根拠にしません"));
-  assert.ok(containsText(skill, "triage されていない finding が review surface 上に残っていないことを確認します"));
+  // Merge-ready: the fence runs last, and neither of its non-pass states is
+  // merge-ready.
+  assert.ok(containsText(skill, "宣言の直前の最後の action として merge-ready fence を実行します"));
+  assert.ok(containsText(skill, "node tooling/merge-ready-fence.mjs"));
+  assert.ok(containsText(skill, "`unknown` を `pass` として扱わないでください"));
 
   // Provider observations stay observations — and, since Issue #72 Phase 1,
   // they live in the reviewer capability record rather than in the skill, with
@@ -1067,7 +1096,7 @@ test("both skills reference the Kernel rules rather than restating them", async 
   }
 
   assert.ok(containsText(code, "は、いずれも `policy/core.md` が定めます"));
-  assert.ok(containsText(code, "merge-ready の成立条件、review obligation の定義"));
+  assert.ok(containsText(code, "`policy/core.md` の Merge-ready completion fence が定めます"));
   assert.ok(
     containsText(doc, "いずれも Acquisition & Validity Contract（`policy/core.md`）が定めます"),
   );

--- a/test/review-evidence-state.test.mjs
+++ b/test/review-evidence-state.test.mjs
@@ -713,3 +713,58 @@ test("legacy reviewer-capability-record@1 remains the compatibility input", () =
   );
   assert.equal(state.state, "completed@target");
 });
+
+const FULL_TARGET = "adf82cbc071f432987801ff6457937f12c693b85";
+const SHORT_TARGET = "adf82cbc07";
+
+// Observed on a real run: a reviewer that reports findings posts a review
+// submission AND inline comments in the same instant, repeats its completion
+// marker on each, and abbreviates the SHA in one of them. Comparing the two
+// claims as raw strings made that look like two different targets, so a run
+// that had plainly completed at the frozen target came out `unknown` — and a
+// merge-ready fence built on this state could never pass whenever the reviewer
+// actually had something to say.
+test("one completion claim repeated across objects, abbreviated differently, is not a conflict", () => {
+  const state = stateFor(
+    evidence({
+      reviews: [
+        review(801, "DONE Target: " + SHORT_TARGET, {
+          reviewed_sha: FULL_TARGET,
+        }),
+      ],
+      inline: [
+        inline(802, "DONE Target: " + FULL_TARGET, {
+          review_id: 801,
+          node_id: "COMMENT-802",
+        }),
+      ],
+    }),
+    { target: FULL_TARGET },
+  );
+  assert.equal(state.state, "completed@target");
+  assert.ok(!state.reason_codes.includes("conflicting_signals"));
+});
+
+// The tolerance is abbreviation only. Two claims that name different commits at
+// the same instant stay a conflict, and a prefix shorter than an abbreviated
+// SHA is not a match.
+test("two different targets claimed at the same instant remain a conflict", () => {
+  const state = stateFor(
+    evidence({
+      reviews: [
+        review(803, "DONE Target: " + FULL_TARGET, {
+          reviewed_sha: FULL_TARGET,
+        }),
+      ],
+      inline: [
+        inline(804, "DONE Target: " + "0123456789abcdef0123456789abcdef01234567", {
+          review_id: 803,
+          node_id: "COMMENT-804",
+        }),
+      ],
+    }),
+    { target: FULL_TARGET },
+  );
+  assert.equal(state.state, "unknown");
+  assert.ok(state.reason_codes.includes("conflicting_signals"));
+});

--- a/test/review-evidence-state.test.mjs
+++ b/test/review-evidence-state.test.mjs
@@ -822,3 +822,60 @@ test("a prefix shorter than an abbreviated SHA is not treated as the same claim"
   assert.equal(state.state, "unknown");
   assert.ok(state.reason_codes.includes("conflicting_signals"));
 });
+
+// A target_pattern may capture surrounding whitespace, and the record validator
+// permits it. Measuring a claim's length on the raw capture while comparing it
+// on the trimmed one lets a padded short claim become the longest claim — and a
+// short claim as representative is exactly what the transitivity guard above
+// exists to prevent. One normalization, used for both.
+test("a whitespace-padded short claim cannot become the representative claim", () => {
+  const OTHER_FULL = "adf82cbc0722222222222222222222222222222f";
+  const paddingRecord = record({
+    completion_marker: {
+      any_of: ["DONE"],
+      // Captures the leading whitespace along with the SHA.
+      target_pattern: "Target:([ ]*[0-9a-fA-F]{7,40})",
+    },
+  });
+  const state = stateFor(
+    evidence({
+      // The padding has to make the RAW capture longer than either full SHA
+      // (40) for the bug to be reachable at all: with raw lengths, this short
+      // claim becomes the representative every other claim is measured against.
+      conversation: [
+        conversation(906, "DONE Target:" + " ".repeat(35) + SHORT_TARGET),
+      ],
+      reviews: [
+        review(907, "DONE Target: " + FULL_TARGET, { reviewed_sha: FULL_TARGET }),
+      ],
+      inline: [
+        inline(908, "DONE Target: " + OTHER_FULL, {
+          review_id: 907,
+          node_id: "COMMENT-908",
+        }),
+      ],
+    }),
+    { target: FULL_TARGET, record: paddingRecord },
+  );
+  assert.equal(state.state, "unknown");
+  assert.ok(state.reason_codes.includes("conflicting_signals"));
+});
+
+// The same normalization must reach the claim that is reported and bound, not
+// only the one that is compared.
+test("a claim captured with surrounding whitespace is reported trimmed", () => {
+  const paddingRecord = record({
+    completion_marker: {
+      any_of: ["DONE"],
+      target_pattern: "Target:([ ]*[0-9a-fA-F]{7,40})",
+    },
+  });
+  const state = stateFor(
+    evidence({
+      conversation: [conversation(909, "DONE Target:    " + FULL_TARGET)],
+    }),
+    { target: FULL_TARGET, record: paddingRecord },
+  );
+  assert.equal(state.state, "completed@target");
+  assert.equal(state.observed_signals[0].target_claim, FULL_TARGET);
+});

--- a/test/review-evidence-state.test.mjs
+++ b/test/review-evidence-state.test.mjs
@@ -768,3 +768,57 @@ test("two different targets claimed at the same instant remain a conflict", () =
   assert.equal(state.state, "unknown");
   assert.ok(state.reason_codes.includes("conflicting_signals"));
 });
+
+// `sameTargetClaim` is not transitive: two different full SHAs can both be
+// abbreviations-compatible with one short claim. Comparing every claim against
+// an arbitrary representative would let that set pass as one claim, and the
+// signal chosen from it could bind to the expected target — a merge-ready fence
+// reading that state would pass on a reviewed target that was never determined.
+test("a short claim does not bridge two different full SHAs into one claim", () => {
+  const OTHER_FULL = "adf82cbc0722222222222222222222222222222f";
+  const state = stateFor(
+    evidence({
+      // The short claim is first, so a comparison against `targets[0]` would
+      // find every claim compatible.
+      conversation: [conversation(901, "DONE Target: " + SHORT_TARGET)],
+      reviews: [
+        review(902, "DONE Target: " + FULL_TARGET, { reviewed_sha: FULL_TARGET }),
+      ],
+      inline: [
+        inline(903, "DONE Target: " + OTHER_FULL, {
+          review_id: 902,
+          node_id: "COMMENT-903",
+        }),
+      ],
+    }),
+    { target: FULL_TARGET },
+  );
+  assert.equal(state.state, "unknown");
+  assert.ok(state.reason_codes.includes("conflicting_signals"));
+});
+
+// A claim too short to stand for a commit is not an abbreviation of anything.
+// A record whose target_pattern already requires 7+ characters never produces
+// such a claim, so this uses one that permits a shorter capture — the guard is
+// what stops a 6-character prefix from merging with a full SHA.
+test("a prefix shorter than an abbreviated SHA is not treated as the same claim", () => {
+  const state = stateFor(
+    evidence({
+      conversation: [conversation(904, "DONE Target: abcdef")],
+      reviews: [
+        review(905, "DONE Target: " + FULL_TARGET, { reviewed_sha: FULL_TARGET }),
+      ],
+    }),
+    {
+      target: FULL_TARGET,
+      record: record({
+        completion_marker: {
+          any_of: ["DONE"],
+          target_pattern: "Target:[^0-9a-fA-F]*([0-9a-fA-F]{3,40})",
+        },
+      }),
+    },
+  );
+  assert.equal(state.state, "unknown");
+  assert.ok(state.reason_codes.includes("conflicting_signals"));
+});

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -735,3 +735,55 @@ test("the helper's source stays free of Review Protocol judgment vocabulary", as
     }
   }
 });
+
+// The GraphQL surface is the one surface whose shape the mocked routes cannot
+// falsify: a query that GitHub rejects still "works" against a stub. Every
+// review-thread fetch had in fact been failing with
+// `Field 'databaseId' doesn't exist on type 'Actor'`, because `author` is typed
+// as the Actor interface, which declares only `login`. The consequence was not
+// a visible error but a permanently `failed` review_threads surface — which the
+// merge-ready fence can only report as `unknown`, never as "no unresolved
+// threads". These assertions read the query text actually sent.
+test("the review-thread query selects actor ids through concrete types, not off the Actor interface", async () => {
+  const sent = [];
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: (url, init) => {
+      sent.push(JSON.parse(init.body).query);
+      return jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            },
+          },
+        },
+      });
+    },
+  };
+
+  await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(sent.length, 1);
+  const query = sent[0];
+  // The exact failure: an id selected directly inside an `author { ... }` block.
+  assert.doesNotMatch(
+    query,
+    /author\s*\{[^}]*\b(databaseId|id)\b/,
+    "author is an Actor; selecting databaseId/id on it directly is a schema error that fails the whole query",
+  );
+  assert.match(query, /fragment ActorIds on Actor/);
+  assert.match(query, /\.\.\. on User \{ databaseId id \}/);
+  assert.match(query, /\.\.\. on Bot \{ databaseId id \}/);
+  // The resolution state the fence reads must be part of the same request, so
+  // an unresolved thread cannot be missed by a surface that fetched cleanly.
+  assert.match(query, /isResolved/);
+  assert.match(query, /isOutdated/);
+
+  // The thread-comment follow-up query has the same author selection and is
+  // only sent when one thread exceeds a page of comments, so it is checked at
+  // the source rather than waiting for that case to occur.
+  const source = await readFile(path.join(root, "tooling", "review-evidence-lib.mjs"), "utf8");
+  assert.doesNotMatch(source, /author\s*\{[^}]*\b(databaseId|id)\b/);
+});

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -31,9 +31,11 @@ function graphqlVariables(init) {
 
 const PR_META = {
   head: { sha: "abc1234" },
+  base: { sha: "base987", ref: "main" },
   state: "open",
   html_url: "https://github.com/octo/demo/pull/62",
   updated_at: "2026-08-27T00:00:00Z",
+  body: "PR body text",
 };
 
 function prRoute(pr = PR_META) {
@@ -89,6 +91,9 @@ function baseRoutes() {
     emptyReviewThreadsRoute(),
     emptyCommitStatusRoute(),
     emptyCheckRunsRoute(),
+    // Appended last so the positional route indices used by the pagination
+    // tests above stay stable.
+    emptyListRoute("/pulls/62/files"),
   ];
 }
 
@@ -155,12 +160,23 @@ test("collects a representative multi-surface snapshot with independent per-surf
       match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/commits/abc1234/check-runs"),
       handler: () => jsonResponse({ total_count: 1, check_runs: [{ id: 9, name: "test", status: "completed", conclusion: "success" }] }),
     },
+    {
+      match: (url) => url.startsWith("https://api.github.com/repos/octo/demo/pulls/62/files"),
+      handler: () =>
+        jsonResponse([
+          { filename: "a.mjs", status: "modified" },
+          { filename: "docs/new.md", status: "added", previous_filename: undefined },
+        ]),
+    },
   ];
 
   const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
 
   assert.equal(result.pr_metadata.fetch_status, "fetched");
   assert.equal(result.pr_metadata.head_sha, "abc1234");
+  assert.equal(result.pr_metadata.base_sha, "base987");
+  assert.equal(result.pr_metadata.base_ref, "main");
+  assert.equal(result.pr_metadata.body, "PR body text");
   assert.equal(result.fetch_failures, 0);
 
   assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
@@ -184,9 +200,48 @@ test("collects a representative multi-surface snapshot with independent per-surf
   assert.equal(result.surfaces.review_threads.items[0].comments[0].actor_database_id, 12);
   assert.equal(result.surfaces.review_threads.items[0].comments[0].review_id, 2);
   assert.equal(result.surfaces.review_threads.items[0].comments[0].owner_state, "APPROVED");
+  assert.equal(result.surfaces.review_threads.items[0].is_resolved, true);
+  assert.equal(result.surfaces.review_threads.items[0].is_outdated, false);
+  assert.equal(result.surfaces.review_threads.items[1].is_resolved, false);
+
+  assert.equal(result.surfaces.pull_request_files.fetch_status, "fetched");
+  assert.equal(result.surfaces.pull_request_files.count, 2);
+  assert.deepEqual(
+    result.surfaces.pull_request_files.items.map((item) => item.path),
+    ["a.mjs", "docs/new.md"],
+  );
+  assert.equal(result.surfaces.pull_request_files.items[1].status, "added");
+  assert.equal(result.surfaces.pull_request_files.items[1].previous_path, null);
 
   assert.equal(result.surfaces.commit_status.status.state, "success");
   assert.equal(result.surfaces.check_runs.count, 1);
+});
+
+// A thread whose resolution state is absent from the response must stay
+// distinguishable from a resolved one; the fence turns that into `unknown`.
+test("a review thread with no resolution state is reported as null, not as resolved", async () => {
+  const routes = baseRoutes();
+  routes[4] = {
+    match: (url, init) => url.endsWith("/graphql") && init.method === "POST",
+    handler: () =>
+      jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ id: "th1", comments: { nodes: [] } }],
+              },
+            },
+          },
+        },
+      }),
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.surfaces.review_threads.items[0].is_resolved, null);
+  assert.equal(result.surfaces.review_threads.items[0].is_outdated, null);
 });
 
 test("a surface with genuinely zero items is reported as fetched(0), not conflated with the other surfaces", async () => {
@@ -590,6 +645,9 @@ test("a PR-metadata fetch failure does not crash the run and marks head-dependen
   assert.equal(result.surfaces.check_runs.fetch_status, "not_applicable");
   // Surfaces that don't depend on head SHA are still attempted.
   assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
+  assert.equal(result.surfaces.pull_request_files.fetch_status, "fetched");
+  assert.equal(result.pr_metadata.base_sha, null);
+  assert.equal(result.pr_metadata.body, null);
   assert.equal(result.fetch_failures, 1);
 });
 
@@ -603,6 +661,7 @@ test("formatHumanSummary renders a deterministic snapshot summary", async () => 
   assert.match(text, /^Head: abc1234 \(state: open\)$/m);
   assert.match(text, /^Conversation comments: fetched \(0\)$/m);
   assert.match(text, /^Review threads: fetched \(0\)$/m);
+  assert.match(text, /^Changed files: fetched \(0\)$/m);
   assert.match(text, /^Fetch failures: 0$/m);
 });
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -132,13 +132,16 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "この節における review target は、Selection Contract で確定した expected target SHA / commit range と target artifact set の組を指します。どちらか一方でも変われば review target の変更です。",
+      "この節における review target は、Selection Contract で確定した expected target SHA / commit range と target artifact set の組を指します。**どれか 1 つでも変われば review target の変更です。**",
     ),
   );
+  // Detecting that drift is the checker's job now (behavior fixtures in
+  // test/merge-ready-fence-lib.test.mjs cover head, base and artifact-set
+  // moves). The Kernel keeps the definition and the fail-safe consequence.
   assert.ok(
     containsText(
       core,
-      "expected target SHA / commit range が不変でも target artifact set が変わった場合も、review target の変更として同じ scope です。",
+      "precondition evidence、discovery evidence、closure evidence はいずれも target-specific であり、確定した target と一致しない evidence を review / closure / merge の根拠にしません。",
     ),
   );
   assert.ok(
@@ -162,7 +165,7 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(
     containsText(
       core,
-      "precondition evidence だけでなく、discovery / closure evidence も target-specific です。",
+      "precondition evidence、discovery evidence、closure evidence はいずれも target-specific であり、確定した target と一致しない evidence を review / closure / merge の根拠にしません。",
     ),
   );
   assert.ok(
@@ -303,18 +306,30 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     containsText(core, "この場合、record は `status: completed` かつ `validity: invalid` として表現します。"),
   );
 
-  // Reviewed-target evidence consistency: when record.target_sha and the acquired
-  // evidence's reviewed target both exist, they must agree; disagreement is invalid,
-  // and an unconfirmable reviewed target is unknown (not silently valid).
+  // Reviewed-target evidence consistency: reconciling the record's target_sha
+  // against the reviewed target carried by the acquired evidence — and ranking
+  // competing representations of the same object — is executed by the
+  // deterministic evaluator (test/review-evidence-state.test.mjs owns those
+  // cases). The Kernel keeps the two consequences it must never lose: an
+  // unconfirmable reviewed target is unknown, and a confirmed mismatch is
+  // invalid. Neither may be read as valid.
   assert.ok(
     containsText(
       core,
-      "record の `target_sha` と acquired evidence 上の reviewed target が両方存在する場合、両者は一致していなければなりません。",
+      "reviewed target をどの field / surface から確定するか、複数表現の間でどの binding を優先するか、および確定した reviewed target を expected target と照合する手順は、Foundation-owned な deterministic evaluator が所有します。",
     ),
   );
-  assert.ok(containsText(core, "一致しない場合は invalid です。"));
   assert.ok(
-    containsText(core, "reviewed target を Validity 判定に必要な精度で確認できない場合は unknown です。"),
+    containsText(
+      core,
+      "reviewed target を Validity 判定に必要な精度で確認できない場合、その binding は成立しておらず、判定結果は `unknown` です。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "確定した reviewed target が expected target と一致しない場合、completion していても invalid です。",
+    ),
   );
 
   // Resolution Contract
@@ -555,7 +570,13 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewCode,
-      "accepted finding の batch fix によって review target が変更された場合のみ targeted closure を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+      "この review flow で accepted finding の fix によって target が変更された場合のみ（手順 9 の second full discovery を挟んだ場合を含む）行います。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "targeted closure の review run に手順 5 と同じ Acquisition & Validity Contract を適用し、completion / acquisition / validity を確認します。",
     ),
   );
 
@@ -576,7 +597,7 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewCode,
-      "targeted closure の finding も Resolution Contract の対象とし、Resolution が完了するまで merge しません。",
+      "targeted closure の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は merge しません。",
     ),
   );
 
@@ -617,35 +638,39 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewCode,
-      "targeted closure の finding に accepted fix がある場合も、fix 後の deterministic verify を経て Review stopping rules を再評価します。",
+      "accepted な closure finding があれば、手順 7 と同じ batch fix semantics でまとめて fix し、手順 8 と同じ deterministic verify を行います。その上で Review stopping rules（`policy/core.md`）を再評価します。",
     ),
   );
   assert.ok(
     containsText(
       reviewCode,
-      "2nd full discovery が未使用でなお必要なら 2nd discovery route へ進み、完了後に targeted closure を再実行します。",
+      "この review flow で手順 9 をまだ使っておらず、2nd full discovery が必要と判断される場合は、手順 9 へ進み、完了後に手順 10 へ進みます。",
     ),
   );
   assert.ok(
     containsText(
       reviewCode,
-      "2nd full discovery を使用済みでなお full discovery が必要なら、3rd full discovery は起動せず、merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
+      "手順 9 を既に使っており、なお追加の full discovery が必要と判断される場合は、3rd full discovery は起動せず merge もせず、upstream task/design の不安定さを疑い、必要に応じて escalate します。",
     ),
   );
   assert.ok(
-    containsText(reviewCode, "追加の full discovery が不要なら、targeted closure を再実行します。"),
+    containsText(reviewCode, "追加の full discovery が不要な場合は、手順 10 へ進みます。"),
   );
   assert.ok(
     containsText(
       reviewCode,
-      "targeted closure の Resolution に加えて、この review flow で実行した discovery stage（2nd full discovery を含む）すべての Resolution が完了していることも merge の条件です。完了順序は問いません。",
+      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution の完了が必要です。discovery Resolution と closure の完了順序は問いません。",
     ),
   );
-  assert.ok(reviewCode.includes("verify target と freeze target の consistency 確認"));
+  // The verify/freeze SHA comparison the diagram used to spell out is a fence
+  // check now (test/merge-ready-fence-lib.test.mjs fixtures 18-20); the diagram
+  // instead shows the fence as the last step before merge.
+  assert.ok(!reviewCode.includes("verify target と freeze target の consistency 確認"));
+  assert.ok(reviewCode.includes("-> merge-ready fence"));
   assert.ok(
     containsText(
       reviewCode,
-      "accepted fix が無く review target が変更されていない場合は、required review 数の valid discovery と Resolution の完了をもって、新たな closure run を要求せずに merge できます。",
+      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で semantic な条件が揃います。",
     ),
   );
   assert.ok(reviewCode.includes("-> accepted fix が無く review target が変更されていない場合:"));
@@ -674,7 +699,7 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewDoc,
-      "closure verification の finding も Resolution Contract の対象とし、Resolution が完了するまで review を完了しません。",
+      "unresolved の finding がある間は review procedure を完了としません。",
     ),
   );
   // Resolve discovery findings before merge, Normative flow: same
@@ -682,16 +707,25 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewDoc,
-      "-> closure finding の Resolution -> semantic discovery の Resolution 完了 -> 完了",
+      "-> closure finding の Resolution -> semantic discovery の Resolution 完了 -> merge-ready fence（merge-ready を宣言する場合） -> 完了",
     ),
   );
   assert.ok(
     containsText(
       reviewDoc,
-      "closure verification の Resolution に加えて、semantic discovery（手順 3）の Resolution が完了していることも review completion の条件です。完了順序は問いません。",
+      "closure Resolution に加えて、手順 5 の semantic discovery Resolution も完了していることが review procedure 完了の条件です。完了順序は問いません。",
     ),
   );
-  assert.ok(reviewDoc.includes("mechanical check target と Selection target の consistency 確認"));
+  // Reconciling the mechanical-check target with the Selection target is no
+  // longer a step in the flow: the fence's `verify-coherence` check compares
+  // them (test/merge-ready-fence-lib.test.mjs, fixtures 18-20). What the skill
+  // keeps is the duty to record the check's SHA and to redo it on a move.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "手順 1 の mechanical check 対象と確定した target の一致、および宣言した routing と changed artifact set の整合は、手順 9 の fence が機械判定します。",
+    ),
+  );
 
   // Normative keeps exactly one semantic discovery round.
   assert.ok(reviewDoc.includes("semantic discovery（1 round）"));
@@ -703,13 +737,19 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewDoc,
-      "accepted finding の fix によって review target が変更された場合のみ、新しい target に対して mechanical check を再実行してから closure verification を行い、その review run も Acquisition & Validity Contract に従って completion / acquisition / validity を確認します。",
+      "accepted finding の fix によって target SHA / range または target artifact set が変わった場合のみ行います。修正後の target に対して手順 1 の mechanical check を再実行し、",
     ),
   );
   assert.ok(
     containsText(
       reviewDoc,
-      "accepted fix が無く review target が変更されていない場合は、required review 数の valid semantic discovery と Resolution の完了をもって、新たな closure run を要求せずに review を完了できます。",
+      "closure verification 自体の completion / acquisition / validity も、この closure target を expected target として Acquisition & Validity Contract に従って確認します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "required review 数の valid semantic discovery と Resolution が完了した時点で review procedure を完了とし、新たな closure run を要求しません。",
     ),
   );
 
@@ -865,13 +905,17 @@ test("core policy defines a provider-neutral skill routing contract", async () =
 test("skill routing contract defines mixed-classification review target routing (Issue #57)", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
-  assert.ok(core.includes("#### Mixed-classification review target"));
+  // The rules live inside the Skill routing contract rather than in a section
+  // of their own; folding them in removed the duplicated framing, not the rules.
+  const routingIndex = core.indexOf("### Skill routing contract");
+  assert.ok(routingIndex !== -1);
+  const routing = core.slice(routingIndex, core.indexOf("## Foundation Change Protocol"));
 
   // MUST load every applicable classification's skill — not just one.
   assert.ok(
     containsText(
-      core,
-      "target に含まれる artifact classification のうち、mandatory review skill を持つ classification（上記 table の Executable および Normative）が複数含まれる場合、該当する classification すべてに対応する skill を load することを MUST とします。",
+      routing,
+      "1 つの review target が、mandatory review skill を持つ classification（Executable と Normative）を複数含む場合（mixed-classification review target）、**該当する classification すべてに対応する skill を load することを MUST とします。**",
     ),
   );
   assert.ok(
@@ -886,13 +930,23 @@ test("skill routing contract defines mixed-classification review target routing 
   assert.ok(
     containsText(
       core,
-      "各 classification の手続き的 obligation（stopping rule、discovery round 数、required review 数、closure / verification 手順を含む）は、その classification に属する artifact subset にのみ適用します。",
+      "各 classification の手続き的 obligation（stopping rule、discovery round 数、required review 数、closure / verification 手順）は、その classification に属する artifact subset にのみ適用し、他の classification へ流用しません。",
+    ),
+  );
+  // Which classifications a target actually contains is derived from the
+  // changed artifact set by the checker, so an under-declared Mixed target
+  // fails rather than depending on the agent noticing
+  // (test/merge-ready-fence-lib.test.mjs, fixtures 15 and 17).
+  assert.ok(
+    containsText(
+      core,
+      "**changed artifact set から required skill を導出する判定は、agent の自己申告だけで決めません。**",
     ),
   );
   assert.ok(
     containsText(
       core,
-      "ある classification の rule を、他の classification に属する artifact へ流用してはいけません",
+      "path から class を確実に導出できない artifact を、checker が勝手に特定の class へ分類することはありません。",
     ),
   );
 
@@ -910,17 +964,7 @@ test("skill routing contract defines mixed-classification review target routing 
   assert.ok(
     containsText(
       core,
-      "複数の skill を load した場合、各 skill が定義する discovery / closure / stopping semantics は、classification ごとに独立した review flow として並行に適用してよく、単一の flow へ統合することを要求しません。",
-    ),
-  );
-
-  // This routing must not replace or restructure the existing 1:1 table for
-  // single-classification targets (Issue #57 explicitly rules out a matrix
-  // redesign as in-scope discretion).
-  assert.ok(
-    containsText(
-      core,
-      "この routing は Skill routing contract の 1:1 table を置き換えません。target が単一の classification のみで構成される場合は、上記 table のとおり単一の skill を load します。",
+      "複数の skill を load した場合、各 skill の discovery / closure / stopping semantics は classification ごとに独立した review flow として並行に適用してよく、単一の flow へ統合することを要求しません。",
     ),
   );
   assert.ok(
@@ -956,6 +1000,9 @@ test("the skill routing contract table stays in sync with the actual skills/ dir
 test("review skills document procedure without duplicating normative rules", async () => {
   const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
   const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+  // Read the Kernel too: several rules the skills used to restate are now
+  // asserted where they actually live.
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
   for (const skill of [reviewCode, reviewDoc]) {
     assert.ok(skill.includes("policy/core.md"), "skill must reference policy/core.md");
@@ -1020,7 +1067,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "reviewer mechanism 自身がそのような外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）と同様に扱い、`collectOutputs()` に相当する手段として、`policy/core.md` の record schema の各 field に加え",
+      "reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition & Validity Contract が定める durable evidence の要求を、その手段で満たします。",
     ),
   );
   assert.ok(
@@ -1047,23 +1094,30 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "この surface から `policy/core.md` の Acquisition & Validity Contract が定義する Completion と Validity の要求事項を後続 session が独立に判定できれば、その surface 自体を同 Contract の record の recoverable な representation として result locator に使えます",
+      "`policy/core.md` の Acquisition & Validity Contract が定める durable evidence の要求を、その手段で満たします。何を persist すれば足りるかは同 Contract が定めます。",
+    ),
+  );
+  // Both halves of the rule stay stated — but in the Kernel, once, instead of
+  // being re-enumerated in the skill where the copy could drift. The
+  // no-surface fallback must still demand evidence, not just conformance to
+  // the bare record schema (whose `validity` field is only a self-asserted
+  // conclusion a later session can't independently re-derive).
+  assert.ok(
+    containsText(
+      core,
+      "その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
     ),
   );
   assert.ok(
     containsText(
-      reviewCode,
-      "それらの要求事項のいずれかを surface から判定できない場合は",
+      core,
+      "上記の record schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる情報を、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
     ),
   );
-  // Root-cause fix #2: the no-surface fallback
-  // here must also require evidence for Completion/Validity, not just
-  // conformance to the bare record schema (whose `validity` field is only a
-  // self-asserted conclusion a later session can't independently re-derive).
   assert.ok(
     containsText(
-      reviewCode,
-      "`policy/core.md` の record schema の各 field に加え、上記の Completion / Validity 要求事項を独立に判定できる情報",
+      core,
+      "record schema 自体（特に `validity` field）は判定結果の要約であり、その根拠情報の代わりにはなりません。",
     ),
   );
 
@@ -1080,7 +1134,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "commit range を review target として使う場合は、対象となる range も同時に freeze し、以降 SHA について述べる target mutation semantics を range にも同じ意味で適用します。",
+      "commit range を review target として使う場合は対象 range も、target artifact set も同時に freeze し、以降 SHA について述べる target mutation semantics を range と artifact set にも同じ意味で適用します。",
     ),
   );
   assert.ok(
@@ -1113,7 +1167,13 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "target artifact set を確定した時点から、その artifact set も review target の一部として扱い、手順 2 の target mutation semantics を artifact set にも同じ意味で適用します。",
+      "commit range を review target として使う場合は対象 range も、target artifact set も同時に freeze し、以降 SHA について述べる target mutation semantics を range と artifact set にも同じ意味で適用します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "artifact classification、reviewer / capability、required review 数、target artifact set、expected target SHA / applicable な commit range を決めます。",
     ),
   );
   assert.ok(
@@ -1177,7 +1237,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution が完了した時点で merge-ready と判定します。",
+      "手順 6 の discovery Resolution（手順 9 を使った場合はその Resolution も含む）と、Closure Acquisition & Validity・Closure Resolution の完了が必要です。",
     ),
   );
 
@@ -1217,28 +1277,37 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // Root cause B, cells E/F (Code): the deterministic verify target captured at
-  // Step 1 must match the frozen candidate SHA at Step 2; a mismatch (a race
-  // between verify start and freeze) re-runs verify against the frozen SHA rather
-  // than carrying over evidence for a different target.
+  // Root cause B, cells E/F (Code): the deterministic verify target must be
+  // recorded at Step 1. Reconciling it with the frozen candidate SHA is no
+  // longer a sentence the agent has to execute — the fence's `verify-coherence`
+  // check compares the two (test/merge-ready-fence-lib.test.mjs, fixtures
+  // 18-20). What the skill still owns is capturing the SHA and the scope.
   assert.ok(containsText(reviewCode, "その時点の candidate SHA"));
   assert.ok(
     containsText(
       reviewCode,
-      "手順 1 で記録した verify 対象の SHA と、ここで freeze する SHA が一致することを確認します。一致しない場合は、freeze した SHA に対して手順 1 の deterministic verify を再実行し、成功してから先へ進みます。",
+      "記録した SHA と freeze した target の一致は手順 13 の fence が機械判定するため、手順の各所で手作業の SHA 照合を繰り返しません。",
     ),
   );
 
-  // SHA-change handling during code review: a pre-validity or post-valid-discovery
-  // non-fix change does not retroactively invalidate the old run's own Validity —
-  // it only stops that run from being used as evidence for the new target,
-  // matching review-doc.md's wording. A post-discovery fix-driven change proceeds
-  // to targeted closure without restarting discovery from scratch.
+  // SHA-change handling during code review. Two cases used to be spelled out in
+  // two near-identical paragraphs; they are one branch now, but the branch must
+  // still cover BOTH triggers — a change before discovery validity is confirmed,
+  // and a non-fix change after it — and must state the consequence as "not
+  // usable as evidence for the new target", never as retroactively invalidating
+  // the prior run's own Validity.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "discovery の completion / validity が確定する前に動いた場合、または **手順 7 の batch fix 以外**の理由で動いた場合",
+    ),
+    "review-code.md must cover both the pre-validity and the post-valid non-fix target move",
+  );
   assert.ok(
     countOccurrences(
       reviewCode,
       "旧 review target / run を現在 target の evidence として扱いません。",
-    ) === 2,
+    ) === 1,
     "review-code.md must not retroactively mark a run's own Validity invalid on a candidate SHA change; it must state the run is no longer usable as evidence for the new target",
   );
   assert.doesNotMatch(
@@ -1246,22 +1315,16 @@ test("review skills document procedure without duplicating normative rules", asy
     /review target \/ run を invalid として扱い/,
     "review-code.md must not conflate a target change with retroactively invalidating the prior run's own Validity",
   );
+  // Both triggers re-run Step 1's deterministic verify against the new SHA
+  // before re-freezing.
   assert.ok(
-    containsText(reviewCode, "valid な discovery の後、手順 7 の batch fix によって SHA が変わった場合は、"),
+    containsText(reviewCode, "新しい SHA に対して手順 1 の verify をやり直し、re-freeze して必要な discovery をやり直します。"),
+  );
+  // A fix-driven change proceeds to targeted closure without restarting discovery.
+  assert.ok(
+    containsText(reviewCode, "valid な discovery の後、**手順 7 の batch fix によって**動いた場合は、"),
   );
   assert.ok(containsText(reviewCode, "re-freeze はしますが手順を最初からやり直さず、"));
-
-  // Gap 1 (same root cause as the canonical invariant, completed): a SHA change
-  // before discovery completion/validity is confirmed must also re-run Step 1's
-  // deterministic verify against the new SHA before re-freezing — not just the
-  // post-valid-discovery non-fix change case.
-  assert.ok(
-    countOccurrences(
-      reviewCode,
-      "新しい SHA に対して手順 1 の deterministic verify を再実行し、成功したら",
-    ) === 2,
-    "review-code.md must re-run deterministic verify on SHA change both before and after discovery validity is confirmed",
-  );
 
   // review-code.md must defer to policy Contracts rather than restating their
   // normative conditions (Fix 2): the specific prohibitions below must not reappear
@@ -1272,6 +1335,9 @@ test("review skills document procedure without duplicating normative rules", asy
   );
   // Completion and validity are independent judgments (not a single enum), and a
   // completed-but-invalid run (e.g. stale/wrong SHA) must remain expressible.
+  // The skill used to restate all three rules; that is the duplication this
+  // test exists to prevent, so it now asserts the skill defers and that the
+  // Kernel is where the distinction is normative.
   assert.ok(
     !containsText(
       reviewCode,
@@ -1279,11 +1345,22 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
     "review-code.md must not collapse completion/validity/none/unknown/failure into a single enum",
   );
-  assert.ok(containsText(reviewCode, "completion と validity は独立した判定とし"));
   assert.ok(
-    containsText(reviewCode, "target SHA / artifact set 等が一致しない completed run は invalid として表現できます"),
+    containsText(
+      reviewCode,
+      "target-bound completion、run state、coverage、および binding の規範的な扱いは、いずれも `policy/core.md` が定めます。",
+    ),
+    "review-code.md must defer the completion/validity distinction to the Contract",
   );
-  assert.ok(containsText(reviewCode, "`none` / `unknown` / `failure` は completion / validity と混同せず"));
+  assert.ok(containsText(core, "Completion は少なくとも次を要求します。"));
+  assert.ok(containsText(core, "Validity はさらに次を要求します。"));
+  assert.ok(
+    containsText(core, "record は `status: completed` かつ `validity: invalid` として表現します"),
+    "a completed-but-invalid run must stay expressible in the Kernel's record schema",
+  );
+  assert.ok(
+    containsText(core, "review run の状態は少なくとも `none` / `unknown` / `failure` を区別し、混同してはいけません。"),
+  );
   assert.ok(
     !containsText(reviewCode, "behavior / blast radius を materially"),
     "review-code.md must not restate the discovery round-limit condition; it must reference Review stopping rules",
@@ -1328,7 +1405,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で merge-ready と判定します。",
+      "この review flow で accepted finding の fix による target 変更が一度も発生していなければ、required review 数の valid discovery と Resolution（手順 6）が完了した時点で semantic な条件が揃います。",
     ),
   );
 
@@ -1345,7 +1422,7 @@ test("review skills document procedure without duplicating normative rules", asy
   // addition, unrelated commits) routes back through Step 2's invalidate/re-freeze/
   // re-discovery handling instead of a separate SHA-change rule.
   assert.ok(
-    containsText(reviewCode, "手順 7 の batch fix 以外の理由で candidate SHA が変わった場合"),
+    containsText(reviewCode, "**手順 7 の batch fix 以外**の理由で動いた場合"),
   );
   assert.ok(
     containsText(reviewCode, "手順 7 の batch fix によって candidate SHA が変更された場合のみ"),
@@ -1359,13 +1436,16 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "手順 7 の batch fix によって candidate SHA が変更された場合のみ、fix 後に手順 1 の verify を再実行します。",
+      "手順 7 の batch fix によって candidate SHA が変更された場合のみ、fix 後に手順 1 の verify を再実行し、記録した verify SHA を更新します。",
     ),
   );
+  // Reconciling the closure target with the last successful verify target is
+  // the fence's `verify-coherence` check now; the skill states the re-freeze
+  // and the Selection/Execution that follows it.
   assert.ok(
     containsText(
       reviewCode,
-      "最終的な post-fix SHA を closure target として re-freeze し、直近の successful deterministic verify target との consistency を確認します。",
+      "最終的な post-fix SHA を closure target として re-freeze し、Selection Contract に従ってこの closure target を expected target として確定し、",
     ),
   );
   assert.ok(
@@ -1392,13 +1472,16 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // Sibling gap A (Step 10): a mismatch between the closure target and the latest
-  // successful deterministic verify target must not carry over stale verify
-  // evidence — it re-runs verify against the confirmed closure target instead.
+  // Sibling gap A (Step 10): a mismatch between the closure target and the
+  // latest successful deterministic verify target must not carry over stale
+  // verify evidence. The SHA comparison itself is the fence's
+  // `verify-coherence` check (test/merge-ready-fence-lib.test.mjs, fixtures
+  // 18-20); what stays with the skill is the artifact-scope coverage the fence
+  // deliberately does not judge.
   assert.ok(
     containsText(
       reviewCode,
-      "一致しない場合は、その verify evidence を使わず、確定した closure target に対して deterministic verify を行い、成功したら re-freeze します。",
+      "確定した closure artifact set まで直近の successful deterministic verify evidence がカバーしているかを確認します。",
     ),
   );
 
@@ -1415,16 +1498,15 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
   // Sibling gap A (Step 9), direction fix: the *current* post-fix SHA is frozen
-  // as the second discovery target, then checked against the latest successful
-  // deterministic verify target (matching Step 10's direction) — not the other
-  // way around, which would freeze a stale verify target and miss a candidate
-  // that advanced further before Step 9 ran. Not entry-point-specific (works
-  // whether Step 9 is reached from Step 8 or looped back into from Step 12); a
-  // mismatch discards the stale verify evidence and re-verifies.
+  // as the second discovery target — not the latest successful verify target,
+  // which would freeze a stale SHA and miss a candidate that advanced further
+  // before Step 9 ran. Comparing the frozen target against the verify target is
+  // the fence's `verify-coherence` check now (test/merge-ready-fence-lib.test.mjs,
+  // fixtures 18-20).
   assert.ok(
     containsText(
       reviewCode,
-      "現在の post-fix SHA を second discovery target として re-freeze し、直近の successful deterministic verify target との consistency を確認します。一致しない場合は、その verify evidence を使わず、確定した second discovery target に対して deterministic verify を行い、成功したら re-freeze して Selection / Execution へ進みます。",
+      "現在の post-fix SHA を second discovery target として re-freeze し、",
     ),
   );
   assert.doesNotMatch(
@@ -1475,7 +1557,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "accepted fix 以外の理由で target が変わった場合は、手順 2 と同じ target-specific evidence の扱いに従います。",
+      "second discovery の実行中、または completion / validity 確定前後に accepted fix 以外の理由で target が変わった場合も同じ扱いです。",
     ),
   );
   // A 3rd full discovery is never triggered; the flow escalates instead, per the
@@ -1562,14 +1644,16 @@ test("review skills document procedure without duplicating normative rules", asy
     ),
   );
 
-  // Root cause B, cells G/H (Normative): the mechanical check target captured at
-  // Step 1 must match the target confirmed at Step 2's Selection; a mismatch
-  // re-runs mechanical check against the confirmed target.
+  // Root cause B, cells G/H (Normative): the mechanical check target must be
+  // captured at Step 1. Matching it against the target confirmed at Step 2 is
+  // the fence's `verify-coherence` check now (test/merge-ready-fence-lib.test.mjs,
+  // fixtures 18-20); the skill keeps capturing the target and redoing the check
+  // when the target moves.
   assert.ok(containsText(reviewDoc, "その時点の target SHA / range"));
   assert.ok(
     containsText(
       reviewDoc,
-      "手順 1 で記録した mechanical check 対象の target と、ここで確定する target が一致することを確認します。一致しない場合は、確定した target に対して手順 1 の mechanical check を再実行してから先へ進みます。",
+      "target が動いたら mechanical check をやり直し、記録した check SHA を更新します。",
     ),
   );
 
@@ -1610,7 +1694,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "re-freeze して手順 2（Selection）からやり直し、手順 3 の semantic discovery を新しい target に対して行います。",
+      "新しい target に対して手順 1 の mechanical check を再実行し、Selection をやり直して、手順 3 の semantic discovery を新しい target に対して行います。",
     ),
   );
 
@@ -1618,23 +1702,27 @@ test("review skills document procedure without duplicating normative rules", asy
   // Normative sibling: the pre-validity mutation clause must cover an
   // artifact-set-only change the same way it covers a SHA/range change, not
   // just the post-validity non-fix clause above.
+  // Two near-identical paragraphs became one branch; it must still cover BOTH
+  // triggers — a move before semantic discovery validity is confirmed, and a
+  // non-fix move after it — and both re-run Step 1's mechanical check against
+  // the new target before Selection is redone.
   assert.ok(
     containsText(
       reviewDoc,
-      "手順 3 の semantic discovery の completion / validity が確定する前に target SHA / range または target artifact set が変わった場合、その review target / run を現在 target の evidence として扱いません。",
+      "手順 3 の semantic discovery の completion / validity が確定する前に動いた場合、または手順 6 の accepted finding batch fix 以外の理由で target SHA / range または target artifact set が変わった場合",
     ),
   );
-
-  // Gap 2 (same root cause as the canonical invariant, completed): a target change
-  // before semantic discovery completion/validity is confirmed must also re-run
-  // Step 1's mechanical check against the new target — not just the
-  // post-valid-discovery non-fix change case (cell D).
   assert.ok(
     countOccurrences(
       reviewDoc,
-      "新しい target に対して手順 1 の mechanical check を再実行し、成功したら",
-    ) === 2,
-    "review-doc.md must re-run mechanical check on target change both before and after semantic discovery validity is confirmed",
+      "旧 review target / run を現在 target の evidence として扱いません。",
+    ) === 1,
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "新しい target に対して手順 1 の mechanical check を再実行し、Selection をやり直して、",
+    ),
   );
   assert.ok(containsText(reviewDoc, "target SHA / range、target artifact set、"));
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -403,11 +403,13 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
 
   // Root cause B (precondition target-binding): precondition evidence used as
   // review/closure/merge grounds must match the confirmed (frozen/Selected)
-  // target, not just "not stale after a later mutation."
+  // target, not just "not stale after a later mutation." Comparing the two SHAs
+  // is the fence's `verify-coherence` check now, so the Kernel states where the
+  // judgment lives instead of restating the comparison.
   assert.ok(
     containsText(
       core,
-      "review / closure / merge の根拠として使う precondition evidence は、review 対象として確定した（freeze / Selection された）target と一致していなければなりません。",
+      "precondition evidence が確定した target SHA を指しているかは deterministic であり、Merge-ready completion fence が参照する checker が機械判定します。照合手順を本節に置きません。",
     ),
   );
 
@@ -415,11 +417,12 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   // SHA/range: a SHA-only match is not enough — the selected target artifact
   // set must also be within the precondition check's covered scope, checked
   // after Selection when the check ran before it, with a rerun required
-  // whenever coverage can't be positively confirmed.
+  // whenever coverage can't be positively confirmed. This half is explicitly
+  // NOT machine-judged, so it stays normative here.
   assert.ok(
     containsText(
       core,
-      "この一致確認は SHA / range だけでなく、selected target artifact set にも及びます。",
+      "checker が判定しないのは、precondition check がどの artifact scope を対象としたかです。",
     ),
   );
   assert.ok(

--- a/test/reviewer-capability-record.test.mjs
+++ b/test/reviewer-capability-record.test.mjs
@@ -320,13 +320,10 @@ test("review-code.md binds Selection, Execution and Acquisition to the record", 
     containsText(skill, "actor attribution 不明、binding 不明、または fetch incomplete は positive completion に使いません"),
     "marker evidence must be attributable to the record's declared actors",
   );
-  assert.ok(
-    containsText(
-      skill,
-      "record の actor login と exact match する observation から得た stable actor ID は同じ snapshot 内の login drift の補助にだけ使います",
-    ),
-    "stable actor identity must remain snapshot-local",
-  );
+  // Snapshot-locality of a stable actor ID is decided by the evaluator, not by
+  // the skill restating it: test/review-evidence-state.test.mjs owns the cases
+  // where a stable ID carries attribution across login drift inside one
+  // snapshot, and where a conflicting or shared ID blocks attribution instead.
 
   assert.ok(
     containsText(
@@ -347,9 +344,11 @@ test("review-code.md binds Selection, Execution and Acquisition to the record", 
   assert.ok(containsText(skill, "5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。"));
 
   // Mutable evidence is represented by the snapshot revision, not a second
-  // history model in the skill.
+  // history model in the skill. Since Issue #76 the skill's duty is narrower
+  // still: record the revision that was triaged, and let the fence compare it
+  // with the current one (test/merge-ready-fence-lib.test.mjs, fixture 10).
   assert.ok(
-    containsText(skill, "同一 object の編集は current body、`updated_at`、body digest の snapshot projection"),
+    containsText(skill, "`canonical_id` と `evidence[].revision.body_digest` を記録します"),
   );
   assert.ok(
     containsText(skill, "state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。"),

--- a/tooling/merge-ready-fence-lib.mjs
+++ b/tooling/merge-ready-fence-lib.mjs
@@ -1,0 +1,626 @@
+// Deterministic merge-ready fence (Issue #76).
+//
+// Every judgment here is a comparison between two things the caller already
+// has: a frozen declaration passed in as an argument, and a fact read out of
+// ONE fresh acquisition snapshot. Nothing in this module reads finding text,
+// interprets a provider's wording, decides whether a finding is resolved, or
+// decides whether merging is allowed. Those stay with the agent
+// (policy/core.md, Review contracts / Merge readiness and merge authority).
+//
+// The module is pure: no fetch, no filesystem, no git, no clock. The CLI
+// (tooling/merge-ready-fence.mjs) performs the single fresh acquisition and
+// hands the result here.
+
+export const MERGE_READY_FENCE_SCHEMA_ID = "ai-dev-foundation/merge-ready-fence@1";
+
+export const FENCE_STATUSES = ["pass", "fail", "unknown"];
+
+// Emitted in this order, so the output shape is stable for callers that read
+// checks positionally as well as by id.
+export const FENCE_CHECK_IDS = [
+  "target-head",
+  "target-base",
+  "artifact-set",
+  "skill-routing",
+  "reviewer-completion",
+  "result-revision-coherence",
+  "acquisition-coverage",
+  "review-threads",
+  "verify-coherence",
+  "autoclose-hygiene",
+];
+
+export const ARTIFACT_CLASSES = ["Executable", "Normative", "Informational"];
+
+// The skill routing table of policy/core.md, as data. Informational has no
+// mandatory review skill, which is a class property — not an absence of
+// information about it.
+export const CLASS_REQUIRED_SKILL = {
+  Executable: "review-code",
+  Normative: "review-doc",
+  Informational: null,
+};
+
+export const MANDATORY_REVIEW_SKILLS = ["review-code", "review-doc"];
+
+// A reviewer state that means "a completed result object exists on this PR".
+// Both are produced only by a completion-kind signal in the #74 evaluator:
+// `completed@target` is bound to the frozen target, `not-bound` is a
+// completed run at some other target whose findings still survive
+// (policy/core.md, Acquisition & Validity Contract, evidence/finding axes).
+export const COMPLETED_RESULT_STATES = ["completed@target", "not-bound"];
+
+// ---------------------------------------------------------------------------
+// Artifact classification
+//
+// This table is a relocation of the examples policy/core.md already spells out
+// under "Artifact classification" — it is not a new consumer-facing mapping
+// language, and there is deliberately no rule DSL and no consumer override
+// record in this phase (Issue #76 decisions).
+//
+// A path this table cannot place is reported as unresolved rather than being
+// pushed into a class. Guessing "Informational" for an unrecognised path would
+// silently drop a mandatory review skill; guessing "Executable" would silently
+// invent an obligation. Neither is the machine's call.
+// ---------------------------------------------------------------------------
+
+const EXECUTABLE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts",
+  ".sql", ".sh", ".bash", ".ps1", ".py", ".rb", ".go", ".rs", ".java", ".kt", ".swift",
+  ".json", ".yaml", ".yml", ".toml",
+]);
+
+const INFORMATIONAL_BASENAMES = new Set([
+  "readme.md", "changelog.md", "license", "license.md", "notice", "notice.md",
+]);
+
+const NORMATIVE_BASENAMES = new Set(["agents.md", "claude.md"]);
+
+const NORMATIVE_PATH_SEGMENTS = ["policy/", "skills/"];
+
+const NORMATIVE_BASENAME_PATTERNS = [
+  /^product([-._].*)?\.md$/,
+  /^architecture([-._].*)?\.md$/,
+  /^adr([-._].*)?\.md$/,
+  /-rules\.md$/,
+];
+
+function normalizePath(value) {
+  return typeof value === "string" ? value.trim().replace(/\\/g, "/").replace(/^\.\//, "") : null;
+}
+
+function basenameOf(path) {
+  const index = path.lastIndexOf("/");
+  return (index === -1 ? path : path.slice(index + 1)).toLowerCase();
+}
+
+function extensionOf(basename) {
+  const index = basename.lastIndexOf(".");
+  return index <= 0 ? "" : basename.slice(index);
+}
+
+/** Classify one repository-relative path, or return null when unresolved. */
+export function classifyArtifactPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized) return null;
+  const basename = basenameOf(normalized);
+  if (INFORMATIONAL_BASENAMES.has(basename)) return "Informational";
+  if (EXECUTABLE_EXTENSIONS.has(extensionOf(basename))) return "Executable";
+  if (extensionOf(basename) === ".md") {
+    const lowered = normalized.toLowerCase();
+    if (NORMATIVE_BASENAMES.has(basename)) return "Normative";
+    if (NORMATIVE_PATH_SEGMENTS.some((segment) => lowered.includes(segment))) return "Normative";
+    if (NORMATIVE_BASENAME_PATTERNS.some((pattern) => pattern.test(basename))) return "Normative";
+  }
+  return null;
+}
+
+/**
+ * Derive artifact classes and the review skills they make mandatory.
+ * Mixed targets fall out of this naturally: two classes with a mandatory
+ * skill produce two required skills.
+ */
+export function classifyArtifactPaths(paths) {
+  const classes = new Set();
+  const requiredSkills = new Set();
+  const unresolved = [];
+  const byPath = [];
+  for (const path of sortedUnique(paths)) {
+    const artifactClass = classifyArtifactPath(path);
+    byPath.push({ path, artifact_class: artifactClass });
+    if (artifactClass === null) {
+      unresolved.push(path);
+      continue;
+    }
+    classes.add(artifactClass);
+    const skill = CLASS_REQUIRED_SKILL[artifactClass];
+    if (skill) requiredSkills.add(skill);
+  }
+  return {
+    classes: ARTIFACT_CLASSES.filter((value) => classes.has(value)),
+    required_skills: [...requiredSkills].sort(),
+    unresolved_paths: unresolved,
+    by_path: byPath,
+  };
+}
+
+/**
+ * Accepts `review-code`, `skills/review-code.md`, or the distributed
+ * `.ai-dev-foundation/skills/review-code.md` form and reduces them to the
+ * skill name used by the routing table.
+ */
+export function normalizeSkillName(value) {
+  const normalized = normalizePath(value);
+  if (!normalized) return null;
+  return basenameOf(normalized).replace(/\.md$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Acknowledged review-result revisions (Issue #76 amendment)
+//
+// A fresh acquisition alone does not close the canary #270 class: a result
+// comment can be edited in place to ADD findings while keeping its completion
+// marker, and the reviewer's target completion state stays `completed@target`.
+// The fence therefore compares the revision the agent actually triaged against
+// the revision that exists now.
+//
+// This is not a Resolution record and not an acknowledgement framework: it
+// stores nothing, keeps no history, and says nothing about what the findings
+// mean. It answers exactly one question — "is the current version of this
+// result the same version that was triaged?"
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses `<canonical_id>=<body_digest>` / `<canonical_id> <body_digest>`
+ * lines. Blank lines and `#` comments are ignored. Splitting on the LAST
+ * separator keeps ids that contain `=` intact; a digest never does.
+ */
+export function parseAcknowledgedRevisions(text) {
+  const entries = [];
+  const malformed = [];
+  const lines = String(text ?? "").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const match = /^(.*\S)[\s=]+(\S+)$/.exec(trimmed);
+    if (!match) {
+      malformed.push(trimmed);
+      continue;
+    }
+    entries.push({ canonical_id: match[1].trim(), body_digest: match[2] });
+  }
+  return { entries, malformed };
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument contract
+//
+// Kept beside the evaluator (like parseReviewEvidenceArgs) so the CLI module
+// stays a thin entrypoint and the argument shape is directly testable without
+// executing it.
+//
+// Only --repo/--pr/--target-sha are mandatory. Every other frozen declaration
+// is optional at the argument level and produces `unknown` for the check that
+// needed it — a missing input must never look like a satisfied one.
+// ---------------------------------------------------------------------------
+
+export const MERGE_READY_FENCE_USAGE = `Usage: node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> --target-sha <sha>
+  [--base-sha <sha>] [--artifact <path>]... [--artifacts-file <path>]
+  [--verify-sha <sha>] [--required <reviewer-id>]... [--declared-skill <name>]...
+  [--acknowledged <canonical_id>=<body_digest>]... [--acknowledged-file <path>]
+  [--run-after <iso>] [--run-anchor-id <id>] [--record <path>] [--token <token>]`;
+
+const REPEATABLE_ARGS = new Map([
+  ["--artifact", "artifacts"],
+  ["--required", "requiredReviewers"],
+  ["--declared-skill", "declaredSkills"],
+  ["--acknowledged", "acknowledged"],
+  ["--run-anchor-id", "runAnchorIds"],
+]);
+
+const SINGLE_ARGS = new Map([
+  ["--repo", "repo"],
+  ["--pr", "pr"],
+  ["--target-sha", "targetSha"],
+  ["--base-sha", "baseSha"],
+  ["--verify-sha", "verifySha"],
+  ["--artifacts-file", "artifactsFile"],
+  ["--acknowledged-file", "acknowledgedFile"],
+  ["--run-after", "runAfter"],
+  ["--record", "record"],
+  ["--token", "token"],
+]);
+
+export function parseMergeReadyFenceArgs(argv) {
+  const args = {
+    artifacts: null,
+    artifactsFile: null,
+    requiredReviewers: [],
+    declaredSkills: [],
+    acknowledged: null,
+    acknowledgedFile: null,
+    runAnchorIds: [],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (REPEATABLE_ARGS.has(arg)) {
+      const key = REPEATABLE_ARGS.get(arg);
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      if (args[key] === null) args[key] = [];
+      args[key].push(value);
+      index += 1;
+    } else if (SINGLE_ARGS.has(arg)) {
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      args[SINGLE_ARGS.get(arg)] = value;
+      index += 1;
+    } else {
+      throw new Error(`Unrecognized argument: ${arg}`);
+    }
+  }
+  if (!args.repo || !/^[^/]+\/[^/]+$/.test(args.repo)) throw new Error("--repo <owner/repo> is required");
+  if (!args.pr || !/^\d+$/.test(String(args.pr))) throw new Error("--pr <number> is required");
+  if (!args.targetSha) throw new Error("--target-sha <sha> is required");
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sortedUnique(values) {
+  const set = new Set();
+  for (const value of Array.isArray(values) ? values : []) {
+    const normalized = normalizePath(value);
+    if (normalized) set.add(normalized);
+  }
+  return [...set].sort();
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+// Same abbreviation tolerance the #74 evaluator applies when comparing a
+// marker-claimed target to the expected one: a 7+ character prefix of either
+// side matches, so a short SHA recorded at Selection still compares equal.
+function shaEqual(left, right) {
+  const a = nonEmpty(left)?.toLowerCase();
+  const b = nonEmpty(right)?.toLowerCase();
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.length >= 7 && b.startsWith(a)) return true;
+  if (b.length >= 7 && a.startsWith(b)) return true;
+  return false;
+}
+
+function check(id, status, reasonCodes = [], detail = {}) {
+  return { id, status, reason_codes: [...new Set(reasonCodes)].sort(), detail };
+}
+
+function surfaceOf(evidence, name) {
+  const surface = evidence?.surfaces?.[name];
+  return surface && typeof surface === "object" ? surface : null;
+}
+
+/** Current changed artifact paths, or a reason code explaining why not. */
+function currentArtifactPaths(evidence) {
+  const surface = surfaceOf(evidence, "pull_request_files");
+  if (!surface) return { paths: null, reason: "changed_files_unavailable" };
+  if (surface.fetch_status !== "fetched") return { paths: null, reason: "changed_files_unavailable" };
+  const items = Array.isArray(surface.items) ? surface.items : [];
+  if (items.some((item) => !nonEmpty(item?.path))) {
+    return { paths: null, reason: "changed_file_path_missing" };
+  }
+  return { paths: sortedUnique(items.map((item) => item.path)), reason: null };
+}
+
+// GitHub's documented closing keywords, followed by an issue reference in any
+// of the accepted forms. Kept as one deterministic pattern; there is no
+// keyword configuration and no per-repository exception.
+const CLOSING_KEYWORD_PATTERN =
+  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s+(#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[^\s/]+\/[^\s/]+\/issues\/\d+)/gi;
+
+export function findClosingKeywordReferences(body) {
+  if (typeof body !== "string") return [];
+  const found = [];
+  for (const match of body.matchAll(CLOSING_KEYWORD_PATTERN)) {
+    found.push({ keyword: match[1].toLowerCase(), reference: match[2] });
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+function checkTargetHead(evidence, inputs) {
+  const frozen = nonEmpty(inputs.targetSha);
+  if (!frozen) return check("target-head", "unknown", ["frozen_target_missing"]);
+  const metadata = evidence?.pr_metadata;
+  if (metadata?.fetch_status !== "fetched" || !nonEmpty(metadata.head_sha)) {
+    return check("target-head", "unknown", ["pr_metadata_unavailable"]);
+  }
+  const detail = { frozen_target_sha: frozen, current_head_sha: metadata.head_sha };
+  return shaEqual(metadata.head_sha, frozen)
+    ? check("target-head", "pass", [], detail)
+    : check("target-head", "fail", ["target_head_moved"], detail);
+}
+
+function checkTargetBase(evidence, inputs) {
+  const frozen = nonEmpty(inputs.baseSha);
+  if (!frozen) return check("target-base", "unknown", ["frozen_base_missing"]);
+  const metadata = evidence?.pr_metadata;
+  if (metadata?.fetch_status !== "fetched" || !nonEmpty(metadata.base_sha)) {
+    return check("target-base", "unknown", ["pr_metadata_unavailable"]);
+  }
+  const detail = { frozen_base_sha: frozen, current_base_sha: metadata.base_sha };
+  return shaEqual(metadata.base_sha, frozen)
+    ? check("target-base", "pass", [], detail)
+    : check("target-base", "fail", ["target_base_moved"], detail);
+}
+
+function checkArtifactSet(current, inputs) {
+  if (!Array.isArray(inputs.artifacts)) {
+    return check("artifact-set", "unknown", ["frozen_artifact_set_missing"]);
+  }
+  if (current.paths === null) {
+    return check("artifact-set", "unknown", [current.reason]);
+  }
+  const frozen = sortedUnique(inputs.artifacts);
+  const added = current.paths.filter((path) => !frozen.includes(path));
+  const removed = frozen.filter((path) => !current.paths.includes(path));
+  const detail = { frozen_count: frozen.length, current_count: current.paths.length, added, removed };
+  if (added.length === 0 && removed.length === 0) return check("artifact-set", "pass", [], detail);
+  const reasons = [];
+  if (added.length > 0) reasons.push("artifact_set_expanded");
+  if (removed.length > 0) reasons.push("artifact_set_reduced");
+  return check("artifact-set", "fail", reasons, detail);
+}
+
+function checkSkillRouting(current, inputs) {
+  if (current.paths === null) {
+    return check("skill-routing", "unknown", [current.reason]);
+  }
+  const classification = classifyArtifactPaths(current.paths);
+  const declaredList = Array.isArray(inputs.declaredSkills)
+    ? [...new Set(inputs.declaredSkills.map(normalizeSkillName).filter(Boolean))].sort()
+    : null;
+  const detail = {
+    derived_classes: classification.classes,
+    derived_required_skills: classification.required_skills,
+    declared_skills: declaredList,
+    unresolved_paths: classification.unresolved_paths,
+  };
+  if (declaredList === null) {
+    return check("skill-routing", "unknown", ["declared_skills_missing"], detail);
+  }
+  const missing = classification.required_skills.filter((skill) => !declaredList.includes(skill));
+  if (missing.length > 0) {
+    return check("skill-routing", "fail", ["required_skill_missing"], { ...detail, missing_skills: missing });
+  }
+  if (classification.unresolved_paths.length > 0) {
+    // An unresolved path only threatens routing safety when the Selection
+    // could still be missing a mandatory skill. A Selection that already
+    // declared every mandatory skill cannot be under-routed by it.
+    const declaresEveryMandatorySkill = MANDATORY_REVIEW_SKILLS.every((skill) => declaredList.includes(skill));
+    return declaresEveryMandatorySkill
+      ? check("skill-routing", "pass", ["artifact_class_unresolved_covered_by_declaration"], detail)
+      : check("skill-routing", "unknown", ["artifact_class_unresolved"], detail);
+  }
+  return check("skill-routing", "pass", [], detail);
+}
+
+function checkReviewerCompletion(state, inputs) {
+  const required = Array.isArray(inputs.requiredReviewers)
+    ? [...new Set(inputs.requiredReviewers.map(nonEmpty).filter(Boolean))]
+    : [];
+  if (required.length === 0) {
+    return check("reviewer-completion", "unknown", ["required_reviewers_missing"]);
+  }
+  const states = Array.isArray(state?.reviewer_states) ? state.reviewer_states : [];
+  const reasons = [];
+  const rows = [];
+  let status = "pass";
+  for (const reviewer of required.sort()) {
+    const entry = states.find((candidate) => candidate.reviewer === reviewer) ?? null;
+    if (entry === null) {
+      reasons.push("required_reviewer_unknown_id");
+      rows.push({ reviewer, state: null });
+      status = "unknown";
+      continue;
+    }
+    rows.push({ reviewer, state: entry.state, reason_codes: entry.reason_codes ?? [] });
+    for (const code of entry.reason_codes ?? []) reasons.push("reviewer_completion:" + code);
+    if (entry.state === "completed@target") continue;
+    if (entry.state === "in-flight" || entry.state === "unknown") {
+      reasons.push("required_reviewer_incomplete");
+      if (status !== "fail") status = "unknown";
+      continue;
+    }
+    // `not-bound` / `rate-limited` / `failed` / `declined`. A required
+    // member's obligation is not discharged by declaring non-participation
+    // (policy/core.md, Selection Contract); changing the required set is a
+    // Selection amendment the agent makes, expressed as a different --required.
+    reasons.push("required_reviewer_not_completed_at_target");
+    status = "fail";
+  }
+  return check("reviewer-completion", status, reasons, { required: rows });
+}
+
+function checkResultRevisionCoherence(state, inputs) {
+  const states = Array.isArray(state?.reviewer_states) ? state.reviewer_states : [];
+  const withResults = states.filter((entry) => COMPLETED_RESULT_STATES.includes(entry.state));
+  const acknowledged = Array.isArray(inputs.acknowledged) ? inputs.acknowledged : null;
+  const rows = [];
+  const reasons = [];
+  let status = "pass";
+
+  // Coverage is gated before "nothing has arrived": an incomplete acquisition
+  // is exactly the state in which a result may exist without being visible, so
+  // an empty result set proves nothing yet.
+  if (state?.coverage_complete !== true) {
+    return check("result-revision-coherence", "unknown", ["coverage_incomplete"], {
+      required: [],
+      incomplete_surfaces: state?.incomplete_surfaces ?? [],
+    });
+  }
+  if (withResults.length === 0) {
+    // Nothing has arrived to triage yet. An advisory reviewer that has not
+    // reported is not a blocker (policy/core.md, Selection Contract).
+    return check("result-revision-coherence", "pass", [], { required: [], unmatched_acknowledgements: [] });
+  }
+
+  const matched = new Set();
+  for (const entry of withResults) {
+    const evidenceItems = Array.isArray(entry.evidence) ? entry.evidence : [];
+    if (evidenceItems.length === 0) {
+      rows.push({ reviewer: entry.reviewer, state: entry.state, canonical_id: null, result: "unresolved" });
+      reasons.push("result_revision_unresolved");
+      if (status !== "fail") status = "unknown";
+      continue;
+    }
+    for (const item of evidenceItems) {
+      const canonicalId = nonEmpty(item?.canonical_id);
+      const currentDigest = nonEmpty(item?.revision?.body_digest);
+      if (!canonicalId || !currentDigest) {
+        rows.push({ reviewer: entry.reviewer, state: entry.state, canonical_id: canonicalId, result: "unresolved" });
+        reasons.push("result_revision_unresolved");
+        if (status !== "fail") status = "unknown";
+        continue;
+      }
+      const ack = acknowledged?.find((candidate) => candidate.canonical_id === canonicalId) ?? null;
+      if (ack) matched.add(canonicalId);
+      const row = {
+        reviewer: entry.reviewer,
+        state: entry.state,
+        canonical_id: canonicalId,
+        current_body_digest: currentDigest,
+        acknowledged_body_digest: ack?.body_digest ?? null,
+      };
+      if (!ack) {
+        rows.push({ ...row, result: "unacknowledged" });
+        reasons.push("result_revision_unacknowledged");
+        status = "fail";
+      } else if (ack.body_digest !== currentDigest) {
+        rows.push({ ...row, result: "changed" });
+        reasons.push("review_result_changed_after_triage");
+        status = "fail";
+      } else {
+        rows.push({ ...row, result: "current" });
+      }
+    }
+  }
+
+  const unmatched = (acknowledged ?? [])
+    .filter((entry) => !matched.has(entry.canonical_id))
+    .map((entry) => entry.canonical_id)
+    .sort();
+  return check("result-revision-coherence", status, reasons, {
+    required: rows,
+    unmatched_acknowledgements: unmatched,
+  });
+}
+
+function checkAcquisitionCoverage(state) {
+  return state?.coverage_complete === true
+    ? check("acquisition-coverage", "pass", [], { incomplete_surfaces: [] })
+    : check("acquisition-coverage", "unknown", ["coverage_incomplete"], {
+        incomplete_surfaces: state?.incomplete_surfaces ?? [],
+      });
+}
+
+function checkReviewThreads(evidence) {
+  const surface = surfaceOf(evidence, "review_threads");
+  if (!surface || surface.fetch_status !== "fetched") {
+    return check("review-threads", "unknown", ["review_threads_unavailable"]);
+  }
+  const items = Array.isArray(surface.items) ? surface.items : [];
+  const unresolved = items.filter((item) => item?.is_resolved === false);
+  const indeterminate = items.filter((item) => item?.is_resolved !== true && item?.is_resolved !== false);
+  const detail = {
+    thread_count: items.length,
+    unresolved_count: unresolved.length,
+    unresolved_outdated_count: unresolved.filter((item) => item?.is_outdated === true).length,
+    unresolved_thread_ids: unresolved.map((item) => item?.id ?? null),
+  };
+  // An outdated-but-unresolved thread still fails: "outdated" is GitHub's
+  // statement about the diff position, not about the conversation.
+  if (unresolved.length > 0) return check("review-threads", "fail", ["unresolved_review_thread"], detail);
+  if (indeterminate.length > 0) {
+    return check("review-threads", "unknown", ["thread_resolution_unknown"], {
+      ...detail,
+      indeterminate_count: indeterminate.length,
+    });
+  }
+  return check("review-threads", "pass", [], detail);
+}
+
+function checkVerifyCoherence(inputs) {
+  const verifySha = nonEmpty(inputs.verifySha);
+  const frozen = nonEmpty(inputs.targetSha);
+  if (!verifySha) return check("verify-coherence", "unknown", ["verify_evidence_missing"]);
+  if (!frozen) return check("verify-coherence", "unknown", ["frozen_target_missing"]);
+  const detail = { verify_sha: verifySha, frozen_target_sha: frozen };
+  return shaEqual(verifySha, frozen)
+    ? check("verify-coherence", "pass", [], detail)
+    : check("verify-coherence", "fail", ["verify_target_mismatch"], detail);
+}
+
+function checkAutocloseHygiene(evidence) {
+  const metadata = evidence?.pr_metadata;
+  if (metadata?.fetch_status !== "fetched") {
+    return check("autoclose-hygiene", "unknown", ["pr_metadata_unavailable"]);
+  }
+  const references = findClosingKeywordReferences(metadata.body ?? "");
+  return references.length === 0
+    ? check("autoclose-hygiene", "pass", [], { references: [] })
+    : check("autoclose-hygiene", "fail", ["autoclose_keyword_present"], { references });
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+export function aggregateFenceStatus(checks) {
+  if (checks.some((entry) => entry.status === "fail")) return "fail";
+  if (checks.some((entry) => entry.status === "unknown")) return "unknown";
+  return "pass";
+}
+
+/**
+ * @param evidence  collectReviewEvidence() result (one fresh acquisition)
+ * @param state     evaluateReviewerTargetStates() result for that same snapshot
+ * @param inputs    the frozen declarations: targetSha, baseSha, artifacts[],
+ *                  verifySha, requiredReviewers[], declaredSkills[],
+ *                  acknowledged[{canonical_id, body_digest}]
+ */
+export function evaluateMergeReadyFence({ evidence, state, inputs = {} } = {}) {
+  const current = currentArtifactPaths(evidence);
+  const checks = [
+    checkTargetHead(evidence, inputs),
+    checkTargetBase(evidence, inputs),
+    checkArtifactSet(current, inputs),
+    checkSkillRouting(current, inputs),
+    checkReviewerCompletion(state, inputs),
+    checkResultRevisionCoherence(state, inputs),
+    checkAcquisitionCoverage(state),
+    checkReviewThreads(evidence),
+    checkVerifyCoherence(inputs),
+    checkAutocloseHygiene(evidence),
+  ];
+  const status = aggregateFenceStatus(checks);
+  return {
+    schema: MERGE_READY_FENCE_SCHEMA_ID,
+    repo: evidence?.repo ?? null,
+    pull_number: evidence?.pull_number ?? null,
+    captured_at: evidence?.generated_at ?? null,
+    target: {
+      sha: nonEmpty(inputs.targetSha),
+      base_sha: nonEmpty(inputs.baseSha),
+    },
+    status,
+    checks,
+    reason_codes: [...new Set(checks.flatMap((entry) => entry.reason_codes))].sort(),
+  };
+}

--- a/tooling/merge-ready-fence-lib.mjs
+++ b/tooling/merge-ready-fence-lib.mjs
@@ -41,7 +41,10 @@ export const CLASS_REQUIRED_SKILL = {
   Informational: null,
 };
 
-export const MANDATORY_REVIEW_SKILLS = ["review-code", "review-doc"];
+// Derived, not restated: a second hand-written list beside the routing table
+// would silently disagree with it if a class ever gained or lost a mandatory
+// skill, and the disagreement would surface as an under-routing that passes.
+export const MANDATORY_REVIEW_SKILLS = [...new Set(Object.values(CLASS_REQUIRED_SKILL).filter(Boolean))].sort();
 
 // A reviewer state that means "a completed result object exists on this PR".
 // Both are produced only by a completion-kind signal in the #74 evaluator:

--- a/tooling/merge-ready-fence.mjs
+++ b/tooling/merge-ready-fence.mjs
@@ -60,61 +60,66 @@ async function readAcknowledged(filePath, inline) {
 
 const EXIT_CODE = { pass: 0, fail: 1, unknown: 2 };
 
-let args;
-try {
-  args = parseMergeReadyFenceArgs(process.argv.slice(2));
-} catch (error) {
-  console.error(error.message);
-  console.error(MERGE_READY_FENCE_USAGE);
-  process.exitCode = 2;
-}
+// A setup failure is not a fence verdict. Anything that prevents the fence from
+// being evaluated at all — bad arguments, no token, an unusable reviewer
+// record, an unreadable input file, a failed acquisition — exits 2 with a
+// message on stderr and no JSON on stdout. Letting one of these escape would
+// exit 1, which a caller reads as `fail`: a definite verdict the fence never
+// reached.
+async function main() {
+  const args = parseMergeReadyFenceArgs(process.argv.slice(2));
 
-if (args) {
   const token = resolveToken(args.token);
   if (!token) {
-    console.error("No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.");
-    process.exitCode = 2;
-  } else {
-    const recordPath = path.resolve(args.record ?? ".ai-dev-foundation/reviewers.json");
-    const loaded = await readReviewerRecordFile(recordPath);
-    if (loaded.status !== "ok") {
-      console.error(`Reviewer record ${loaded.status}: ${recordPath}`);
-      process.exitCode = 2;
-    } else {
-      const [artifacts, acknowledged] = await Promise.all([
-        readPathList(args.artifactsFile, args.artifacts),
-        readAcknowledged(args.acknowledgedFile, args.acknowledged),
-      ]);
-      const [owner, repo] = args.repo.split("/");
-      const evidence = await collectReviewEvidence({
-        owner,
-        repo,
-        pullNumber: Number(args.pr),
-        token,
-      });
-      // Every reviewer in the record is evaluated, not just the required
-      // ones: an advisory reviewer whose result has already arrived still
-      // owes revision coherence (Issue #76 amendment).
-      const state = evaluateReviewerTargetStates(evidence, {
-        record: loaded.record,
-        target: { sha: args.targetSha },
-        runAnchor: { ids: args.runAnchorIds, after: args.runAfter ?? null },
-      });
-      const fence = evaluateMergeReadyFence({
-        evidence,
-        state,
-        inputs: {
-          targetSha: args.targetSha,
-          baseSha: args.baseSha ?? null,
-          artifacts,
-          verifySha: args.verifySha ?? null,
-          requiredReviewers: args.requiredReviewers,
-          declaredSkills: args.declaredSkills.length > 0 ? args.declaredSkills : null,
-          acknowledged,
-        },
-      });
-      console.log(JSON.stringify(fence, null, 2));
-      process.exitCode = EXIT_CODE[fence.status];
-    }
+    throw new Error("No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.");
   }
+
+  const recordPath = path.resolve(args.record ?? ".ai-dev-foundation/reviewers.json");
+  const loaded = await readReviewerRecordFile(recordPath);
+  if (loaded.status !== "ok") {
+    throw new Error(`Reviewer record ${loaded.status}: ${recordPath}`);
+  }
+
+  const [artifacts, acknowledged] = await Promise.all([
+    readPathList(args.artifactsFile, args.artifacts),
+    readAcknowledged(args.acknowledgedFile, args.acknowledged),
+  ]);
+  const [owner, repo] = args.repo.split("/");
+  const evidence = await collectReviewEvidence({
+    owner,
+    repo,
+    pullNumber: Number(args.pr),
+    token,
+  });
+  // Every reviewer in the record is evaluated, not just the required ones: an
+  // advisory reviewer whose result has already arrived still owes revision
+  // coherence (Issue #76 amendment).
+  const state = evaluateReviewerTargetStates(evidence, {
+    record: loaded.record,
+    target: { sha: args.targetSha },
+    runAnchor: { ids: args.runAnchorIds, after: args.runAfter ?? null },
+  });
+  return evaluateMergeReadyFence({
+    evidence,
+    state,
+    inputs: {
+      targetSha: args.targetSha,
+      baseSha: args.baseSha ?? null,
+      artifacts,
+      verifySha: args.verifySha ?? null,
+      requiredReviewers: args.requiredReviewers,
+      declaredSkills: args.declaredSkills.length > 0 ? args.declaredSkills : null,
+      acknowledged,
+    },
+  });
+}
+
+try {
+  const fence = await main();
+  console.log(JSON.stringify(fence, null, 2));
+  process.exitCode = EXIT_CODE[fence.status];
+} catch (error) {
+  console.error(error?.message ?? String(error));
+  console.error(MERGE_READY_FENCE_USAGE);
+  process.exitCode = 2;
 }

--- a/tooling/merge-ready-fence.mjs
+++ b/tooling/merge-ready-fence.mjs
@@ -62,10 +62,15 @@ const EXIT_CODE = { pass: 0, fail: 1, unknown: 2 };
 
 // A setup failure is not a fence verdict. Anything that prevents the fence from
 // being evaluated at all — bad arguments, no token, an unusable reviewer
-// record, an unreadable input file, a failed acquisition — exits 2 with a
-// message on stderr and no JSON on stdout. Letting one of these escape would
-// exit 1, which a caller reads as `fail`: a definite verdict the fence never
-// reached.
+// record, an unreadable input file — exits 2 with a message on stderr and no
+// JSON on stdout. Letting one of these escape would exit 1, which a caller
+// reads as `fail`: a definite verdict the fence never reached.
+//
+// An ordinary acquisition failure is NOT one of these. collectReviewEvidence()
+// reports a GitHub API failure as that surface's own `fetch_status` and does
+// not throw, so the fence is still evaluated and reports `unknown` through
+// `acquisition-coverage`. Both paths exit 2; only a setup failure writes
+// nothing to stdout.
 async function main() {
   const args = parseMergeReadyFenceArgs(process.argv.slice(2));
 

--- a/tooling/merge-ready-fence.mjs
+++ b/tooling/merge-ready-fence.mjs
@@ -1,0 +1,120 @@
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { collectReviewEvidence } from "./review-evidence-lib.mjs";
+import { readReviewerRecordFile } from "./reviewer-record-lib.mjs";
+import { evaluateReviewerTargetStates } from "./review-evidence-state-lib.mjs";
+import {
+  MERGE_READY_FENCE_USAGE,
+  evaluateMergeReadyFence,
+  parseAcknowledgedRevisions,
+  parseMergeReadyFenceArgs,
+} from "./merge-ready-fence-lib.mjs";
+
+// Deterministic merge-ready fence CLI (Issue #76).
+//
+// One invocation performs exactly ONE fresh acquisition and evaluates every
+// machine-checkable precondition against it. It deliberately accepts no
+// snapshot argument: there is no way to hand this tool an evidence snapshot
+// observed earlier in a session, which is what makes "the fence was evaluated
+// on fresh evidence" a structural property rather than a promise.
+//
+// Exit codes: 0 = pass, 1 = fail, 2 = unknown. Usage/setup errors also exit 2
+// but write to stderr and emit no JSON on stdout.
+
+function resolveToken(explicitToken) {
+  if (explicitToken) return explicitToken;
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  try {
+    return execFileSync("gh", ["auth", "token"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// A missing optional list stays null so the fence can report `unknown` for the
+// check that needed it, rather than silently evaluating against an empty set.
+async function readPathList(filePath, inline) {
+  const values = inline === null ? [] : [...inline];
+  if (filePath) {
+    const text = await readFile(path.resolve(filePath), "utf8");
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed !== "" && !trimmed.startsWith("#")) values.push(trimmed);
+    }
+  }
+  return inline === null && !filePath ? null : values;
+}
+
+async function readAcknowledged(filePath, inline) {
+  if (inline === null && !filePath) return null;
+  const lines = inline === null ? [] : [...inline];
+  if (filePath) lines.push(await readFile(path.resolve(filePath), "utf8"));
+  const parsed = parseAcknowledgedRevisions(lines.join("\n"));
+  if (parsed.malformed.length > 0) {
+    throw new Error(`Malformed --acknowledged entry: ${parsed.malformed[0]}`);
+  }
+  return parsed.entries;
+}
+
+const EXIT_CODE = { pass: 0, fail: 1, unknown: 2 };
+
+let args;
+try {
+  args = parseMergeReadyFenceArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(error.message);
+  console.error(MERGE_READY_FENCE_USAGE);
+  process.exitCode = 2;
+}
+
+if (args) {
+  const token = resolveToken(args.token);
+  if (!token) {
+    console.error("No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.");
+    process.exitCode = 2;
+  } else {
+    const recordPath = path.resolve(args.record ?? ".ai-dev-foundation/reviewers.json");
+    const loaded = await readReviewerRecordFile(recordPath);
+    if (loaded.status !== "ok") {
+      console.error(`Reviewer record ${loaded.status}: ${recordPath}`);
+      process.exitCode = 2;
+    } else {
+      const [artifacts, acknowledged] = await Promise.all([
+        readPathList(args.artifactsFile, args.artifacts),
+        readAcknowledged(args.acknowledgedFile, args.acknowledged),
+      ]);
+      const [owner, repo] = args.repo.split("/");
+      const evidence = await collectReviewEvidence({
+        owner,
+        repo,
+        pullNumber: Number(args.pr),
+        token,
+      });
+      // Every reviewer in the record is evaluated, not just the required
+      // ones: an advisory reviewer whose result has already arrived still
+      // owes revision coherence (Issue #76 amendment).
+      const state = evaluateReviewerTargetStates(evidence, {
+        record: loaded.record,
+        target: { sha: args.targetSha },
+        runAnchor: { ids: args.runAnchorIds, after: args.runAfter ?? null },
+      });
+      const fence = evaluateMergeReadyFence({
+        evidence,
+        state,
+        inputs: {
+          targetSha: args.targetSha,
+          baseSha: args.baseSha ?? null,
+          artifacts,
+          verifySha: args.verifySha ?? null,
+          requiredReviewers: args.requiredReviewers,
+          declaredSkills: args.declaredSkills.length > 0 ? args.declaredSkills : null,
+          acknowledged,
+        },
+      });
+      console.log(JSON.stringify(fence, null, 2));
+      process.exitCode = EXIT_CODE[fence.status];
+    }
+  }
+}

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -129,6 +129,20 @@ async function fetchGraphQL(fetchImpl, token, query, variables) {
   return body?.data ?? null;
 }
 
+// `author` is typed as the `Actor` interface, which declares only `login`.
+// Selecting `databaseId` / `id` on it directly is a schema error that fails the
+// whole query, so the ids are selected through the concrete types that carry
+// them. An actor type not listed here still yields its `login`; the ids stay
+// null and the caller treats identity as unconfirmed rather than absent.
+const ACTOR_IDS_FRAGMENT = `
+fragment ActorIds on Actor {
+  ... on User { databaseId id }
+  ... on Bot { databaseId id }
+  ... on Organization { databaseId id }
+  ... on Mannequin { databaseId id }
+  ... on EnterpriseUserAccount { id }
+}`;
+
 const REVIEW_THREADS_QUERY = `
 query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
@@ -147,7 +161,7 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
               url
               createdAt
               updatedAt
-              author { login databaseId id }
+              author { login ...ActorIds }
               commit { oid }
               originalCommit { oid }
               pullRequestReview {
@@ -164,7 +178,8 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
       }
     }
   }
-}`;
+}
+${ACTOR_IDS_FRAGMENT}`;
 
 const THREAD_COMMENTS_QUERY = `
 query($id: ID!, $cursor: String) {
@@ -178,7 +193,7 @@ query($id: ID!, $cursor: String) {
           url
           createdAt
           updatedAt
-          author { login databaseId id }
+          author { login ...ActorIds }
           commit { oid }
           originalCommit { oid }
           pullRequestReview {
@@ -193,7 +208,8 @@ query($id: ID!, $cursor: String) {
       }
     }
   }
-}`;
+}
+${ACTOR_IDS_FRAGMENT}`;
 
 // A thread's own `comments` connection can exceed the first page fetched by
 // REVIEW_THREADS_QUERY (>50 replies on one thread). This follows that

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -137,6 +137,8 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
+          isResolved
+          isOutdated
           comments(first: 50) {
             pageInfo { hasNextPage endCursor }
             nodes {
@@ -323,9 +325,15 @@ function normalizeInlineReviewComment(item) {
   };
 }
 
+// `is_resolved` is the thread's own GitHub resolution state, kept separate
+// from anything the canonical review_comment projection derives from the
+// child comments. `null` means the field was absent from the response, and is
+// reported as such rather than being read as resolved.
 function normalizeReviewThread(node) {
   return {
     id: node.id ?? null,
+    is_resolved: typeof node.isResolved === "boolean" ? node.isResolved : null,
+    is_outdated: typeof node.isOutdated === "boolean" ? node.isOutdated : null,
     comments: (node.comments?.nodes ?? []).map((comment) => ({
       id: comment.id ?? null,
       database_id: comment.databaseId ?? null,
@@ -377,6 +385,18 @@ function normalizeStatus(status) {
   };
 }
 
+// Which artifacts the PR currently changes. `status` is kept so an added or
+// removed file stays distinguishable from a modified one; patch content is
+// deliberately not retained — this surface reports the changed path set and
+// nothing about the change's meaning.
+function normalizePullRequestFile(item) {
+  return {
+    path: item.filename ?? null,
+    status: item.status ?? null,
+    previous_path: item.previous_filename ?? null,
+  };
+}
+
 function notApplicableSurface(note) {
   return { fetch_status: "not_applicable", count: null, pages_fetched: 0, items: [], failure: null, note };
 }
@@ -401,11 +421,12 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
   }
   const headSha = prBody?.head?.sha ?? null;
 
-  const [conversationComments, reviewSubmissions, inlineReviewComments, reviewThreads] = await Promise.all([
+  const [conversationComments, reviewSubmissions, inlineReviewComments, reviewThreads, pullRequestFiles] = await Promise.all([
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/issues/${pullNumber}/comments?per_page=100`),
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/reviews?per_page=100`),
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/comments?per_page=100`),
     fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber),
+    fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/files?per_page=100`),
   ]);
 
   // commit_status/check_runs are fetched for this snapshot's headSha only —
@@ -441,6 +462,7 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
     review_submissions: { ...reviewSubmissions, items: reviewSubmissions.items.map(normalizeReviewSubmission) },
     inline_review_comments: { ...inlineReviewComments, items: inlineReviewComments.items.map(normalizeInlineReviewComment) },
     review_threads: { ...reviewThreads, items: reviewThreads.items.map(normalizeReviewThread) },
+    pull_request_files: { ...pullRequestFiles, items: pullRequestFiles.items.map(normalizePullRequestFile) },
     commit_status:
       commitStatus.fetch_status === "not_applicable"
         ? { fetch_status: "not_applicable", failure: null, status: null, note: commitStatus.note }
@@ -464,9 +486,33 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
     repo: `${owner}/${repo}`,
     pull_number: pullNumber,
     generated_at: new Date().toISOString(),
+    // base_sha/base_ref/body are retained so a caller can compare the PR's
+    // current base against a recorded one and scan the current body text.
+    // Both were previously only reachable by reading the PR by hand; keeping
+    // them here adds acquisition coverage, not judgment.
     pr_metadata: prBody
-      ? { fetch_status: "fetched", failure: null, head_sha: headSha, state: prBody.state ?? null, html_url: prBody.html_url ?? null, updated_at: prBody.updated_at ?? null }
-      : { fetch_status: "failed", failure: prMetadataFailure, head_sha: null, state: null, html_url: null, updated_at: null },
+      ? {
+          fetch_status: "fetched",
+          failure: null,
+          head_sha: headSha,
+          base_sha: prBody.base?.sha ?? null,
+          base_ref: prBody.base?.ref ?? null,
+          state: prBody.state ?? null,
+          html_url: prBody.html_url ?? null,
+          updated_at: prBody.updated_at ?? null,
+          body: prBody.body ?? null,
+        }
+      : {
+          fetch_status: "failed",
+          failure: prMetadataFailure,
+          head_sha: null,
+          base_sha: null,
+          base_ref: null,
+          state: null,
+          html_url: null,
+          updated_at: null,
+          body: null,
+        },
     surfaces,
     fetch_failures: fetchFailures,
   };
@@ -477,6 +523,7 @@ const SURFACE_LABELS = [
   ["review_submissions", "Review submissions"],
   ["inline_review_comments", "Inline review comments"],
   ["review_threads", "Review threads"],
+  ["pull_request_files", "Changed files"],
   ["commit_status", "Commit status (combined)"],
   ["check_runs", "Check runs"],
 ];

--- a/tooling/review-evidence-state-lib.mjs
+++ b/tooling/review-evidence-state-lib.mjs
@@ -992,6 +992,25 @@ function bindingForObject(object, markerTarget) {
   return { status: "bound", effective: strongest[0], reason_code: null };
 }
 
+// The shortest abbreviation that may stand for a commit. Below this, a prefix
+// match is not evidence that two claims name the same target.
+const MIN_ABBREVIATED_TARGET_LENGTH = 7;
+
+// Two target claims describe the same commit when they are equal, or when one
+// is an abbreviation of the other. This is the same tolerance the target
+// comparison below applies, and it is the only comparison that may be used
+// between two claimed targets: comparing them as raw strings makes a short SHA
+// and its full form look like two different targets.
+function sameTargetClaim(left, right) {
+  const a = nonEmpty(left)?.toLowerCase();
+  const b = nonEmpty(right)?.toLowerCase();
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.length >= MIN_ABBREVIATED_TARGET_LENGTH && b.startsWith(a)) return true;
+  if (b.length >= MIN_ABBREVIATED_TARGET_LENGTH && a.startsWith(b)) return true;
+  return false;
+}
+
 function chooseSignal(signals) {
   if (signals.length === 0)
     return { signal: null, conflict: false, latest: [] };
@@ -999,15 +1018,28 @@ function chooseSignal(signals) {
   const latestTime = Math.max(...signals.map(time));
   const latest = signals.filter((signal) => time(signal) === latestTime);
   const kinds = new Set(latest.map((signal) => signal.kind));
-  const targets = new Set(
-    latest.map((signal) => signal.target_claim).filter(Boolean),
+  const targets = latest.map((signal) => signal.target_claim).filter(Boolean);
+  // A reviewer that posts its result across several objects at once (a review
+  // submission plus its inline comments, say) repeats its completion marker on
+  // each of them, and may abbreviate the SHA differently between them. That is
+  // one claim expressed more than once, not two claims in conflict.
+  const targetsDisagree = targets.some(
+    (candidate) => !sameTargetClaim(candidate, targets[0]),
   );
-  if (kinds.size > 1 || targets.size > 1) {
+  if (kinds.size > 1 || targetsDisagree) {
     return { signal: null, conflict: true, latest };
   }
-  latest.sort((left, right) =>
-    compareNullable(left.canonical_id, right.canonical_id),
-  );
+  // Prefer the most specific claim, so the binding downstream compares the
+  // longest SHA the reviewer actually stated. `canonical_id` breaks ties so the
+  // choice stays deterministic across snapshots.
+  latest.sort((left, right) => {
+    const byLength =
+      (nonEmpty(left.target_claim)?.length ?? 0) -
+      (nonEmpty(right.target_claim)?.length ?? 0);
+    return byLength !== 0
+      ? byLength
+      : compareNullable(left.canonical_id, right.canonical_id);
+  });
   return { signal: latest[latest.length - 1], conflict: false, latest };
 }
 
@@ -1107,15 +1139,7 @@ function stateForReviewer(canonical, reviewer, target, runAnchor, reviewers) {
             reasons.add("coverage_incomplete");
           } else if (
             (() => {
-              const candidate = nonEmpty(
-                binding.effective.target,
-              )?.toLowerCase();
-              const expected = targetValue.toLowerCase();
-              return (
-                candidate === expected ||
-                (candidate.length >= 7 && expected.startsWith(candidate)) ||
-                (expected.length >= 7 && candidate.startsWith(expected))
-              );
+              return sameTargetClaim(binding.effective.target, targetValue);
             })()
           ) {
             state = "completed@target";

--- a/tooling/review-evidence-state-lib.mjs
+++ b/tooling/review-evidence-state-lib.mjs
@@ -812,7 +812,11 @@ function markerMatch(body, marker) {
       return { target: null, reason_code: "target_marker_invalid" };
     }
     const match = expression.exec(body);
-    if (match) target = match.slice(1).find((value) => nonEmpty(value)) ?? null;
+    // Normalized at the source, so every later comparison and every length
+    // measurement sees the same value. A target_pattern is free to capture
+    // surrounding whitespace, and a claim that is padded in one place but
+    // trimmed in another is what lets a short claim masquerade as a long one.
+    if (match) target = nonEmpty(match.slice(1).find((value) => nonEmpty(value)));
     if (!match) return { target: null, reason_code: "target_marker_missing" };
   }
   return { target };
@@ -1018,7 +1022,10 @@ function chooseSignal(signals) {
   const latestTime = Math.max(...signals.map(time));
   const latest = signals.filter((signal) => time(signal) === latestTime);
   const kinds = new Set(latest.map((signal) => signal.kind));
-  const targets = latest.map((signal) => signal.target_claim).filter(Boolean);
+  // Normalized here as well as at extraction: the length that picks the
+  // representative and the value that is compared against it must be the same
+  // string, or a padded short claim becomes the `longest` one.
+  const targets = latest.map((signal) => nonEmpty(signal.target_claim)).filter(Boolean);
   // A reviewer that posts its result across several objects at once (a review
   // submission plus its inline comments, say) repeats its completion marker on
   // each of them, and may abbreviate the SHA differently between them. That is
@@ -1047,9 +1054,7 @@ function chooseSignal(signals) {
     const byLength =
       (nonEmpty(left.target_claim)?.length ?? 0) -
       (nonEmpty(right.target_claim)?.length ?? 0);
-    return byLength !== 0
-      ? byLength
-      : compareNullable(left.canonical_id, right.canonical_id);
+    return byLength !== 0 ? byLength : compareNullable(left.canonical_id, right.canonical_id);
   });
   return { signal: latest[latest.length - 1], conflict: false, latest };
 }

--- a/tooling/review-evidence-state-lib.mjs
+++ b/tooling/review-evidence-state-lib.mjs
@@ -1023,8 +1023,19 @@ function chooseSignal(signals) {
   // submission plus its inline comments, say) repeats its completion marker on
   // each of them, and may abbreviate the SHA differently between them. That is
   // one claim expressed more than once, not two claims in conflict.
+  //
+  // Every claim is compared against the LONGEST one, never against an arbitrary
+  // representative: `sameTargetClaim` is not transitive, so `abcdef0…111` and
+  // `abcdef0…222` are both compatible with the abbreviation `abcdef0` while
+  // naming different commits. Requiring each claim to be an abbreviation of one
+  // longest claim makes them pairwise compatible — prefixes of a common string
+  // are ordered by length — so two full SHAs that disagree are still a conflict.
+  const longest = targets.reduce(
+    (best, candidate) => (candidate.length > (best?.length ?? -1) ? candidate : best),
+    null,
+  );
   const targetsDisagree = targets.some(
-    (candidate) => !sameTargetClaim(candidate, targets[0]),
+    (candidate) => !sameTargetClaim(candidate, longest),
   );
   if (kinds.size > 1 || targetsDisagree) {
     return { signal: null, conflict: true, latest };


### PR DESCRIPTION
Refs #76 / design checkpoint: https://github.com/reitojike/ai-dev-foundation/issues/76#issuecomment-5525547746

approved design を basis に、orchestrator decisions 1〜7 と result revision coherence amendment を適用した Phase 2 implementation です。merge / Issue close / #71・#70 変更 / stage-tracker repin は行っていません。

## 何を code へ移したか

merge-ready 宣言前に残っていた deterministic judgment を、1 回の fresh acquisition に対して評価する bounded checker（`tooling/merge-ready-fence.mjs` / `tooling/merge-ready-fence-lib.mjs`）へ集約しました。10 check、`pass` / `fail` / `unknown` の 3 値、machine-readable な `reason_codes`。

`target-head` / `target-base` / `artifact-set` / `skill-routing` / `reviewer-completion` / `result-revision-coherence` / `acquisition-coverage` / `review-threads` / `verify-coherence` / `autoclose-hygiene`。

checker は pure function です（fetch / fs / git / clock なし、provider 分岐 0 件）。`reviewer-completion` は #74 の `evaluateReviewerTargetStates()` の出力を消費するだけで、provider marker parser を 1 行も持ちません。

## Orchestrator decisions の適用

1. **artifact class mapping** — Foundation-owned default のみ。consumer override record なし。path から確実に導出できない artifact は unresolved として報告し、特定 class へ昇格させません。ただし Selection が mandatory review skill をすべて宣言していれば under-route されえないため `pass`（`artifact_class_unresolved_covered_by_declaration`）。generic mapping DSL なし。
2. **fence output** — new durable schema / validator なし。output shape は production test（`fence output shape is stable: schema, ordered checks, tri-state status`）が固定します。persistent protocol record へ昇格させていません。
3. **auto-close** — `--allow-autoclose` は導入していません。current PR body に closing keyword があれば `fail`。commit message は fence 実行時点に存在しないため対象外。
4. **artifact-set drift** — 厳密一致。追加・削除いずれも `fail`（subset 許容なし）。
5. **reviewer machine gate** — required reviewer のみ。expected / optional の membership closure は自動化していません。
6. **TEST-ONLY decision model** — 下記「test delta」および「残した semantic invariant」参照。
7. **review-code / review-doc** — 同一 fence を両 skill が参照。classification 別 fence なし。verify coherence は `--verify-sha == --target-sha` の最小判定のみで、`--verify-scope` / `--verify-artifacts-file` は導入していません。

### Required amendment: result revision coherence

fresh acquisition だけでは canary #270 を塞げません。同じ result comment が in-place 更新され、completion marker を保ったまま finding が追加された場合、#74 state は `completed@target` のままです。

`result-revision-coherence` check を追加しました。#74 が既に提供する `canonical_id` / current `revision` / `body_digest` を再利用し、`--acknowledged <canonical_id>=<body_digest>`（または `--acknowledged-file` の改行区切り plain text）で受け取った「triage 対象にした版」と、fresh acquisition 後の current revision を比較します。

- same → `pass`
- current result は存在するが acknowledged revision が無い → `fail`（`result_revision_unacknowledged`）
- digest changed → `fail`（`review_result_changed_after_triage`）
- acquisition incomplete / identity 不明 → `unknown`

対象は required reviewer の current completed result と、fresh acquisition 時点で既に到着している advisory / optional reviewer の result です。未到着の advisory reviewer は block しません。finding の意味や Resolution の完了は判断しません。provider 固有の warning / finding parser は追加していません。

### Architecture brake

- new persistent artifact: **0**
- new durable schema: **0**
- provider-specific branch: **0**
- semantic Resolution automation: **0**

generic acknowledgement framework / event history / review database へ広げていません。fence は `--resolution-complete` のような agent 申告 flag を入力に取らず、snapshot file も引数に取りません（後者が fresh acquisition の構造的保証です）。

## 実装を実際に動かして見つかった defect 3 件

いずれも既存 production code の defect で、**Phase 2 の Success Criteria が成立するために修正が必要**でした。fixture を追加しています。

### 1. review-thread GraphQL query が常に失敗していた

`author` は `Actor` interface 型で `login` しか宣言していないため、`author { login databaseId id }` は schema error となり **review_threads surface が常に `failed`** でした。main 以前から継続していた defect です。mocked fetch は query 文を検証しないため既存 fixture では検知できません。

coverage が常に incomplete になり、fence の `review-threads` は「unresolved thread 0 件」を報告できず常に `unknown` になります。**Success Criterion 3 はこの修正なしには成立しません。**

`ActorIds` fragment 経由で concrete type から id を取得するよう修正し、**実際に送信された query 文を読む** regression fixture を追加しました。

### 2. fence CLI の setup failure が exit 1 へ落ちていた

引数誤り、token 不在、reviewer record / 入力 file の読み取り失敗が unhandled rejection として escape し、exit 1 = caller にとって `fail`（**fence が到達した判定**）を意味していました。到達していない状態を判定として報告する誤りです。`main()` へ集約し exit 2 + stderr + stdout 無出力へ統一。CLI を spawn して exit code を固定する fixture を追加しました。

なお review で指摘を受け、**通常の acquisition failure は setup error ではない**ことを明記しました。`collectReviewEvidence()` は GitHub API の失敗を surface ごとの `fetch_status` として返し例外を送出しないため、fence は評価へ到達して `unknown` の JSON を stdout へ出力します。exit 2 の 2 経路は stdout の有無で区別できます。

### 3. #74 evaluator が同一 claim の abbreviation 差を conflict と誤判定していた

`chooseSignal()` が同一時刻の target claim を raw string で比較していたため、短縮 SHA とその完全形が「異なる 2 つの target」に見え、`conflicting_signals` として `unknown` になっていました。

reviewer は finding を伴う結果で review submission と inline comment を同一時刻に投稿し、それぞれへ completion marker を繰り返します。SHA の短縮桁数が両者で異なることがあります。これは 1 つの claim の重複表現であって conflict ではありません。

**この repository の実 reviewer 構成では、reviewer が finding を出した場合に限り `completed@target` へ到達できず、`reviewer-completion` が永久に `unknown` になります。** findings がある場合こそ fence が必要であるため、この経路が塞がると fence は成立しません。本 PR の review 中に実際に発生しました。

binding 比較が既に持っていた abbreviation tolerance を `sameTargetClaim()` へ括り出し、両方の比較で使うようにしました。

この判定は review で 2 度指摘を受け、そのたびに穴を塞いでいます。

1. **`sameTargetClaim()` は transitive ではない** — 短縮 claim を任意の representative にすると、それと compatible な 2 つの異なる full SHA が同一視されます。すべての claim を **最長の claim** と比較する形へ修正しました。各 claim が 1 つの最長 claim の abbreviation であれば pairwise にも compatible であり、異なる full SHA は conflict として残ります。
2. **代表 claim の選択だけが未加工文字列の長さを使っていた** — `target_pattern` は空白ごと capture でき（record validator が許可）、空白で水増しされた短縮 claim が最長になりえました。正規化を marker 抽出時点の 1 箇所へ寄せ、比較・長さ測定・出力・binding がすべて同じ値を見るようにしています。

いずれも fixture で固定し、2 番目については fixture が falsifiable であること（正規化を戻すと失敗すること）を実際に確認しています。

## Delta（design checkpoint baseline = `ca1ba90` に対して）

### production tooling delta

| file | delta |
| --- | --- |
| `tooling/merge-ready-fence-lib.mjs` | new, 629 行 / 26,158 bytes |
| `tooling/merge-ready-fence.mjs` | new, 130 行 / 5,058 bytes |
| `tooling/review-evidence-lib.mjs` | +63 行 / +2,502 bytes（base SHA / PR body / `is_resolved` / `is_outdated` / `pull_request_files` / `ActorIds` fragment） |
| `tooling/review-evidence-state-lib.mjs` | +40 行 / +2,506 bytes（`sameTargetClaim` の抽出、最長 claim 比較、target claim の抽出時正規化） |
| new persistent record / schema | 0 |

見積（新規 2 file、300-380 行 + 80-100 行、既存 1 file へ +45 行）に対し、lib が 629 行と大きくなりました。増分は 10 check ぶんの `detail` 構築と、CLI 引数 contract および acknowledged revision の parser を lib 側へ置いたこと（CLI を thin に保ち、引数 shape を実行せずに test できるようにするため）に由来します。既存 file への変更 2 件は、上記 defect 1 / 3 の修正を含みます。

### test delta

| file | delta |
| --- | --- |
| `test/merge-ready-fence-lib.test.mjs` | new, 802 行 / 35,800 bytes（fixture 24 件 + 境界 case + CLI exit code） |
| `test/review-evidence.test.mjs` | +111 行 / +5,003 bytes |
| `test/review-protocol.test.mjs` | +91 行 / +4,374 bytes |
| `test/merge-ready-fence.test.mjs` | +48 行 / +2,687 bytes |
| `test/review-evidence-state.test.mjs` | +166 行 / +6,293 bytes |
| その他 2 file | +3 行 / +453 bytes |

**`test/review-protocol.test.mjs` は縮小せず増加しました。** 見積は −15〜−25KB でしたが、実際に削除できた prose assertion は 8 行、追加は assertion 19 行と comment 79 行です。理由は 2 つあります。削除できた散文が見積より少なかったこと。そして ownership を移した各 assertion site に「その invariant を今どの fixture が証明しているか」を記録したことです。後者は decision 6 の rule-by-rule 判断を後続 session が再現できるようにするためで、意図的です。

### policy / skills / generated AGENTS byte delta

| artifact | before | after | delta |
| --- | --- | --- | --- |
| `policy/core.md` | 55,296 | 55,472 | **+176** |
| `skills/review-code.md` | 31,109 | 27,831 | **−3,278** |
| `skills/review-doc.md` | 13,609 | 13,377 | **−232** |
| generated consumer `AGENTS.md` | 57,455 | 57,631 | **+176** |
| **total（Acceptance Criterion 10）** | **157,469** | **154,311** | **−3,158（−2.0%）** |

純減は成立していますが、見積（−28〜−36KB）には大きく届いていません。

## Phase 2 の completion evidence — 「code を追加した」ではなく「散文が減った」か

byte 純減 −3,158 だけではこの問いに答えられないので、内訳を明示します。

### 移した deterministic judgment と、それによって消えた散文

| 移した判定 | 消えた散文 | 今の証明 |
| --- | --- | --- |
| verify target と frozen target の一致 | review-code 手順 1・2・3・9・10 に **4 回反復**していた照合手順、review-doc 手順 2・7 の同種記述、core.md Review stopping rules の precondition 照合段落 | `verify-coherence`（fixture 18-20） |
| target / base / artifact set の drift | core.md Review stopping rules の手動照合手順 | `target-head` / `target-base` / `artifact-set`（fixture 2-4b） |
| reviewer ごとの target completion state 照合 | core.md fence 手順 3、review-code 手順 5・7 の state 判定詳細 | `reviewer-completion`（fixture 5-8, 23） |
| merge-ready fence の逐次手順 1〜6 | core.md `#### Merge-ready completion fence` の手順列挙 | fence 全体 + 集約規則（fixture 24） |
| stable actor identity の snapshot-locality | review-code の binding 記述 | #74 evaluator + `review-evidence-state.test.mjs` |
| completion / validity の区別 | review-code の再記述 3 文 | Kernel（Contract 本文）+ #74 |
| Mixed classification の routing 判定 | core.md `#### Mixed-classification review target` の 5 bullet 詳細 | `skill-routing`（fixture 13-17b） |
| unresolved review conversation | review-code 手順 13 の手動確認 | `review-threads`（fixture 11-12） |
| auto-close keyword | core.md Issue closure 末尾の運用文 | `autoclose-hygiene`（fixture 21-22） |
| triage した result revision の同一性 | （新規。従来は「会話内 snapshot を根拠にしない」という散文だった） | `result-revision-coherence`（fixture 10, 10b） |

`skills/review-code.md` の実測: 削除 162 行 / 13,180 bytes に対し追加 115 行 / 9,855 bytes。差分の大半は上記の反復記述です。

### なぜ core.md が減らなかったか（+176）

core.md からは 124 行 / 9,807 bytes を削り、115 行 / 9,974 bytes を追加しました。削ったのは上表の mechanical 手順、加えたのは次の invariant です。

- **checker の pass は merge-ready の成立ではない**（新規 1 文。fence を merge-ready と同一視させないため）
- **triage した review result の revision は判断の対象である**（amendment 由来。in-place 編集された result を triage 済みとして扱わせないため）
- machine / semantic の境界と、checker が判定しないもの（artifact scope coverage、Resolution の完了、merge authority）の明示

core.md は「手順を失い、invariant を得て」ほぼ等量になりました。これは Phase 2 の意図どおりですが、byte 目標には効きません。

### 削れなかった散文の分類（#72 の 30KB 目標に対する説明）

`policy/core.md` は 55,472 bytes で 30KB 目標に未達です。残存分を 3 分類します。

1. **invariant として必要（削らない）** — Selection Contract の expected review set 閉包（5.3KB）、Merge-ready completion fence の class 別 review obligation と post-fix exception（7.2KB の大半）、Acquisition & Validity Contract の completion / validity / durable evidence / 2 軸（7.3KB）。これらは decision 5 で「今回 production 化しない」と決めた semantic judgment そのものです。加えて Review Protocol 外の Task Protocol / Issue closure / Foundation Change Protocol（約 18KB）は本 Issue の scope 外です。
2. **将来 phase で機械化しうる** — expected / optional member の membership 自動閉包（#71 で再設計）、Resolution completeness の observable proxy 拡張。いずれも今回そのための field / abstraction を追加していません。
3. **純粋に冗長** — 今回削った分でほぼ解消しました。残りは cross-reference 用の短い再掲です。

30KB 達成のために semantic invariant を削除する選択はしていません。

## 削除した prose / test

- core.md: `#### Mixed-classification review target` 節の 5 bullet 詳細手順を table + MUST + 数文へ圧縮
- core.md: Merge-ready completion fence の手順 1〜6 の逐次列挙を machine / semantic の 2 分割へ置換
- core.md: Acquisition & Validity の reviewed target 確定手順・binding 優先順位の記述（#74 evaluator が所有）
- core.md: Review stopping rules の precondition evidence SHA 照合段落
- review-code.md: verify-target consistency 照合の 4 重反復、手順 13 の fence 実務段落
- test: skill が normative rule を再記述していることを要求していた assertion 群（completion / validity の再記述、stable actor identity、verify SHA 照合、snapshot freshness の心得）

## 残した semantic invariant

- expected review set は agent が選択した reviewer だけでは閉じない。presence だけでは member にならない
- required member は非参加の宣言によって blocker から外れない
- 非参加の宣言は既に出した finding の Resolution obligation を discharge しない（finding 軸）
- `not-bound` な run は evidence 軸で使えないが finding 軸では残る
- optional / advisory member の `unknown` は blocker ではないが、observed finding は Resolution 対象
- post-fix exception は 3 条件すべてを満たす場合に限る。一度も `completed@target` になっていない member へ適用しない
- 0 findings は positive evidence を要求する。CI status は review completion ではない
- **fence pass は merge-ready の成立ではない。merge-ready と merge execution authority は別物**
- precondition check がどの artifact scope を対象としたかの確認は agent が所有する（checker は判定しない）

`test/merge-ready-fence.test.mjs` の TEST-ONLY decision model は rule-by-rule で再検討しました。R2 の binding precedence と R6 の state gate は production へ委ね、R1 / R3 / R4 / R5 は今回 production 化しない Kernel invariant の唯一の regression proof として残しています。判断根拠は同 file の header に記録しました。同 file の丸ごと削除は goal にせず、ownership を移した結果として残すべき範囲を確定した、という判断です。

## Verification

- `npm test` — 235 tests / 0 fail（guardrails 8 fixture を含む）
- `npm run check:fixture` — generated adapters / quality profile / skill bundle / reviewer record すべて current
- `git diff --check` — clean
- fence CLI の実 GitHub に対する smoke を各 stage で実施
- Prettier: Foundation repository root は Prettier gate を持たず、`main` 時点でも root の `test/*.mjs` は Prettier 非準拠です（本 PR で触れていない `test/task-protocol.test.mjs` を含む）。Prettier は consumer quality profile の資産であり、その互換性は `npm run test:guardrails` が検証しています

## Review 経過

本 PR 自身に current Review Protocol を適用しました。durable record は PR comment に stage ごとに残しています。

- discovery stage 1（`6e32ef3`）— required reviewer `completed@target`、0 findings。その後 **実装側で defect 2 件を自ら発見**して修正したため non-fix target mutation となり、discovery をやり直し
- discovery stage 2（`adf82cb`）— finding 1 件（accept / fix）。あわせて **defect 3**（evaluator の conflict 誤判定）を修正。後者が non-fix のため再度やり直し
- discovery stage 3（`3c9b330`）— finding 1 件（accept / fix）。**accepted finding の fix のみ**のため targeted closure へ
- targeted closure 1（`d6aa0fe`）— closure finding 1 件（accept / fix）
- targeted closure 2（`5e6e8e1`）— **0 findings、clean**

到着した GitHub review thread 3 件は、いずれも fix 内容を返信したうえで resolve 済みです。unresolved は 0 件。

closure cycle は 2 巡で収束しました。finding 2 / 3 はいずれも同じ関数（`chooseSignal()` の target 一致判定）への指摘だったため、同じ関数に対する closure finding がもう 1 件出た場合は cycle を重ねず設計の不安定さとして escalate する、という停止条件を durable record に明記したうえで進めています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
