### PR TITLE
fix: review skill の fence 例が run anchor を欠落させないようにする (#80)

### DIFF
--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -35,10 +35,13 @@ review でも同じ意味で適用します。
 4. record の `required_selection` に従って required slot を埋め、expected review set と
    required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
-6. 状態は会話内の記憶ではなく、fresh 取得で確認する。
+   起動した時点で run anchor（ISO-8601 timestamp または run 固有の ID）を記録する。
+6. 状態は会話内の記憶ではなく、fresh 取得で確認する。手順 5 で記録した run anchor を
+   `--run-after`（または `--run-anchor-id`）として渡す。
 
    ```text
-   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --json
+   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
+     --target-sha <sha> --run-after <手順 5 で記録した run anchor> --json
    ```
 
 7. fresh snapshot を state evaluator へ渡して target completion state を読み、
@@ -48,15 +51,17 @@ review でも同じ意味で適用します。
    failure ではなく、沈黙、preamble、acknowledgement、fetch incomplete、marker 不明を
    positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
    は `policy/core.md` に従います。
-8. accepted finding を batch で fix し、target が動いたら targeted closure を回す。
+8. accepted finding を batch で fix し、target が動いたら targeted closure を回す
+   （closure でも同じく起動時点で run anchor を記録し直す）。
 9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
-   authority に従う。
+   authority に従う。run anchor と acknowledged revision は、手順 7（closure を
+   回した場合はその closure 版）で記録したものを再利用する。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path>
+     --acknowledged-file <path> --run-after <手順 5 で記録した run anchor>
    ```
 
 ## reviewer capability record
@@ -162,9 +167,21 @@ required/expected review の消化根拠にしてはいけません。この区�
      なら fallback order に従います。
      record に宣言されていない reviewer は formal acquisition になりません。
      trigger 方法、実際に渡した target と artifact set、required context を記録します。
+
+   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
+   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
+   この anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
+   同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した値を
+   そのまま運びます。手順 9 の second full discovery、手順 10 の targeted closure も
+   同様に、それぞれの起動時点で新しい run anchor を記録し、そのラウンド自身の
+   Acquisition & Validity 確認に使います。closure を経由した場合、手順 13 の
+   merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
+   closure run の anchor です。
+
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
-   fresh に実行し、必要なら `--state --target-sha <sha> --run-after <timestamp>`
-   （または `--run-anchor-id <id>`）で state evaluator を実行します。
+   fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
+   `--run-after <timestamp>`（または `--run-anchor-id <id>`）として渡し、state
+   evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
    `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
@@ -232,15 +249,18 @@ required/expected review の消化根拠にしてはいけません。この区�
     successful deterministic verify evidence がカバーしているかを確認します。
     カバーしていると確認できない場合は、確定した closure target に対して
     deterministic verify を再実行し、成功してから Execution Contract に従って
-    closure run を起動します。
+    closure run を起動します。起動した時点で、この closure run 専用の run anchor を
+    新たに記録します（手順 4 の anchor をそのまま使い回しません）。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted
     finding の fix によって target が変更された場合のみ（手順 9 を
     挟んだ場合を含む）、この closure target を expected target として、
-    targeted closure の review run に手順 5 と同じ Acquisition &
-    Validity Contract を適用し、completion / acquisition / validity を
-    確認します。
+    targeted closure の review run に手順 5 と同じ Acquisition & Validity
+    Contract を適用し、completion / acquisition / validity を確認します。
+    手順 10 で記録した run anchor を使います。手順 5 と同様に、triage の対象に
+    する result の `canonical_id` と `evidence[].revision.body_digest` を
+    記録します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
     closure 用 Selection Contract で required とした review 数ぶんの valid
@@ -281,13 +301,18 @@ required/expected review の消化根拠にしてはいけません。この区�
     discovery Resolution と closure の完了順序は問いません。
 
     そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
+    run anchor と acknowledged revision は、この review flow で最後に使った
+    Acquisition & Validity 確認（closure を経由していなければ手順 5、経由していれば
+    手順 11）で記録したものを再利用します。手順 5 / 11 で `--run-anchor-id` を
+    使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
 
     ```text
     node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
       --target-sha <frozen target> --base-sha <frozen base> \
       --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
       --required <reviewer-id> --declared-skill review-code \
-      --acknowledged-file <手順 5 で記録した canonical_id=body_digest>
+      --acknowledged-file <手順 5（または closure 時は手順 11）で記録した canonical_id=body_digest> \
+      --run-after <手順 4（または closure 時は手順 10）で記録した run anchor>
     ```
 
     fence は machine-checkable な precondition だけを評価します。`pass`（exit 0）の

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -35,9 +35,11 @@ review でも同じ意味で適用します。
 4. record の `required_selection` に従って required slot を埋め、expected review set と
    required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
-   起動した時点で run anchor（ISO-8601 timestamp または run 固有の ID）を記録する。
+   起動した時点で run anchor（起動直前の ISO-8601 timestamp）を記録する。
+   `--run-anchor-id` はこの時点では値を持たない（reviewer の result 自身の ID が
+   必要なため）ので使わない。
 6. 状態は会話内の記憶ではなく、fresh 取得で確認する。手順 5 で記録した run anchor を
-   `--run-after`（または `--run-anchor-id`）として渡す。
+   `--run-after` として渡す。
 
    ```text
    node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
@@ -52,16 +54,19 @@ review でも同じ意味で適用します。
    positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
    は `policy/core.md` に従います。
 8. accepted finding を batch で fix し、target が動いたら targeted closure を回す
-   （closure でも同じく起動時点で run anchor を記録し直す）。
+   （closure でも同じく起動時点で run anchor（timestamp）を記録し直し、triage 対象の
+   `canonical_id` と `body_digest` を再取得する）。
 9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
-   authority に従う。run anchor と acknowledged revision は、手順 7（closure を
-   回した場合はその closure 版）で記録したものを再利用する。
+   authority に従う。run anchor は手順 5（closure を回した場合は手順 8）で、
+   acknowledged revision は手順 7（closure を回した場合はその closure 時の再取得分）で
+   記録したものを再利用する。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path> --run-after <手順 5 で記録した run anchor>
+     --acknowledged-file <path> \
+     --run-after <手順 5（または closure 時は手順 8）で記録した run anchor>
    ```
 
 ## reviewer capability record
@@ -168,20 +173,21 @@ required/expected review の消化根拠にしてはいけません。この区�
      record に宣言されていない reviewer は formal acquisition になりません。
      trigger 方法、実際に渡した target と artifact set、required context を記録します。
 
-   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
-   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
-   この anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
-   同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した値を
-   そのまま運びます。手順 9 の second full discovery、手順 10 の targeted closure も
-   同様に、それぞれの起動時点で新しい run anchor を記録し、そのラウンド自身の
-   Acquisition & Validity 確認に使います。closure を経由した場合、手順 13 の
-   merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
+   起動した時点で、その run を後から一意に特定できる run anchor として、起動直前の
+   ISO-8601 timestamp を記録します。`--run-anchor-id` はこの時点では値を持ちません
+   （state evaluator は reviewer の result 自身の `sources[].surface_id` と照合するため、
+   その result が届く前の trigger comment の ID 等を渡しても一致しません）。この
+   timestamp anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
+   `--run-after` として同じ値を再利用します。session の記憶や再計算ではなく、この時点で
+   記録した値をそのまま運びます。手順 9 の second full discovery、手順 10 の targeted
+   closure も同様に、それぞれの起動時点で新しい run anchor（timestamp）を記録し、その
+   ラウンド自身の Acquisition & Validity 確認に使います。closure を経由した場合、手順 13
+   の merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
    closure run の anchor です。
 
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
    fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
-   `--run-after <timestamp>`（または `--run-anchor-id <id>`）として渡し、state
-   evaluator を実行します。
+   `--run-after <timestamp>` として渡し、state evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
    `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
@@ -301,10 +307,11 @@ required/expected review の消化根拠にしてはいけません。この区�
     discovery Resolution と closure の完了順序は問いません。
 
     そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
-    run anchor と acknowledged revision は、この review flow で最後に使った
-    Acquisition & Validity 確認（closure を経由していなければ手順 5、経由していれば
-    手順 11）で記録したものを再利用します。手順 5 / 11 で `--run-anchor-id` を
-    使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
+    run anchor は、この review flow で最後に起動した run の trigger 時点
+    （closure を経由していなければ手順 4、経由していれば手順 10）で記録した
+    timestamp を再利用します。acknowledged revision は、対応する Acquisition &
+    Validity 確認（closure を経由していなければ手順 5、経由していれば手順 11）で
+    記録したものを再利用します。
 
     ```text
     node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -75,6 +75,14 @@ record」節および「Adapter boundary」節に従います。この skill で
    target と artifact set、required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
    Artifact classification / Review stopping rules（`policy/core.md`）に従います。
+   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
+   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
+   この anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready fence の
+   両方で同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した
+   値をそのまま運びます。手順 7 の closure を実行する場合、その closure run の
+   trigger 時点でも新しい run anchor を記録し（この手順 3 の anchor をそのまま
+   使い回しません）、closure verification と手順 9 の fence ではその closure run の
+   anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
@@ -99,7 +107,8 @@ record」節および「Adapter boundary」節に従います。この skill で
    GitHub 上の durable review surface の取得は、Foundation リポジトリの
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
-   boundary（`collectOutputs()`）に従います。
+   boundary（`collectOutputs()`）に従います。その際、手順 3 で記録した run
+   anchor を `--run-after`（または `--run-anchor-id`）として渡します。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -113,12 +122,15 @@ record」節および「Adapter boundary」節に従います。この skill で
    確定した closure artifact set を、直近の mechanical-check evidence が
    カバーしていることを確認します。確認できない場合は、確定した closure target に
    対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
-   closure review run に適用します。
+   closure review run に適用します。この closure run を起動した時点で、手順 3 と
+   同様にこの run 専用の run anchor を新たに記録します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
    この closure target を expected target として Acquisition & Validity
-   Contract に従って確認します。
+   Contract に従って確認します。上記の run anchor を使います。手順 4 と同様に、
+   triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。
    closure 用 Selection Contract で required とした review 数ぶんの valid
    な closure run が揃うまで Closure Resolution へ進みません。不足する
    run の扱いは Failure / retry（`policy/core.md`）に従います。
@@ -150,13 +162,18 @@ record」節および「Adapter boundary」節に従います。この skill で
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
    宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
+   run anchor と acknowledged revision は、この review flow で最後に使った
+   Acquisition & Validity 確認（closure を経由していなければ手順 4、経由していれば
+   手順 7）で記録したものを再利用します。手順 4 / 7 で `--run-anchor-id` を
+   使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <frozen target> --base-sha <frozen base> \
      --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
      --required <reviewer-id> --declared-skill review-doc \
-     --acknowledged-file <手順 4 で記録した canonical_id=body_digest>
+     --acknowledged-file <手順 4（または closure 時は手順 7）で記録した canonical_id=body_digest> \
+     --run-after <手順 3（または closure 時は手順 7）で記録した run anchor>
    ```
 
    Mixed classification の target では、`--declared-skill` に該当する skill を

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -75,14 +75,16 @@ record」節および「Adapter boundary」節に従います。この skill で
    target と artifact set、required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
    Artifact classification / Review stopping rules（`policy/core.md`）に従います。
-   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
-   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
-   この anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready fence の
-   両方で同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した
-   値をそのまま運びます。手順 7 の closure を実行する場合、その closure run の
-   trigger 時点でも新しい run anchor を記録し（この手順 3 の anchor をそのまま
-   使い回しません）、closure verification と手順 9 の fence ではその closure run の
-   anchor を使います。
+   起動した時点で、その run を後から一意に特定できる run anchor として、起動直前の
+   ISO-8601 timestamp を記録します。`--run-anchor-id` はこの時点では値を持ちません
+   （state evaluator は reviewer の result 自身の `sources[].surface_id` と照合するため、
+   その result が届く前の trigger comment の ID 等を渡しても一致しません）。この
+   timestamp anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready
+   fence の両方で `--run-after` として同じ値を再利用します。session の記憶や再計算
+   ではなく、この時点で記録した値をそのまま運びます。手順 7 の closure を実行する場合、
+   その closure run の trigger 時点でも新しい run anchor（timestamp）を記録し（この
+   手順 3 の anchor をそのまま使い回しません）、closure verification と手順 9 の fence
+   ではその closure run の anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
@@ -108,7 +110,7 @@ record」節および「Adapter boundary」節に従います。この skill で
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
    boundary（`collectOutputs()`）に従います。その際、手順 3 で記録した run
-   anchor を `--run-after`（または `--run-anchor-id`）として渡します。
+   anchor を `--run-after` として渡します。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -162,10 +164,10 @@ record」節および「Adapter boundary」節に従います。この skill で
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
    宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
-   run anchor と acknowledged revision は、この review flow で最後に使った
-   Acquisition & Validity 確認（closure を経由していなければ手順 4、経由していれば
-   手順 7）で記録したものを再利用します。手順 4 / 7 で `--run-anchor-id` を
-   使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
+   run anchor は、この review flow で最後に起動した run の trigger 時点（closure を
+   経由していなければ手順 3、経由していれば手順 7）で記録した timestamp を再利用
+   します。acknowledged revision は、対応する Acquisition & Validity 確認（closure
+   を経由していなければ手順 4、経由していれば手順 7）で記録したものを再利用します。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -35,10 +35,13 @@ review でも同じ意味で適用します。
 4. record の `required_selection` に従って required slot を埋め、expected review set と
    required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
-6. 状態は会話内の記憶ではなく、fresh 取得で確認する。
+   起動した時点で run anchor（ISO-8601 timestamp または run 固有の ID）を記録する。
+6. 状態は会話内の記憶ではなく、fresh 取得で確認する。手順 5 で記録した run anchor を
+   `--run-after`（または `--run-anchor-id`）として渡す。
 
    ```text
-   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --json
+   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
+     --target-sha <sha> --run-after <手順 5 で記録した run anchor> --json
    ```
 
 7. fresh snapshot を state evaluator へ渡して target completion state を読み、
@@ -48,15 +51,17 @@ review でも同じ意味で適用します。
    failure ではなく、沈黙、preamble、acknowledgement、fetch incomplete、marker 不明を
    positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
    は `policy/core.md` に従います。
-8. accepted finding を batch で fix し、target が動いたら targeted closure を回す。
+8. accepted finding を batch で fix し、target が動いたら targeted closure を回す
+   （closure でも同じく起動時点で run anchor を記録し直す）。
 9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
-   authority に従う。
+   authority に従う。run anchor と acknowledged revision は、手順 7（closure を
+   回した場合はその closure 版）で記録したものを再利用する。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path>
+     --acknowledged-file <path> --run-after <手順 5 で記録した run anchor>
    ```
 
 ## reviewer capability record
@@ -162,9 +167,21 @@ required/expected review の消化根拠にしてはいけません。この区�
      なら fallback order に従います。
      record に宣言されていない reviewer は formal acquisition になりません。
      trigger 方法、実際に渡した target と artifact set、required context を記録します。
+
+   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
+   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
+   この anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
+   同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した値を
+   そのまま運びます。手順 9 の second full discovery、手順 10 の targeted closure も
+   同様に、それぞれの起動時点で新しい run anchor を記録し、そのラウンド自身の
+   Acquisition & Validity 確認に使います。closure を経由した場合、手順 13 の
+   merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
+   closure run の anchor です。
+
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
-   fresh に実行し、必要なら `--state --target-sha <sha> --run-after <timestamp>`
-   （または `--run-anchor-id <id>`）で state evaluator を実行します。
+   fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
+   `--run-after <timestamp>`（または `--run-anchor-id <id>`）として渡し、state
+   evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
    `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
@@ -232,15 +249,18 @@ required/expected review の消化根拠にしてはいけません。この区�
     successful deterministic verify evidence がカバーしているかを確認します。
     カバーしていると確認できない場合は、確定した closure target に対して
     deterministic verify を再実行し、成功してから Execution Contract に従って
-    closure run を起動します。
+    closure run を起動します。起動した時点で、この closure run 専用の run anchor を
+    新たに記録します（手順 4 の anchor をそのまま使い回しません）。
     Review stopping rules（`policy/core.md`）に従い、fix した箇所に対応
     する範囲のみ再確認します。
 11. **Closure Acquisition & Validity** — この review flow で accepted
     finding の fix によって target が変更された場合のみ（手順 9 を
     挟んだ場合を含む）、この closure target を expected target として、
-    targeted closure の review run に手順 5 と同じ Acquisition &
-    Validity Contract を適用し、completion / acquisition / validity を
-    確認します。
+    targeted closure の review run に手順 5 と同じ Acquisition & Validity
+    Contract を適用し、completion / acquisition / validity を確認します。
+    手順 10 で記録した run anchor を使います。手順 5 と同様に、triage の対象に
+    する result の `canonical_id` と `evidence[].revision.body_digest` を
+    記録します。
     確認できなければ merge せず、その後の扱いは Failure / retry
     （`policy/core.md`）に従います。
     closure 用 Selection Contract で required とした review 数ぶんの valid
@@ -281,13 +301,18 @@ required/expected review の消化根拠にしてはいけません。この区�
     discovery Resolution と closure の完了順序は問いません。
 
     そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
+    run anchor と acknowledged revision は、この review flow で最後に使った
+    Acquisition & Validity 確認（closure を経由していなければ手順 5、経由していれば
+    手順 11）で記録したものを再利用します。手順 5 / 11 で `--run-anchor-id` を
+    使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
 
     ```text
     node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
       --target-sha <frozen target> --base-sha <frozen base> \
       --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
       --required <reviewer-id> --declared-skill review-code \
-      --acknowledged-file <手順 5 で記録した canonical_id=body_digest>
+      --acknowledged-file <手順 5（または closure 時は手順 11）で記録した canonical_id=body_digest> \
+      --run-after <手順 4（または closure 時は手順 10）で記録した run anchor>
     ```
 
     fence は machine-checkable な precondition だけを評価します。`pass`（exit 0）の

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -35,9 +35,11 @@ review でも同じ意味で適用します。
 4. record の `required_selection` に従って required slot を埋め、expected review set と
    required review skill を確定して Selection を記録する。
 5. record の `trigger.kind` に従って reviewer を起動する（分岐の詳細は手順 4）。
-   起動した時点で run anchor（ISO-8601 timestamp または run 固有の ID）を記録する。
+   起動した時点で run anchor（起動直前の ISO-8601 timestamp）を記録する。
+   `--run-anchor-id` はこの時点では値を持たない（reviewer の result 自身の ID が
+   必要なため）ので使わない。
 6. 状態は会話内の記憶ではなく、fresh 取得で確認する。手順 5 で記録した run anchor を
-   `--run-after`（または `--run-anchor-id`）として渡す。
+   `--run-after` として渡す。
 
    ```text
    node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
@@ -52,16 +54,19 @@ review でも同じ意味で適用します。
    positive/negative に変換しません。finding の意味付け、Resolution、fallback の policy
    は `policy/core.md` に従います。
 8. accepted finding を batch で fix し、target が動いたら targeted closure を回す
-   （closure でも同じく起動時点で run anchor を記録し直す）。
+   （closure でも同じく起動時点で run anchor（timestamp）を記録し直し、triage 対象の
+   `canonical_id` と `body_digest` を再取得する）。
 9. merge-ready fence を実行し、`pass` の場合だけ merge-ready を宣言する。merge の実行は
-   authority に従う。run anchor と acknowledged revision は、手順 7（closure を
-   回した場合はその closure 版）で記録したものを再利用する。
+   authority に従う。run anchor は手順 5（closure を回した場合は手順 8）で、
+   acknowledged revision は手順 7（closure を回した場合はその closure 時の再取得分）で
+   記録したものを再利用する。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path> --run-after <手順 5 で記録した run anchor>
+     --acknowledged-file <path> \
+     --run-after <手順 5（または closure 時は手順 8）で記録した run anchor>
    ```
 
 ## reviewer capability record
@@ -168,20 +173,21 @@ required/expected review の消化根拠にしてはいけません。この区�
      record に宣言されていない reviewer は formal acquisition になりません。
      trigger 方法、実際に渡した target と artifact set、required context を記録します。
 
-   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
-   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
-   この anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
-   同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した値を
-   そのまま運びます。手順 9 の second full discovery、手順 10 の targeted closure も
-   同様に、それぞれの起動時点で新しい run anchor を記録し、そのラウンド自身の
-   Acquisition & Validity 確認に使います。closure を経由した場合、手順 13 の
-   merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
+   起動した時点で、その run を後から一意に特定できる run anchor として、起動直前の
+   ISO-8601 timestamp を記録します。`--run-anchor-id` はこの時点では値を持ちません
+   （state evaluator は reviewer の result 自身の `sources[].surface_id` と照合するため、
+   その result が届く前の trigger comment の ID 等を渡しても一致しません）。この
+   timestamp anchor は手順 5 の state evaluator と手順 13 の merge-ready fence の両方で
+   `--run-after` として同じ値を再利用します。session の記憶や再計算ではなく、この時点で
+   記録した値をそのまま運びます。手順 9 の second full discovery、手順 10 の targeted
+   closure も同様に、それぞれの起動時点で新しい run anchor（timestamp）を記録し、その
+   ラウンド自身の Acquisition & Validity 確認に使います。closure を経由した場合、手順 13
+   の merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
    closure run の anchor です。
 
 5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
    fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
-   `--run-after <timestamp>`（または `--run-anchor-id <id>`）として渡し、state
-   evaluator を実行します。
+   `--run-after <timestamp>` として渡し、state evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
    `evidence[].revision.body_digest` を記録します。** review result は in-place で編集
@@ -301,10 +307,11 @@ required/expected review の消化根拠にしてはいけません。この区�
     discovery Resolution と closure の完了順序は問いません。
 
     そのうえで、宣言の直前の最後の action として merge-ready fence を実行します。
-    run anchor と acknowledged revision は、この review flow で最後に使った
-    Acquisition & Validity 確認（closure を経由していなければ手順 5、経由していれば
-    手順 11）で記録したものを再利用します。手順 5 / 11 で `--run-anchor-id` を
-    使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
+    run anchor は、この review flow で最後に起動した run の trigger 時点
+    （closure を経由していなければ手順 4、経由していれば手順 10）で記録した
+    timestamp を再利用します。acknowledged revision は、対応する Acquisition &
+    Validity 確認（closure を経由していなければ手順 5、経由していれば手順 11）で
+    記録したものを再利用します。
 
     ```text
     node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -75,6 +75,14 @@ record」節および「Adapter boundary」節に従います。この skill で
    target と artifact set、required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
    Artifact classification / Review stopping rules（`policy/core.md`）に従います。
+   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
+   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
+   この anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready fence の
+   両方で同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した
+   値をそのまま運びます。手順 7 の closure を実行する場合、その closure run の
+   trigger 時点でも新しい run anchor を記録し（この手順 3 の anchor をそのまま
+   使い回しません）、closure verification と手順 9 の fence ではその closure run の
+   anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
@@ -99,7 +107,8 @@ record」節および「Adapter boundary」節に従います。この skill で
    GitHub 上の durable review surface の取得は、Foundation リポジトリの
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
-   boundary（`collectOutputs()`）に従います。
+   boundary（`collectOutputs()`）に従います。その際、手順 3 で記録した run
+   anchor を `--run-after`（または `--run-anchor-id`）として渡します。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -113,12 +122,15 @@ record」節および「Adapter boundary」節に従います。この skill で
    確定した closure artifact set を、直近の mechanical-check evidence が
    カバーしていることを確認します。確認できない場合は、確定した closure target に
    対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
-   closure review run に適用します。
+   closure review run に適用します。この closure run を起動した時点で、手順 3 と
+   同様にこの run 専用の run anchor を新たに記録します。
    その上で、triage した finding に対応しているかの closure verification
    のみを行い、full な再 discovery はしません。
    closure verification 自体の completion / acquisition / validity も、
    この closure target を expected target として Acquisition & Validity
-   Contract に従って確認します。
+   Contract に従って確認します。上記の run anchor を使います。手順 4 と同様に、
+   triage の対象にする result の `canonical_id` と
+   `evidence[].revision.body_digest` を記録します。
    closure 用 Selection Contract で required とした review 数ぶんの valid
    な closure run が揃うまで Closure Resolution へ進みません。不足する
    run の扱いは Failure / retry（`policy/core.md`）に従います。
@@ -150,13 +162,18 @@ record」節および「Adapter boundary」節に従います。この skill で
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
    宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
+   run anchor と acknowledged revision は、この review flow で最後に使った
+   Acquisition & Validity 確認（closure を経由していなければ手順 4、経由していれば
+   手順 7）で記録したものを再利用します。手順 4 / 7 で `--run-anchor-id` を
+   使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <frozen target> --base-sha <frozen base> \
      --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
      --required <reviewer-id> --declared-skill review-doc \
-     --acknowledged-file <手順 4 で記録した canonical_id=body_digest>
+     --acknowledged-file <手順 4（または closure 時は手順 7）で記録した canonical_id=body_digest> \
+     --run-after <手順 3（または closure 時は手順 7）で記録した run anchor>
    ```
 
    Mixed classification の target では、`--declared-skill` に該当する skill を

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -75,14 +75,16 @@ record」節および「Adapter boundary」節に従います。この skill で
    target と artifact set、required context を記録した上で、独立
    reviewer による意味的な discovery を 1 回行います。round 数の扱いは
    Artifact classification / Review stopping rules（`policy/core.md`）に従います。
-   起動した時点で、その run を後から一意に特定できる run anchor（起動直前の
-   ISO-8601 timestamp、または trigger 経路から得られる run 固有の ID）を記録します。
-   この anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready fence の
-   両方で同じ値を再利用します。session の記憶や再計算ではなく、この時点で記録した
-   値をそのまま運びます。手順 7 の closure を実行する場合、その closure run の
-   trigger 時点でも新しい run anchor を記録し（この手順 3 の anchor をそのまま
-   使い回しません）、closure verification と手順 9 の fence ではその closure run の
-   anchor を使います。
+   起動した時点で、その run を後から一意に特定できる run anchor として、起動直前の
+   ISO-8601 timestamp を記録します。`--run-anchor-id` はこの時点では値を持ちません
+   （state evaluator は reviewer の result 自身の `sources[].surface_id` と照合するため、
+   その result が届く前の trigger comment の ID 等を渡しても一致しません）。この
+   timestamp anchor は手順 4 の Acquisition & Validity 確認と手順 9 の merge-ready
+   fence の両方で `--run-after` として同じ値を再利用します。session の記憶や再計算
+   ではなく、この時点で記録した値をそのまま運びます。手順 7 の closure を実行する場合、
+   その closure run の trigger 時点でも新しい run anchor（timestamp）を記録し（この
+   手順 3 の anchor をそのまま使い回しません）、closure verification と手順 9 の fence
+   ではその closure run の anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
    （`policy/core.md`）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
@@ -108,7 +110,7 @@ record」節および「Adapter boundary」節に従います。この skill で
    `skills/review-code.md`（consumer には
    `.ai-dev-foundation/skills/review-code.md` として配布）の Adapter
    boundary（`collectOutputs()`）に従います。その際、手順 3 で記録した run
-   anchor を `--run-after`（または `--run-anchor-id`）として渡します。
+   anchor を `--run-after` として渡します。
 5. **Triage** — 出た finding を Resolution Contract のカテゴリ（fix /
    false-positive / needs-verification / technical-dispute / intent-question）へ
    仕分けます。
@@ -162,10 +164,10 @@ record」節および「Adapter boundary」節に従います。この skill で
    手順は不要です。
 9. **Merge-ready fence** — この review 対象を含む変更について merge-ready を
    宣言する場合は、宣言の直前の最後の action として merge-ready fence を実行します。
-   run anchor と acknowledged revision は、この review flow で最後に使った
-   Acquisition & Validity 確認（closure を経由していなければ手順 4、経由していれば
-   手順 7）で記録したものを再利用します。手順 4 / 7 で `--run-anchor-id` を
-   使った場合は、ここでも `--run-after` の代わりに同じ `--run-anchor-id` を使います。
+   run anchor は、この review flow で最後に起動した run の trigger 時点（closure を
+   経由していなければ手順 3、経由していれば手順 7）で記録した timestamp を再利用
+   します。acknowledged revision は、対応する Acquisition & Validity 確認（closure
+   を経由していなければ手順 4、経由していれば手順 7）で記録したものを再利用します。
 
    ```text
    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -852,6 +852,65 @@ test("both review skills require the merge-ready fence on the no-fix branch too 
   );
 });
 
