### PR TITLE
fix: target-base を actual base branch tip に対して判定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ blocking checkで検知します。
 ## Review evidence helper
 
 `tooling/review-evidence.mjs` は、指定した GitHub PR について durable review
-surface（PR metadata / head SHA / base SHA / body、Conversation comments、review
-submissions、inline review comments、review-thread comments とその resolution
-state、changed files、combined commit status、check runs）を fresh に取得し、
-pagination を完了した上で human-readable summary または `--json` machine-readable
-output を返す snapshot tool です。
+surface（PR metadata / head SHA / base SHA / body、PR が target とする base branch の
+現在の tip SHA、Conversation comments、review submissions、inline review comments、
+review-thread comments とその resolution state、changed files、combined commit
+status、check runs）を fresh に取得し、pagination を完了した上で human-readable
+summary または `--json` machine-readable output を返す snapshot tool です。
 
 ```text
 node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> [--json]
@@ -236,7 +236,7 @@ exit 2 の 2 つの経路は stdout の有無で区別できます。
 | check id | pass | fail | unknown |
 | --- | --- | --- | --- |
 | `target-head` | current head == `--target-sha` | 不一致 | 取得失敗 / 宣言なし |
-| `target-base` | current base == `--base-sha` | 不一致 | 取得失敗 / 宣言なし |
+| `target-base` | base branch の現在の tip == `--base-sha` | 不一致 | tip 取得失敗 / 宣言なし |
 | `artifact-set` | changed path 集合が frozen 集合と厳密一致 | 追加・削除いずれも | files surface 取得失敗 / 宣言なし |
 | `skill-routing` | derived required skills ⊆ declared skills | derived ⊄ declared | 分類不能 path（declared が mandatory skill を網羅していれば pass）/ 宣言なし |
 | `reviewer-completion` | required reviewer がすべて `completed@target` | `not-bound` / `rate-limited` / `failed` / `declined` | `in-flight` / `unknown` / record に無い id |

--- a/test/merge-ready-fence-lib.test.mjs
+++ b/test/merge-ready-fence-lib.test.mjs
@@ -33,7 +33,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const TARGET = "abcdef1234567890abcdef1234567890abcdef12";
 const OTHER_TARGET = "1234567890abcdef1234567890abcdef12345678";
 const BASE = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f";
-const OTHER_BASE = "0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e";
+const ADVANCED_BASE = "0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d";
 const ANCHOR = "2026-09-03T00:00:00.000Z";
 const OBSERVED = "2026-09-03T01:00:00.000Z";
 
@@ -99,9 +99,28 @@ function file(path, status = "modified") {
   return { path, status, previous_path: null };
 }
 
+// The base branch tip fact of one acquisition (Issue #82), in its three
+// observable shapes.
+function baseBranch(fetchStatus, tipSha) {
+  if (fetchStatus === "fetched") {
+    return { fetch_status: "fetched", failure: null, repo: "org/repo", ref: "main", tip_sha: tipSha };
+  }
+  if (fetchStatus === "not_applicable") {
+    return { fetch_status: "not_applicable", failure: null, repo: null, ref: null, tip_sha: null, note: "base ref unavailable" };
+  }
+  return { fetch_status: "failed", failure: { status: 404, message: "Branch not found" }, repo: "org/repo", ref: "main", tip_sha: null };
+}
+
 function evidence({
   headSha = TARGET,
   baseSha = BASE,
+  // The base branch tip is acquired separately from the PR object's base
+  // commit (Issue #82). It defaults to `baseSha` only so unrelated fixtures
+  // stay on the clean path; every base fixture sets it explicitly.
+  baseTipSha = baseSha,
+  // Defaults to the acquisition's own coupling: with no PR object there is no
+  // base ref to read, so the tip is not_applicable rather than fetched.
+  baseBranchStatus = null,
   body = "Refs #76",
   metadataStatus = "fetched",
   comments = [completionComment(1, "primary-bot", TARGET), completionComment(2, "advisor-bot", TARGET)],
@@ -119,6 +138,7 @@ function evidence({
       metadataStatus === "fetched"
         ? { fetch_status: "fetched", failure: null, head_sha: headSha, base_sha: baseSha, base_ref: "main", state: "open", html_url: null, updated_at: OBSERVED, body }
         : { fetch_status: "failed", failure: { status: 500, message: "boom" }, head_sha: null, base_sha: null, base_ref: null, state: null, html_url: null, updated_at: null, body: null },
+    base_branch: baseBranch(baseBranchStatus ?? (metadataStatus === "fetched" ? "fetched" : "not_applicable"), baseTipSha),
     surfaces: {
       conversation_comments: surface(comments),
       review_submissions: surface([], reviewSubmissionsStatus),
@@ -239,11 +259,73 @@ test("an abbreviated frozen SHA still matches the full current head", () => {
   assert.equal(checkOf(fence, "target-head").status, "pass");
 });
 
-test("fixture 3: base moved under the frozen range -> fail", () => {
-  const { fence } = runFence({ snapshot: evidence({ baseSha: OTHER_BASE }) });
+// The authority for target-base is where the base branch points now, not the
+// base commit the PR object carries (Issue #82). The PR's `base.sha` does not
+// advance when the base branch alone moves, so a check that reads it reports
+// `pass` for exactly the ordinary case this check exists to catch.
+
+test("fixture 3: the base branch advanced while the PR head stood still -> fail", () => {
+  // The PR object still reports the base commit it was opened against, which
+  // is also the frozen one. Only the live tip has moved.
+  const { fence } = runFence({ snapshot: evidence({ baseSha: BASE, baseTipSha: ADVANCED_BASE }) });
   const check = checkOf(fence, "target-base");
   assert.equal(check.status, "fail");
   assert.deepEqual(check.reason_codes, ["target_base_moved"]);
+  assert.equal(check.detail.frozen_base_sha, BASE);
+  assert.equal(check.detail.current_base_tip_sha, ADVANCED_BASE);
+  // The PR snapshot's agreeing base commit is reported as a diagnostic fact
+  // and did not produce the verdict.
+  assert.equal(check.detail.pr_base_sha, BASE);
+  assert.equal(fence.status, "fail");
+});
+
+test("fixture 3b: a PR sync that refreshed the PR's base commit does not clear a stale frozen base", () => {
+  // After the base advanced, a push synced the PR, so the PR object's base
+  // commit now matches the live tip. The frozen base is still the old one.
+  const { fence } = runFence({
+    snapshot: evidence({ baseSha: ADVANCED_BASE, baseTipSha: ADVANCED_BASE }),
+    inputs: { baseSha: BASE },
+  });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "fail");
+  assert.deepEqual(check.reason_codes, ["target_base_moved"]);
+  assert.equal(fence.status, "fail");
+});
+
+test("fixture 3c: re-freezing against the integrated base passes", () => {
+  const { fence } = runFence({
+    snapshot: evidence({ baseSha: BASE, baseTipSha: ADVANCED_BASE }),
+    inputs: { baseSha: ADVANCED_BASE },
+  });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "pass");
+  assert.deepEqual(check.reason_codes, []);
+  assert.equal(fence.status, "pass");
+});
+
+test("fixture 3d: an unreadable base ref is unknown, never a pass borrowed from the PR's base commit", () => {
+  const { fence } = runFence({ snapshot: evidence({ baseSha: BASE, baseBranchStatus: "failed" }) });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["base_branch_tip_unavailable"]);
+  assert.equal(check.detail.current_base_tip_sha, null);
+  // The PR object's base commit matches the frozen one and still yields no pass.
+  assert.equal(check.detail.pr_base_sha, BASE);
+  assert.equal(fence.status, "unknown");
+});
+
+test("a base branch fact that is absent altogether is unknown, not a pass", () => {
+  const snapshot = evidence();
+  delete snapshot.base_branch;
+  const { fence } = runFence({ snapshot });
+  const check = checkOf(fence, "target-base");
+  assert.equal(check.status, "unknown");
+  assert.deepEqual(check.reason_codes, ["base_branch_tip_unavailable"]);
+});
+
+test("an abbreviated frozen base still matches the full current base branch tip", () => {
+  const { fence } = runFence({ inputs: { baseSha: BASE.slice(0, 7) } });
+  assert.equal(checkOf(fence, "target-base").status, "pass");
 });
 
 test("a frozen base that was never recorded is unknown, never a silent pass", () => {

--- a/test/review-evidence.test.mjs
+++ b/test/review-evidence.test.mjs
@@ -38,10 +38,25 @@ const PR_META = {
   body: "PR body text",
 };
 
+const BASE_TIP = "basetip0";
+
 function prRoute(pr = PR_META) {
   return {
     match: (url, init) => url.endsWith("/repos/octo/demo/pulls/62") && (!init.method || init.method === "GET"),
     handler: () => jsonResponse(pr),
+  };
+}
+
+// The base ref lookup added by Issue #82. It returns a SHA distinct from
+// PR_META.base.sha so a fixture can never pass by reading the PR snapshot's
+// base commit when it meant to read the branch tip.
+function baseRefRoute({ sha = BASE_TIP, status = 200, body } = {}) {
+  return {
+    match: (url) => url.includes("/git/ref/heads/"),
+    handler: () =>
+      status === 200
+        ? jsonResponse(body === undefined ? { ref: "refs/heads/main", object: { sha, type: "commit" } } : body)
+        : jsonResponse({ message: "Not Found" }, { status }),
   };
 }
 
@@ -94,6 +109,7 @@ function baseRoutes() {
     // Appended last so the positional route indices used by the pagination
     // tests above stay stable.
     emptyListRoute("/pulls/62/files"),
+    baseRefRoute(),
   ];
 }
 
@@ -168,6 +184,7 @@ test("collects a representative multi-surface snapshot with independent per-surf
           { filename: "docs/new.md", status: "added", previous_filename: undefined },
         ]),
     },
+    baseRefRoute(),
   ];
 
   const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
@@ -178,6 +195,14 @@ test("collects a representative multi-surface snapshot with independent per-surf
   assert.equal(result.pr_metadata.base_ref, "main");
   assert.equal(result.pr_metadata.body, "PR body text");
   assert.equal(result.fetch_failures, 0);
+
+  // Issue #82: the base branch tip is its own acquired fact, read from the
+  // base ref rather than copied off the PR object's base commit.
+  assert.equal(result.base_branch.fetch_status, "fetched");
+  assert.equal(result.base_branch.repo, "octo/demo");
+  assert.equal(result.base_branch.ref, "main");
+  assert.equal(result.base_branch.tip_sha, BASE_TIP);
+  assert.notEqual(result.base_branch.tip_sha, result.pr_metadata.base_sha);
 
   assert.equal(result.surfaces.conversation_comments.fetch_status, "fetched");
   assert.equal(result.surfaces.conversation_comments.count, 1);
@@ -648,7 +673,108 @@ test("a PR-metadata fetch failure does not crash the run and marks head-dependen
   assert.equal(result.surfaces.pull_request_files.fetch_status, "fetched");
   assert.equal(result.pr_metadata.base_sha, null);
   assert.equal(result.pr_metadata.body, null);
+  // No PR object means no base ref to read, so the base branch tip is
+  // not_applicable rather than a second counted failure.
+  assert.equal(result.base_branch.fetch_status, "not_applicable");
+  assert.equal(result.base_branch.tip_sha, null);
   assert.equal(result.fetch_failures, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Base branch tip acquisition (Issue #82)
+//
+// The PR object's `base.sha` is the base commit recorded on the PR at its last
+// sync; it does not advance when the base branch alone moves. These fixtures
+// pin that the tip is read from the ref itself and that every way of failing to
+// read it stays distinguishable from "read it, and it was unchanged".
+// ---------------------------------------------------------------------------
+
+test("the base branch tip is read from the base ref, not copied off the PR object's base commit", async () => {
+  const routes = baseRoutes();
+  const requested = [];
+  routes[routes.length - 1] = {
+    match: (url) => url.includes("/git/ref/heads/"),
+    handler: (url) => {
+      requested.push(url);
+      return jsonResponse({ ref: "refs/heads/main", object: { sha: "advanced9", type: "commit" } });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.deepEqual(requested, ["https://api.github.com/repos/octo/demo/git/ref/heads/main"]);
+  assert.equal(result.base_branch.fetch_status, "fetched");
+  assert.equal(result.base_branch.tip_sha, "advanced9");
+  // The PR snapshot still reports its own, older base commit. Both facts are
+  // present and neither is derived from the other.
+  assert.equal(result.pr_metadata.base_sha, "base987");
+  assert.equal(result.fetch_failures, 0);
+});
+
+test("a base ref that no longer exists is a counted failure with a null tip, never a fetched blank", async () => {
+  const routes = baseRoutes();
+  routes[routes.length - 1] = baseRefRoute({ status: 404 });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.base_branch.fetch_status, "failed");
+  assert.equal(result.base_branch.failure.status, 404);
+  assert.equal(result.base_branch.ref, "main");
+  assert.equal(result.base_branch.tip_sha, null);
+  assert.equal(result.fetch_failures, 1);
+});
+
+test("a 200 base ref response carrying no commit SHA is a failure, not a fetched null tip", async () => {
+  const routes = baseRoutes();
+  routes[routes.length - 1] = baseRefRoute({ body: { ref: "refs/heads/main" } });
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.equal(result.base_branch.fetch_status, "failed");
+  assert.equal(result.base_branch.tip_sha, null);
+  assert.match(result.base_branch.failure.message, /no commit SHA/);
+  assert.equal(result.fetch_failures, 1);
+});
+
+test("a base ref containing slashes is requested as path segments, not as one encoded component", async () => {
+  const routes = baseRoutes();
+  routes[0] = prRoute({ ...PR_META, base: { sha: "base987", ref: "release/2026-09" } });
+  const requested = [];
+  routes[routes.length - 1] = {
+    match: (url) => url.includes("/git/ref/heads/"),
+    handler: (url) => {
+      requested.push(url);
+      return jsonResponse({ ref: "refs/heads/release/2026-09", object: { sha: "reltip1" } });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.deepEqual(requested, ["https://api.github.com/repos/octo/demo/git/ref/heads/release/2026-09"]);
+  assert.equal(result.base_branch.ref, "release/2026-09");
+  assert.equal(result.base_branch.tip_sha, "reltip1");
+});
+
+test("the base ref is resolved on the repository the PR merges into, which a fork head does not change", async () => {
+  const routes = baseRoutes();
+  routes[0] = prRoute({
+    ...PR_META,
+    head: { sha: "abc1234", repo: { owner: { login: "contributor" }, name: "demo-fork" } },
+    base: { sha: "base987", ref: "main", repo: { owner: { login: "octo" }, name: "demo" } },
+  });
+  const requested = [];
+  routes[routes.length - 1] = {
+    match: (url) => url.includes("/git/ref/heads/"),
+    handler: (url) => {
+      requested.push(url);
+      return jsonResponse({ ref: "refs/heads/main", object: { sha: "basetip0" } });
+    },
+  };
+
+  const result = await collectReviewEvidence({ owner: "octo", repo: "demo", pullNumber: 62, token: "t", fetchImpl: createFetch(routes) });
+
+  assert.deepEqual(requested, ["https://api.github.com/repos/octo/demo/git/ref/heads/main"]);
+  assert.equal(result.base_branch.repo, "octo/demo");
 });
 
 test("formatHumanSummary renders a deterministic snapshot summary", async () => {
@@ -662,6 +788,7 @@ test("formatHumanSummary renders a deterministic snapshot summary", async () => 
   assert.match(text, /^Conversation comments: fetched \(0\)$/m);
   assert.match(text, /^Review threads: fetched \(0\)$/m);
   assert.match(text, /^Changed files: fetched \(0\)$/m);
+  assert.match(text, /^Base branch: main tip basetip0 \(octo\/demo\)$/m);
   assert.match(text, /^Fetch failures: 0$/m);
 });
 

--- a/tooling/merge-ready-fence-lib.mjs
+++ b/tooling/merge-ready-fence-lib.mjs
@@ -350,15 +350,30 @@ function checkTargetHead(evidence, inputs) {
     : check("target-head", "fail", ["target_head_moved"], detail);
 }
 
+// The authority here is where the base branch points NOW, not the PR object's
+// `base.sha` (Issue #82). `base.sha` is a snapshot the PR carries: advancing
+// the base branch alone does not update it, so comparing against it reports
+// `pass` for exactly the ordinary case this check exists to catch — the base
+// moved while the PR head stood still. `pr_base_sha` is kept in the detail as
+// a diagnostic fact, and is never consulted to reach a verdict.
 function checkTargetBase(evidence, inputs) {
   const frozen = nonEmpty(inputs.baseSha);
   if (!frozen) return check("target-base", "unknown", ["frozen_base_missing"]);
   const metadata = evidence?.pr_metadata;
-  if (metadata?.fetch_status !== "fetched" || !nonEmpty(metadata.base_sha)) {
-    return check("target-base", "unknown", ["pr_metadata_unavailable"]);
-  }
-  const detail = { frozen_base_sha: frozen, current_base_sha: metadata.base_sha };
-  return shaEqual(metadata.base_sha, frozen)
+  const prBaseSha = metadata?.fetch_status === "fetched" ? nonEmpty(metadata.base_sha) : null;
+  const baseBranch = evidence?.base_branch;
+  const tip = baseBranch?.fetch_status === "fetched" ? nonEmpty(baseBranch.tip_sha) : null;
+  const detail = {
+    frozen_base_sha: frozen,
+    base_ref: nonEmpty(baseBranch?.ref),
+    base_branch_fetch_status: nonEmpty(baseBranch?.fetch_status),
+    current_base_tip_sha: tip,
+    pr_base_sha: prBaseSha,
+  };
+  // No confirmed tip is `unknown`, never `pass`: an unreadable base ref is
+  // the state in which the base is most likely to have moved unobserved.
+  if (!tip) return check("target-base", "unknown", ["base_branch_tip_unavailable"], detail);
+  return shaEqual(tip, frozen)
     ? check("target-base", "pass", [], detail)
     : check("target-base", "fail", ["target_base_moved"], detail);
 }

--- a/tooling/review-evidence-lib.mjs
+++ b/tooling/review-evidence-lib.mjs
@@ -413,6 +413,72 @@ function normalizePullRequestFile(item) {
   };
 }
 
+function encodeRefPath(ref) {
+  return ref.split("/").map(encodeURIComponent).join("/");
+}
+
+// Where the PR's base branch currently points.
+//
+// The PR object's `base.sha` is a snapshot field: it does not advance when the
+// base branch alone moves, so it cannot answer "has the base moved since the
+// target was frozen?" (Issue #82). This reads the base ref itself, once, in the
+// same fresh acquisition, and reports that ref's current commit SHA as its own
+// fact. It stays mechanical — it compares nothing and decides nothing about
+// whether a moved base is acceptable.
+//
+// Anything short of a confirmed commit SHA (PR metadata failure, missing ref,
+// deleted branch, a response carrying no object SHA) is reported as
+// not_applicable/failed with `tip_sha: null` — never as an empty-but-fetched
+// value a caller could read as "unchanged".
+export async function fetchBaseBranchTip(fetchImpl, token, owner, repo, prBody) {
+  const baseRef = typeof prBody?.base?.ref === "string" ? prBody.base.ref.trim() : "";
+  if (baseRef === "") {
+    return {
+      fetch_status: "not_applicable",
+      failure: null,
+      repo: null,
+      ref: null,
+      tip_sha: null,
+      note: "base ref unavailable because PR metadata fetch failed or carried no base ref",
+    };
+  }
+  // The base repository is the one the PR targets — where the base ref lives
+  // even when the head is a fork. `base.repo` is preferred over the requested
+  // owner/repo so the ref is resolved on the repository the PR actually merges
+  // into, and the requested owner/repo is only a fallback when the PR object
+  // did not carry it.
+  const baseOwner = prBody.base.repo?.owner?.login ?? owner;
+  const baseRepo = prBody.base.repo?.name ?? repo;
+  const baseRepoFullName = baseOwner + "/" + baseRepo;
+  // The singular `git/ref/heads/<ref>` form is an exact-match lookup: a ref
+  // that does not exist is a 404 rather than a prefix match on some other
+  // branch, so a deleted or renamed base branch cannot resolve to a SHA.
+  const url = `${GITHUB_API_ROOT}/repos/${baseOwner}/${baseRepo}/git/ref/heads/${encodeRefPath(baseRef)}`;
+  let body;
+  try {
+    ({ body } = await fetchRestPage(fetchImpl, token, url));
+  } catch (error) {
+    return {
+      fetch_status: "failed",
+      failure: error.failure ?? { status: null, message: error.message },
+      repo: baseRepoFullName,
+      ref: baseRef,
+      tip_sha: null,
+    };
+  }
+  const tipSha = typeof body?.object?.sha === "string" && body.object.sha.trim() !== "" ? body.object.sha : null;
+  if (!tipSha) {
+    return {
+      fetch_status: "failed",
+      failure: { status: null, message: "base ref response carried no commit SHA" },
+      repo: baseRepoFullName,
+      ref: baseRef,
+      tip_sha: null,
+    };
+  }
+  return { fetch_status: "fetched", failure: null, repo: baseRepoFullName, ref: baseRef, tip_sha: tipSha };
+}
+
 function notApplicableSurface(note) {
   return { fetch_status: "not_applicable", count: null, pages_fetched: 0, items: [], failure: null, note };
 }
@@ -437,12 +503,13 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
   }
   const headSha = prBody?.head?.sha ?? null;
 
-  const [conversationComments, reviewSubmissions, inlineReviewComments, reviewThreads, pullRequestFiles] = await Promise.all([
+  const [conversationComments, reviewSubmissions, inlineReviewComments, reviewThreads, pullRequestFiles, baseBranch] = await Promise.all([
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/issues/${pullNumber}/comments?per_page=100`),
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/reviews?per_page=100`),
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/comments?per_page=100`),
     fetchReviewThreadsSurface(fetchImpl, token, owner, repo, pullNumber),
     fetchPaginatedSurface(fetchImpl, token, `${restBase}/pulls/${pullNumber}/files?per_page=100`),
