### PR TITLE
fix: review-doc の no-fix branch でも merge-ready fence を必須化する (#78)

### DIFF
--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -127,6 +127,9 @@ record」節および「Adapter boundary」節に従います。この skill で
    false-positive 等として Resolution した場合）は、required review 数の
    valid semantic discovery と Resolution が完了した時点で review
    procedure を完了とし、新たな closure run を要求しません。
+   この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence
+   を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready
+   を宣言するかどうかで決まります。
 8. **Closure Resolution** — closure verification（手順 7）の finding を
    Resolution Contract（`policy/core.md`）に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。
@@ -186,5 +189,6 @@ mechanical check
        -> 完了
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
+       -> merge-ready fence（merge-ready を宣言する場合）
        -> 完了
 ```

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -125,11 +125,15 @@ record」節および「Adapter boundary」節に従います。この skill で
    accepted finding の fix が無く target SHA / range も target artifact
    set も変更されていない場合（例えば 0 findings の場合や、finding を
    false-positive 等として Resolution した場合）は、required review 数の
-   valid semantic discovery と Resolution が完了した時点で review
-   procedure を完了とし、新たな closure run を要求しません。
-   この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence
-   を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready
-   を宣言するかどうかで決まります。
+   valid semantic discovery と Resolution が完了した時点で closure の
+   obligation が解除され、新たな closure run を要求しません。
+   解除されるのは closure の obligation だけであり、この時点で review
+   procedure が完了したことにはなりません。review completion と merge-ready
+   の関係は `policy/core.md` の Merge readiness and merge authority が定めて
+   おり、review completion の宣言は merge-ready の宣言にあたります。したがって
+   この branch でも、手順 9 の merge-ready fence を通る前に review completion /
+   merge-ready を宣言しません。fence の要否は accepted fix の有無ではなく、
+   その宣言を行うかどうかで決まります。
 8. **Closure Resolution** — closure verification（手順 7）の finding を
    Resolution Contract（`policy/core.md`）に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -127,6 +127,9 @@ record」節および「Adapter boundary」節に従います。この skill で
    false-positive 等として Resolution した場合）は、required review 数の
    valid semantic discovery と Resolution が完了した時点で review
    procedure を完了とし、新たな closure run を要求しません。
+   この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence
+   を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready
+   を宣言するかどうかで決まります。
 8. **Closure Resolution** — closure verification（手順 7）の finding を
    Resolution Contract（`policy/core.md`）に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。
@@ -186,5 +189,6 @@ mechanical check
        -> 完了
   -> accepted fix が無く review target が変更されていない場合:
        required review 数の valid semantic discovery と Resolution の完了
+       -> merge-ready fence（merge-ready を宣言する場合）
        -> 完了
 ```

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -125,11 +125,15 @@ record」節および「Adapter boundary」節に従います。この skill で
    accepted finding の fix が無く target SHA / range も target artifact
    set も変更されていない場合（例えば 0 findings の場合や、finding を
    false-positive 等として Resolution した場合）は、required review 数の
-   valid semantic discovery と Resolution が完了した時点で review
-   procedure を完了とし、新たな closure run を要求しません。
-   この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence
-   を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready
-   を宣言するかどうかで決まります。
+   valid semantic discovery と Resolution が完了した時点で closure の
+   obligation が解除され、新たな closure run を要求しません。
+   解除されるのは closure の obligation だけであり、この時点で review
+   procedure が完了したことにはなりません。review completion と merge-ready
+   の関係は `policy/core.md` の Merge readiness and merge authority が定めて
+   おり、review completion の宣言は merge-ready の宣言にあたります。したがって
+   この branch でも、手順 9 の merge-ready fence を通る前に review completion /
+   merge-ready を宣言しません。fence の要否は accepted fix の有無ではなく、
+   その宣言を行うかどうかで決まります。
 8. **Closure Resolution** — closure verification（手順 7）の finding を
    Resolution Contract（`policy/core.md`）に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -810,9 +810,11 @@ test("both review skills require the merge-ready fence on the no-fix branch too 
   // merge-ready, so a pre-fence completion sentence reopens the same escape
   // hatch under a different word — an agent reports "review 完了" without ever
   // saying "merge-ready" and step 9 never runs.
-  assert.doesNotMatch(
-    reviewDoc,
-    /Resolution が完了した時点で reviews*procedure を完了とし/,
+  // Whitespace-agnostic on purpose: the forbidden sentence wraps across lines in
+  // the source, and a hand-escaped regex for that is easy to get wrong in a way
+  // that silently passes. containsText() strips whitespace on both sides.
+  assert.ok(
+    !containsText(reviewDoc, "Resolution が完了した時点で review procedure を完了とし"),
     "the no-fix branch must not declare the review procedure complete before the fence; review completion is itself merge-ready",
   );
   assert.ok(

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -752,7 +752,7 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewDoc,
-      "required review 数の valid semantic discovery と Resolution が完了した時点で review procedure を完了とし、新たな closure run を要求しません。",
+      "required review 数の valid semantic discovery と Resolution が完了した時点で closure の obligation が解除され、新たな closure run を要求しません。",
     ),
   );
 
@@ -804,15 +804,30 @@ test("both review skills require the merge-ready fence on the no-fix branch too 
     "the Normative no-fix branch must not short-circuit from Resolution straight to 完了",
   );
 
-  // Step 7's prose ends the *closure* obligation for this branch, not the
-  // fence obligation — the sentence that ends the procedure must be adjacent to
-  // the one that keeps step 9 in force, or the branch reads as fence-exempt again.
+  // Step 7's prose ends the *closure* obligation for this branch and nothing
+  // more. It must not also declare the review procedure complete: policy/core.md
+  // ("Merge readiness and merge authority") defines review completion itself as
+  // merge-ready, so a pre-fence completion sentence reopens the same escape
+  // hatch under a different word — an agent reports "review 完了" without ever
+  // saying "merge-ready" and step 9 never runs.
+  assert.doesNotMatch(
+    reviewDoc,
+    /Resolution が完了した時点で reviews*procedure を完了とし/,
+    "the no-fix branch must not declare the review procedure complete before the fence; review completion is itself merge-ready",
+  );
   assert.ok(
     containsText(
       reviewDoc,
-      "procedure を完了とし、新たな closure run を要求しません。この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready を宣言するかどうかで決まります。",
+      "closure の obligation が解除され、新たな closure run を要求しません。解除されるのは closure の obligation だけであり、この時点で review procedure が完了したことにはなりません。",
     ),
-    "review-doc step 7 must state that ending the closure obligation does not waive the step 9 fence",
+    "review-doc step 7 must scope its release to the closure obligation, not to review completion",
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "この branch でも、手順 9 の merge-ready fence を通る前に review completion / merge-ready を宣言しません。fence の要否は accepted fix の有無ではなく、その宣言を行うかどうかで決まります。",
+    ),
+    "review-doc step 7 must keep the step 9 fence in force for review completion as well as for merge-ready",
   );
 
   // Step 9 itself is unconditional on the fix branch: it keys on the merge-ready
@@ -1896,7 +1911,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "required review 数の valid semantic discovery と Resolution が完了した時点で review procedure を完了とし、新たな closure run を要求しません。",
+      "required review 数の valid semantic discovery と Resolution が完了した時点で closure の obligation が解除され、新たな closure run を要求しません。",
     ),
   );
 

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -775,6 +775,66 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   );
 });
 