+// Issue #80: the skill's own fence command example, followed as written, must
+// not fall into `run_anchor_missing -> actor_unattributed -> no_current_run_signal`.
+// The fix is to (1) define where the run anchor comes from (Execution/trigger
+// time), (2) carry that same value through Acquisition/state or closure, and
+// into the final fence, and (3) never require a first fence run to fail just to
+// harvest the digest for a second, real run — that recovery-only pattern from
+// PR #79 must not become the documented happy path.
+test("both review skills define a run-anchor source and reuse it through to the fence (#80)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  for (const [name, skill] of [["review-code.md", reviewCode], ["review-doc.md", reviewDoc]]) {
+    // The anchor is recorded at trigger time, not invented later from memory.
+    assert.ok(
+      containsText(skill, "起動した時点で、その run を後から一意に特定できる run anchor"),
+      `${name} must define the run anchor at Execution/trigger time`,
+    );
+
+    // Every merge-ready-fence.mjs example in the skill — the terse Happy path
+    // pointer as well as the detailed procedure block — must carry a run-anchor
+    // flag pointing back at a recorded step, not a bare placeholder. An agent
+    // that copies any one of these examples verbatim must not be able to omit
+    // the anchor.
+    let searchFrom = 0;
+    let blockCount = 0;
+    for (;;) {
+      const start = skill.indexOf("node tooling/merge-ready-fence.mjs", searchFrom);
+      if (start === -1) break;
+      const end = skill.indexOf("```", start);
+      const block = skill.slice(start, end === -1 ? undefined : end);
+      blockCount += 1;
+      assert.ok(
+        block.includes("--run-after") || block.includes("--run-anchor-id"),
+        `${name} fence command example #${blockCount} must include --run-after or --run-anchor-id`,
+      );
+      assert.match(
+        block,
+        /手順\s*\d/,
+        `${name} fence command example #${blockCount} must point the run-anchor value back at a recorded step, not a bare placeholder`,
+      );
+      searchFrom = start + 1;
+    }
+    assert.ok(blockCount > 0, `${name} must contain at least one merge-ready-fence.mjs example`);
+  }
+
+  // The recovery-only "fail once to harvest the digest, then run for real"
+  // sequence documented in Issue #78/#79's evidence must not be codified here.
+  for (const [name, skill] of [["review-code.md", reviewCode], ["review-doc.md", reviewDoc]]) {
+    assert.ok(
+      !containsText(skill, "1 回目") && !containsText(skill, "2 回目"),
+      `${name} must not codify a two-pass (fail-then-confirm) fence procedure`,
+    );
+    assert.ok(
+      !/fence.{0,40}(失敗|fail).{0,80}(採取|harvest)/.test(stripWhitespace(skill)),
+      `${name} must not instruct deliberately failing the fence to harvest a digest`,
+    );
+  }
+});
+
 // #51 Phase 1 contract: routing remains in the Kernel, procedure moved to the
 // skills. This guards both halves at once — a regression that copies the flow
 // back into the Kernel (or into the generated consumer adapter) fails here, and