+    fetchBaseBranchTip(fetchImpl, token, owner, repo, prBody),
   ]);
 
   // commit_status/check_runs are fetched for this snapshot's headSha only —
@@ -493,7 +560,11 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
     check_runs: { ...checkRuns, items: checkRuns.items.map(normalizeCheckRun) },
   };
 
+  // base_branch is counted like a surface: a failed base-ref read is a real
+  // acquisition failure. `not_applicable` is not counted, because it only
+  // arises when PR metadata already failed, which is counted once above.
   let fetchFailures = prMetadataFailure ? 1 : 0;
+  if (baseBranch.fetch_status === "failed") fetchFailures += 1;
   for (const surface of Object.values(surfaces)) {
     if (surface.fetch_status === "failed" || surface.fetch_status === "partial") fetchFailures += 1;
   }
@@ -529,6 +600,10 @@ export async function collectReviewEvidence({ owner, repo, pullNumber, token, fe
           updated_at: null,
           body: null,
         },
+    // Where the base branch points right now, as opposed to
+    // `pr_metadata.base_sha`, which is the base commit recorded on the PR
+    // object at its last sync (Issue #82).
+    base_branch: baseBranch,
     surfaces,
     fetch_failures: fetchFailures,
   };
@@ -554,6 +629,14 @@ export function formatHumanSummary(result) {
     lines.push(`Head: ${result.pr_metadata.head_sha ?? "unknown"} (state: ${result.pr_metadata.state ?? "unknown"})`);
   } else {
     lines.push(`Head: unknown (PR metadata fetch failed: ${result.pr_metadata.failure?.message ?? "unknown error"})`);
+  }
+  const baseBranch = result.base_branch;
+  if (baseBranch?.fetch_status === "fetched") {
+    lines.push(`Base branch: ${baseBranch.ref} tip ${baseBranch.tip_sha} (${baseBranch.repo})`);
+  } else {
+    lines.push(
+      `Base branch: ${baseBranch?.fetch_status ?? "unavailable"} — ${baseBranch?.failure?.message ?? baseBranch?.note ?? "unknown error"}`,
+    );
   }
   lines.push(`Snapshot fetched at: ${result.generated_at}`);
   lines.push("");