+// Issue #78: review-doc.md's no-fix branch (0 findings, or findings all resolved
+// as false-positive) used to fall straight from Resolution to 完了, while the
+// same file's step 9 requires the deterministic merge-ready fence as the last
+// action before any merge-ready declaration. A consumer smoke (stage-tracker PR
+// #298) hit the contradiction: the branch reads as permission to declare
+// merge-ready without the fence, and review-code.md's sibling branch — which
+// does carry the fence — made the asymmetry look intentional. The fence's
+// necessity keys on whether merge-ready is declared, never on whether an
+// accepted fix moved the target.
+test("both review skills require the merge-ready fence on the no-fix branch too (#78)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  // The Normative no-fix branch reaches the fence before it terminates.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "-> accepted fix が無く review target が変更されていない場合: required review 数の valid semantic discovery と Resolution の完了 -> merge-ready fence（merge-ready を宣言する場合） -> 完了",
+    ),
+    "the Normative no-fix branch must pass through the merge-ready fence before 完了",
+  );
+  assert.ok(
+    !containsText(
+      reviewDoc,
+      "required review 数の valid semantic discovery と Resolution の完了 -> 完了",
+    ),
+    "the Normative no-fix branch must not short-circuit from Resolution straight to 完了",
+  );
+
+  // Step 7's prose ends the *closure* obligation for this branch, not the
+  // fence obligation — the sentence that ends the procedure must be adjacent to
+  // the one that keeps step 9 in force, or the branch reads as fence-exempt again.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "procedure を完了とし、新たな closure run を要求しません。この branch でも、merge-ready を宣言する場合は手順 9 の merge-ready fence を省略できません。fence の要否は accepted fix の有無ではなく、merge-ready を宣言するかどうかで決まります。",
+    ),
+    "review-doc step 7 must state that ending the closure obligation does not waive the step 9 fence",
+  );
+
+  // Step 9 itself is unconditional on the fix branch: it keys on the merge-ready
+  // declaration alone.
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "この review 対象を含む変更について merge-ready を宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。",
+    ),
+  );
+
+  // The Executable sibling keeps the same shape, so the two classes cannot drift
+  // into disagreeing about whether a fix-free review needs the fence.
+  assert.ok(
+    containsText(
+      reviewCode,
+      "-> accepted fix が無く review target が変更されていない場合: required review 数の valid discovery と Resolution の完了 -> merge-ready fence",
+    ),
+    "the Executable no-fix branch must pass through the merge-ready fence too",
+  );
+});
+
 // #51 Phase 1 contract: routing remains in the Kernel, procedure moved to the
 // skills. This guards both halves at once — a regression that copies the flow
 // back into the Kernel (or into the generated consumer adapter) fails here, and