### PR DESCRIPTION
## 概要

Issue #80 の bounded Foundation correction。

`skills/review-code.md` / `skills/review-doc.md` の merge-ready fence command 例（Happy path・詳細手順の両方）が `--run-after` / `--run-anchor-id` を欠いていたため、closure cycle を経た PR（review target が複数回動き、同一 reviewer の run が複数回投稿されている状態）でこの例をそのまま実行すると

```text
run_anchor_missing -> actor_unattributed -> no_current_run_signal
```

で `reviewer-completion` が `unknown` に落ちていた（Issue #78 / PR #79 の merge-ready fence 実行時に観測）。`tooling/merge-ready-fence.mjs` 自体は `--run-after` / `--run-anchor-id` を実装しているが、skill の command 例に無いため agent がその必要性を知る手段が無かった。

## 変更内容

Issue #80 の Orchestrator decision（2-pass 運用を canonical happy path にしない）に従い、run anchor という deterministic input を agent/session の暗黙知から外し、skill の通常 flow から取得・再利用できるようにした。

### 1. `skills/review-code.md` / `skills/review-doc.md`（canonical source）

- reviewer trigger / Execution 時点で run anchor（ISO-8601 timestamp または run 固有の ID）を記録することを明文化。
- Acquisition & state（review-code 手順 5 / review-doc 手順 4 の Adapter boundary 経由）で、その run anchor を `--run-after`（または `--run-anchor-id`）として渡すことを明文化。
- targeted closure / Closure を実行する場合、closure run 専用の run anchor を新たに記録し、Closure Acquisition & Validity（review-code 手順 11 / review-doc 手順 7）で使うことを明文化。あわせて `canonical_id` / `body_digest` の記録も closure 側に揃えた（review-code 手順 5 では既に記録済みだったが、closure 側の手順 11 には明記が無かった）。
- 最終 merge-ready fence の command 例（Happy path・詳細手順の両方）に `--run-after <記録した run anchor>` を追加し、どの手順で記録した値を再利用するか（closure を経由したかどうかで参照先が変わる）を明記した。
- `canonical_id=body_digest` は新しい persistent record を導入せず、既存の Acquisition / Triage evidence（手順 5 系）からそのまま渡す。
- fence をまず失敗させて digest を採取し、2 回目を本判定にする 2-pass 運用は明文化しない（PR #79 の evidence は recovery であり、canonical procedure ではない）。