### PR DESCRIPTION
## 背景

Issue #76 の Phase 2 consumer validation（stage-tracker #304 / PR #313 を Canary B として実行）で、`target-base` check が actual base branch tip の drift を検出できないことが判明しました。

`target-base` は frozen `--base-sha` を review acquisition の `pr_metadata.base_sha` と比較していましたが、この値は GitHub PR object の `base.sha` 由来です。PR の `base.sha` は base branch 単独の前進では即時に current branch tip へ追随しません。したがって、PR head を触らず `main` だけ進んだ通常の状態で actual base drift を見逃し、`target-base: pass` になり得ました。

これは safe-base-drift policy の問題ではなく、base drift detection そのものの correctness gap です。

Refs #82
Refs #76

## 変更内容

### acquisition（`tooling/review-evidence-lib.mjs`）

- `fetchBaseBranchTip()` を追加し、PR の `base.repo` / `base.ref` から base ref の current tip SHA を **1 回**取得します。既存の fresh acquisition の `Promise.all` に相乗りさせており、新しい acquisition 責務や persistent schema は導入していません。
- 取得経路は `git/ref/heads/<ref>` の exact-match lookup です。存在しない ref は prefix match ではなく 404 になるため、削除・rename された base branch が別 branch の SHA へ解決されません。
- slash を含む ref（`release/2026-09` 等）は segment ごとに encode し、path 区切りとして送ります。
- 結果は snapshot の `base_branch` fact（`fetch_status` / `repo` / `ref` / `tip_sha` / `failure`）として載せます。SHA を確定できない場合は `not_applicable` / `failed` かつ `tip_sha: null` であり、`fetched` の空値にはしません。
- `failed` は `fetch_failures` に算入します。`not_applicable` は PR metadata 失敗時にのみ発生し、そちらで既に 1 回数えているため算入しません。