### PR DESCRIPTION
## 概要

Issue #78 の bounded Foundation correction。

`skills/review-doc.md` の `## 停止条件` finite flow で、accepted fix が無く review target が変更されていない branch（0 findings / false-positive only 等）だけ merge-ready fence を通らずに `完了` へ落ちていた。

同じ file の `## 手順` step 9 は

> merge-ready を宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します

と無条件に定めているため、finite flow と矛盾していた。`skills/review-code.md` の対応する finite flow は両分岐に fence を持つため、Phase 2 で review-code / review-doc 間の非対称にもなっていた。

stage-tracker PR #298 の consumer repin smoke で Codex / CodeRabbit が独立に指摘した canonical inconsistency。

## 変更内容

### 1. `skills/review-doc.md`（canonical source）

finite flow の no-fix branch に fence を追加:

```text
  -> accepted fix が無く review target が変更されていない場合:
       required review 数の valid semantic discovery と Resolution の完了
+      -> merge-ready fence（merge-ready を宣言する場合）
       -> 完了
```

あわせて step 7 の「required review 数の valid semantic discovery と Resolution が完了した時点で review procedure を完了とし、新たな closure run を要求しません」が fence の免除にも読めてしまう問題を、隣接する 1 文で塞いだ。fence の要否は accepted fix の有無ではなく、merge-ready を宣言するかどうかで決まる。

### 2. Regression proof（`test/review-protocol.test.mjs`）

`both review skills require the merge-ready fence on the no-fix branch too (#78)` を追加。

- review-doc の no-fix branch が `完了` の前に fence を通ること
- Resolution から `完了` への short-circuit が復活していないこと
- step 7 の完了文と fence 存続文が隣接していること
- step 9 が merge-ready 宣言のみを条件にしていること
- review-code の同じ branch も fence を通ること（class 間の drift 防止）

修正前の `skills/review-doc.md` に対して fail することを確認済み（`the Normative no-fix branch must pass through the merge-ready fence before 完了`）。

### 3. Generated / fixture sync

`npm run sync:fixture` で consumer fixture の skill bundle を同期。手作業での consumer artifact patch は行っていない。

## 変更 artifact

| artifact | 種別 |
| --- | --- |
| `skills/review-doc.md` | canonical source（Normative） |
| `test/review-protocol.test.mjs` | regression proof（Executable） |
| `test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md` | generated（sync 出力） |

## Verification

- targeted: `node --test test/review-protocol.test.mjs` → 8 pass / 0 fail
- red-proof: 修正前 source で新規 test が fail することを確認
- `npm test` → 237 tests / 236 pass / 0 fail / 1 skipped（skip は既存の DB 依存 test）
- guardrails: `Verified 8 guardrail fixtures.`
- `npm run check:fixture` → `Generated adapters, quality profile, skill bundle, and reviewer capability record are current`
- `git diff --check` → clean

## Design / complexity guard

- Phase 2 fence architecture / provider behavior / reviewer schema の変更なし
- new persistent artifact / schema = 0
- generic flow abstraction / workflow DSL / shared orchestration framework の追加なし
- `policy/core.md` 無変更

## Out of scope（Issue #78 の Non-goals に従う）

tooling cwd ergonomics、`review-evidence --record` resolution、CodeRabbit marker observation、reviewer record redesign、#71 / #70、stage-tracker 側変更。

Refs #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the review workflow so declaring a review as merge-ready always requires completing the merge-ready step.
  - Updated completion guidance to include this step whether or not accepted fixes are present.
  - Added consistent instructions for both review skill variants.

- **Bug Fixes**
  - Prevented review procedures from reaching completion without the required merge-ready confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->