review-code / review-doc 間で run anchor の扱いに非対称が生じないよう、両 skill に同じ粒度で反映した。

### 2. Regression proof（`test/review-protocol.test.mjs`）

`both review skills define a run-anchor source and reuse it through to the fence (#80)` を追加。

- 両 skill が Execution/trigger 時点で run anchor を定義していること
- 両 skill 内のすべての `merge-ready-fence.mjs` command 例（Happy path 例を含む）が `--run-after` / `--run-anchor-id` を含み、それが記録済みの手順を指していること（bare placeholder ではないこと）
- fence を意図的に失敗させて digest を採取する 2-pass 運用を codify していないこと

修正前の `skills/review-code.md` / `skills/review-doc.md` に対して fail することを確認済み。

### 3. Generated / fixture sync

`npm run sync:fixture` で consumer fixture の skill bundle を同期。手作業での consumer artifact patch は行っていない。

## 変更 artifact

| artifact | 種別 |
| --- | --- |
| `skills/review-code.md` | canonical source（Normative） |
| `skills/review-doc.md` | canonical source（Normative） |
| `test/review-protocol.test.mjs` | regression proof（Executable） |
| `test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md` | generated（sync 出力） |
| `test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md` | generated（sync 出力） |

## Verification

- targeted: `node --test test/review-protocol.test.mjs test/merge-ready-fence.test.mjs` → 35 pass / 0 fail
- red-proof: 修正前 source に対して新規 test が fail することを確認
- `npm test` → 238 tests / 237 pass / 0 fail / 1 skipped（既存の DB 依存 test の skip）
- guardrails: `Verified 8 guardrail fixtures.`
- `npm run check:fixture` → `Generated adapters, quality profile, skill bundle, and reviewer capability record are current`
- consumer fixture 側の `format:check`（printWidth:100 の quality profile config）→ pass
- `git diff --check` → clean

## Design / complexity guard（Issue #80 Architecture brake）

- review-run DB / persistent run-anchor record / new durable schema = 追加なし
- generic acknowledgement store / generic review orchestration framework / workflow DSL = 追加なし
- `tooling/merge-ready-fence.mjs` の 1-pass 化、automatic acknowledgement generation = 実施していない（既存 CLI の `--run-after` / `--run-anchor-id` をそのまま使用）
- Phase 2 fence architecture の再設計なし、`policy/core.md` 無変更

## Out of scope（Issue #80 の Non-goals に従う）

Phase 2 fence architecture の再設計、reviewer capability record の redesign、Issue #78 の no-fix branch fence 必須化そのものの再変更、stage-tracker 側の変更、2-pass fence execution の canonical happy path 化、review-run 用の new persistent artifact / durable schema、generic review orchestration / acknowledgement framework。

## STOP

Issue #80 の指示に従い、本 PR は merge-ready までで停止する。PR merge / Issue #80 close / stage-tracker 側の変更は行わない。

Refs #80