### fence（`tooling/merge-ready-fence-lib.mjs`）

- `target-base` は frozen base と `base_branch.tip_sha`（actual current base branch tip）を比較します。
- PR object の `base.sha` は detail の `pr_base_sha` として diagnostic に残しますが、verdict の authority にはしません。
- tip を確定できない場合は `unknown`（`base_branch_tip_unavailable`）です。`pr_base_sha` が frozen base と一致していても pass にはなりません。

安全側の判定のみで、base drift を自動的に safe 扱いする policy は導入していません。

## fixtures

`test/merge-ready-fence-lib.test.mjs`

- fixture 3: PR head unchanged + base branch のみ前進 → `fail` / `target_base_moved`（PR の `base.sha` は frozen base と一致したまま）
- fixture 3b: base 前進後に PR を sync して PR `base.sha` が更新されても frozen base が古い → `fail`
- fixture 3c: current base を取り込んで新 base で freeze し直す → `pass`
- fixture 3d: live base tip 取得失敗 → `unknown` / `base_branch_tip_unavailable`
- `base_branch` fact 自体が欠落した snapshot → `unknown`
- abbreviated frozen base と full tip の照合

`test/review-evidence.test.mjs`

- base branch tip が base ref から取得され、PR object の base commit のコピーではないこと（要求 URL も pin）
- 存在しない base ref → `failed` / `tip_sha: null` / `fetch_failures` 算入
- commit SHA を持たない 200 応答 → `failed`
- slash を含む ref の path segment 送出
- fork head でも base ref は PR が merge する repository 上で解決されること

## verification

- `npm test` … 247 pass / 0 fail
- `npm run test:guardrails` … Verified 8 guardrail fixtures
- `npm run check:fixture` … green
- `git diff --check` … clean
- 既存の target-head / artifact-set / skill-routing / reviewer-completion / result-revision-coherence / acquisition-coverage / review-threads / verify-coherence / autoclose-hygiene に regression なし

## scope 外（意図的に触れていません）

conflict-free / artifact-disjoint drift の safe 扱い、review carry-forward policy、#70 / #71、artifact classifier の Observation 修正、provider-specific rule、persistent review DB、stage-tracker 側の変更。

コードへ追加した mechanical behavior は Markdown へ重複記載していません。README の変更は、誤りになった `target-base` の contract 表記と acquisition surface 一覧の更新のみです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Target-base checks now compare against the current tip of the pull request’s base branch, improving detection of changes made after the pull request was created.
  - Checks return a clear unknown status when the base branch tip cannot be read, rather than attributing the issue to unavailable pull request metadata.

- **New Features**
  - Review evidence now includes the current base-branch tip and displays its status in human-readable summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->