### PR TITLE
reviewer seed template を stage-tracker で実証済みの provider evidence へ更新する

### DIFF
--- a/.ai-dev-foundation/reviewers.json
+++ b/.ai-dev-foundation/reviewers.json
@@ -27,12 +27,17 @@
         "target_pattern": "Reviewed commit:[^0-9a-fA-F]*([0-9a-fA-F]{7,40})"
       },
       "non_participation_marker": null,
-      "rate_limit_marker": null,
+      "rate_limit_marker": {
+        "any_of": [
+          "You have reached your Codex usage limits.",
+          "You have reached your Codex usage limits for code reviews."
+        ]
+      },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": ["claude"],
-      "observed_at": "2026-09-02",
-      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。"
+      "observed_at": "2026-09-05",
+      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。quota 上限に達している場合、review 結果の代わりに `You have reached your Codex usage limits.`（cloud task 側）と `You have reached your Codex usage limits for code reviews.`（code review 側）の通知 comment を投稿することを実測した。2 文は前者が後者の prefix にならないため、両方を rate_limit_marker.any_of へ実観測どおり列挙する。これは non-success state であり、completion や 0 findings へ変換せず、Failure / retry と fallback_order に従って扱う。"
     },
     {
       "id": "claude",
@@ -60,7 +65,7 @@
       },
       "fallback_order": ["codex"],
       "observed_at": "2026-09-02",
-      "notes": "この entry の actors と marker は未実測。次に selection した時点で実測し observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
+      "notes": "この entry の actors、completion marker（`**Claude finished` / `Reviewed commit:`）、target_argument による binding は real PR の run で実測済み。実測と宣言が食い違った場合は待たず、この record の marker と observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
     },
     {
       "id": "coderabbitai",
@@ -73,7 +78,10 @@
         "value": "@coderabbitai review"
       },
       "completion_marker": {
-        "any_of": ["Actionable comments posted:"]
+        "any_of": [
+          "Actionable comments posted:",
+          "No actionable comments were generated in the recent review."
+        ]
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
@@ -82,8 +90,8 @@
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-02",
-      "notes": "結果は review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿される。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-03",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
     }
   ]
 }

--- a/templates/reviewers.example.json
+++ b/templates/reviewers.example.json
@@ -27,12 +27,17 @@
         "target_pattern": "Reviewed commit:[^0-9a-fA-F]*([0-9a-fA-F]{7,40})"
       },
       "non_participation_marker": null,
-      "rate_limit_marker": null,
+      "rate_limit_marker": {
+        "any_of": [
+          "You have reached your Codex usage limits.",
+          "You have reached your Codex usage limits for code reviews."
+        ]
+      },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": ["claude"],
-      "observed_at": "2026-09-02",
-      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。"
+      "observed_at": "2026-09-05",
+      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。quota 上限に達している場合、review 結果の代わりに `You have reached your Codex usage limits.`（cloud task 側）と `You have reached your Codex usage limits for code reviews.`（code review 側）の通知 comment を投稿することを実測した。2 文は前者が後者の prefix にならないため、両方を rate_limit_marker.any_of へ実観測どおり列挙する。これは non-success state であり、completion や 0 findings へ変換せず、Failure / retry と fallback_order に従って扱う。"
     },
     {
       "id": "claude",
@@ -60,7 +65,7 @@
       },
       "fallback_order": ["codex"],
       "observed_at": "2026-09-02",
-      "notes": "この entry の actors と marker は未実測。次に selection した時点で実測し observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
+      "notes": "この entry の actors、completion marker（`**Claude finished` / `Reviewed commit:`）、target_argument による binding は real PR の run で実測済み。実測と宣言が食い違った場合は待たず、この record の marker と observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
     },
     {
       "id": "coderabbitai",
@@ -73,7 +78,10 @@
         "value": "@coderabbitai review"
       },
       "completion_marker": {
-        "any_of": ["Actionable comments posted:"]
+        "any_of": [
+          "Actionable comments posted:",
+          "No actionable comments were generated in the recent review."
+        ]
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
@@ -82,8 +90,8 @@
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-02",
-      "notes": "結果は review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿される。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-03",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
     }
   ]
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/reviewers.json
+++ b/test/fixtures/consumer/.ai-dev-foundation/reviewers.json
@@ -27,12 +27,17 @@
         "target_pattern": "Reviewed commit:[^0-9a-fA-F]*([0-9a-fA-F]{7,40})"
       },
       "non_participation_marker": null,
-      "rate_limit_marker": null,
+      "rate_limit_marker": {
+        "any_of": [
+          "You have reached your Codex usage limits.",
+          "You have reached your Codex usage limits for code reviews."
+        ]
+      },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": ["claude"],
-      "observed_at": "2026-09-02",
-      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。"
+      "observed_at": "2026-09-05",
+      "notes": "finding がある run では GitHub review submission（state=COMMENTED）と inline comment を投稿し、submission の commit_id が reviewed target を表す。finding が無い run では submission を作らず conversation comment のみを残すため、その場合は completion_marker が唯一の完了根拠になる。どちらの本文にも `**Reviewed commit:** <短縮 SHA>` を含む。本結果の前に環境案内 comment を複数投稿することがあるため、最初の comment の到着を completion と誤認しない。PR-open automatic review の有効・無効は repository code では完結しない operator/account 側の設定であり、その変更を repository code から完了したものとして扱わない。quota 上限に達している場合、review 結果の代わりに `You have reached your Codex usage limits.`（cloud task 側）と `You have reached your Codex usage limits for code reviews.`（code review 側）の通知 comment を投稿することを実測した。2 文は前者が後者の prefix にならないため、両方を rate_limit_marker.any_of へ実観測どおり列挙する。これは non-success state であり、completion や 0 findings へ変換せず、Failure / retry と fallback_order に従って扱う。"
     },
     {
       "id": "claude",
@@ -60,7 +65,7 @@
       },
       "fallback_order": ["codex"],
       "observed_at": "2026-09-02",
-      "notes": "この entry の actors と marker は未実測。次に selection した時点で実測し observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
+      "notes": "この entry の actors、completion marker（`**Claude finished` / `Reviewed commit:`）、target_argument による binding は real PR の run で実測済み。実測と宣言が食い違った場合は待たず、この record の marker と observed_at を更新する。GitHub Actions 経由のこの route は review submission を作らず、単一の conversation comment を in-place 編集して `**Claude finished ...**` で完成するため、構造的 evidence が無く completion_marker に依存する。comment 自体は reviewed SHA を持たないため、trigger.target_argument で結果へ `Reviewed commit:` 行を要求し binding に使う。その行が無ければ state は unknown になる。mention trigger workflow（例: .github/workflows/claude-review.yml）は review 対象 repository が個別に用意する必要があり、Foundation は配布しない。workflow が無い repository ではこの trigger は unavailable。"
     },
     {
       "id": "coderabbitai",
@@ -73,7 +78,10 @@
         "value": "@coderabbitai review"
       },
       "completion_marker": {
-        "any_of": ["Actionable comments posted:"]
+        "any_of": [
+          "Actionable comments posted:",
+          "No actionable comments were generated in the recent review."
+        ]
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
@@ -82,8 +90,8 @@
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-02",
-      "notes": "結果は review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿される。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-03",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
     }
   ]
 }

--- a/test/reviewer-capability-record.test.mjs
+++ b/test/reviewer-capability-record.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REVIEWER_RECORD_SCHEMA_ID, readReviewerRecordFile, validateReviewerRecord } from "../tooling/reviewer-record-lib.mjs";
+import { evaluateReviewerTargetStates } from "../tooling/review-evidence-state-lib.mjs";
 
 // Issue #72 Phase 1: the reviewer capability record makes "which reviewers
 // exist, how are they triggered, what counts as completion" machine-readable
@@ -360,4 +361,156 @@ test("review-code.md binds Selection, Execution and Acquisition to the record", 
   // the header paragraph already makes.
   const headingIndex = (heading) => skill.search(new RegExp(`^${heading}$`, "m"));
   assert.ok(headingIndex("## Happy path") > -1 && headingIndex("## Happy path") < headingIndex("## 手順"));
+});
+
+// --- observed evidence replay (Issue #88) -----------------------------------
+
+// The markers in the shipped seed are observed evidence, not a provider
+// contract. That makes them only as good as the bodies they were derived from,
+// so these replay the real provider bodies the seed cites through the current
+// evaluator against the shipped record itself. A synthetic record would prove
+// the evaluator works; only the shipped record proves the *seed* works.
+//
+// These are behavior fixtures, not a provider parser: nothing here teaches the
+// production tooling a provider-specific string.
+
+const REPLAY_TARGET = "abcdef1234567";
+const REPLAY_CAPTURED = "2026-09-05T00:00:00.000Z";
+const REPLAY_OBSERVED = "2026-09-05T02:13:28.000Z";
+
+function replayEvidence(comments) {
+  const fetched = (items = []) => ({ fetch_status: "fetched", items });
+  return {
+    repo: "org/repo",
+    pull_number: 88,
+    generated_at: REPLAY_CAPTURED,
+    pr_metadata: { fetch_status: "fetched", head_sha: REPLAY_TARGET },
+    surfaces: {
+      conversation_comments: fetched(comments),
+      review_submissions: fetched(),
+      inline_review_comments: fetched(),
+      review_threads: fetched(),
+    },
+  };
+}
+
+// One conversation comment from `actor`, which is how every body replayed here
+// was actually observed.
+function replayState(reviewerId, actor, body) {
+  const seed = JSON.parse(readFileSync(path.join(root, "templates", "reviewers.example.json"), "utf8"));
+  const evidence = replayEvidence([
+    {
+      id: 1,
+      actor,
+      actor_database_id: "9001",
+      actor_node_id: "ACTOR-9001",
+      body,
+      created_at: REPLAY_OBSERVED,
+      updated_at: REPLAY_OBSERVED,
+      locator: "conversation-1",
+    },
+  ]);
+  return evaluateReviewerTargetStates(evidence, {
+    record: seed,
+    reviewerId,
+    target: { sha: REPLAY_TARGET },
+    runAnchor: { after: REPLAY_CAPTURED },
+  }).reviewer_states[0];
+}
+
+function acceptedSignalKinds(state) {
+  return state.observed_signals.filter((signal) => signal.accepted).map((signal) => signal.kind);
+}
+
+test("the observed Codex quota notifications replay as rate-limited, not as completion", () => {
+  // Verbatim bodies from stage-tracker PR #327 (#issuecomment-5548663119 and
+  // #issuecomment-5548663539) and PR #325 (#issuecomment-5548636047). The
+  // second sentence differs between the cloud-task and code-review variants,
+  // and neither string is a prefix of the other, which is why the seed lists
+  // both rather than the shorter one alone.
+  const bodies = [
+    "You have reached your Codex usage limits. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).",
+    "You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).\nTo continue using code reviews, you can upgrade your account or add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review).",
+  ];
+
+  for (const body of bodies) {
+    const state = replayState("codex", "chatgpt-codex-connector[bot]", body);
+    assert.equal(state.state, "rate-limited", `quota notification must be machine-detectable: ${body.slice(0, 48)}`);
+    // The failure this guards is the one that silently passes a fence: a quota
+    // notice converted into a clean review with zero findings.
+    assert.notEqual(state.state, "completed@target");
+    assert.ok(
+      !acceptedSignalKinds(state).includes("completion"),
+      "a quota notification must not also register as completion evidence",
+    );
+  }
+
+  // Neither quota string may be matched by the *shorter* marker alone, which is
+  // what makes listing both non-redundant rather than belt-and-braces.
+  const codex = JSON.parse(
+    readFileSync(path.join(root, "templates", "reviewers.example.json"), "utf8"),
+  ).reviewers.find((reviewer) => reviewer.id === "codex");
+  assert.ok(!bodies[1].includes("You have reached your Codex usage limits."));
+  assert.deepEqual(codex.rate_limit_marker.any_of, [
+    "You have reached your Codex usage limits.",
+    "You have reached your Codex usage limits for code reviews.",
+  ]);
+});
+
+test("a Codex review result still completes at target after the quota marker was added", () => {
+  // Regression guard for the added rate_limit_marker: a real result must not
+  // start resolving as rate-limited.
+  const state = replayState(
+    "codex",
+    "chatgpt-codex-connector[bot]",
+    `**Reviewed commit:** ${REPLAY_TARGET}\n\nNo issues found.`,
+  );
+  assert.equal(state.state, "completed@target");
+});
+
+test("both observed CodeRabbit result bodies replay as positive completion evidence", () => {
+  // The 0-finding body is the one Issue #88 adds: observed on stage-tracker
+  // PR #290 (#issuecomment-5511416364) as a conversation comment rather than a
+  // review submission. The seed records that this body was seen, not that this
+  // surface is where CodeRabbit always posts.
+  const zeroFindings = replayState(
+    "coderabbitai",
+    "coderabbitai[bot]",
+    "No actionable comments were generated in the recent review. \u{1F389}\n\n<details>\n<summary>Pre-merge checks</summary>\n\nDocstring Coverage: warning\n\n</details>",
+  );
+  assert.ok(
+    acceptedSignalKinds(zeroFindings).includes("completion"),
+    "a 0-finding CodeRabbit run must register as completion evidence, not as silence",
+  );
+
+  // The pre-existing path must keep resolving exactly as before.
+  const withFindings = replayState(
+    "coderabbitai",
+    "coderabbitai[bot]",
+    "Actionable comments posted: 3\n\n<details>\n<summary>Review details</summary>\n</details>",
+  );
+  assert.ok(
+    acceptedSignalKinds(withFindings).includes("completion"),
+    "the existing Actionable-comments path must not regress",
+  );
+
+  // CodeRabbit declares no target_pattern, so neither body binds itself to a
+  // commit. That is unchanged by this Issue and is why the added marker cannot
+  // manufacture a `completed@target` for an advisory reviewer.
+  for (const state of [zeroFindings, withFindings]) {
+    assert.notEqual(state.state, "completed@target");
+    assert.ok(state.reason_codes.includes("target_binding_missing"));
+  }
+});
+
+test("the Claude completion and in-flight behavior is unchanged by the notes correction", () => {
+  const completed = replayState(
+    "claude",
+    "claude[bot]",
+    `**Claude finished @reitojike's task**\n\nLooks good.\n\nReviewed commit: ${REPLAY_TARGET}`,
+  );
+  assert.equal(completed.state, "completed@target");
+
+  const working = replayState("claude", "claude[bot]", "Claude Code is working on this…");
+  assert.equal(working.state, "in-flight");
 });


### PR DESCRIPTION
Refs #88

## 目的

`templates/reviewers.example.json` を seed source として、stage-tracker の real PR で
実測済みの reviewer/provider evidence を Foundation の reviewer capability seed へ
反映します。

これは provider behavior を Foundation core rule へ昇格する変更では**ありません**。
`reviewer-capability-record@1` が明示する **observed evidence の seed 更新**に限定して
います。Review Protocol semantics、reviewer state evaluator、merge-ready fence、
fallback policy、provider parsing architecture はいずれも変更していません。

## 変更内容

### A. Codex — quota notification を rate-limited として machine 判定可能にする

`codex.rate_limit_marker` は seed では `null` のままでしたが、stage-tracker #328 で
実測した 2 文字列を `any_of` へ追加しました。

- `You have reached your Codex usage limits.`
- `You have reached your Codex usage limits for code reviews.`

後者の本文には `You have reached your Codex usage limits.`（末尾ピリオド付き）が
含まれないため、前者は後者の prefix になりません。したがって片方だけでは両方を
捕捉できず、実観測どおり 2 文字列を列挙しています。

quota notification は **non-success state** です。`completed@target` や clean review /
0 findings へ変換していません。fallback order・reviewer selection policy も変更して
いません。

Canonical evidence:
- reitojike/stage-tracker#328
- stage-tracker PR #327 #issuecomment-5548663119 / #issuecomment-5548663539
- stage-tracker PR #325 #issuecomment-5548636047

### B. CodeRabbit — finding 0 件 run の completion marker

`coderabbitai.completion_marker.any_of` へ
`No actionable comments were generated in the recent review.` を追加しました。
既存の `Actionable comments posted:` は維持しています。

notes は、finding 0 件 run が review submission ではなく conversation comment surface で
観測されたという事実を最小限記録するに留めました。「CodeRabbit は常に conversation
comment に結果を出す」「finding 有り run は常に review submission になる」といった
**surface 固定の negative claim は追加していません**。むしろ surface は再検証対象として
扱う旨を記述しています。`result_surfaces` 等の schema 拡張も行っていません。

Canonical evidence:
- stage-tracker #270 / PR #290（#issuecomment-5511416364、#issuecomment-5511697863）

### C. Claude — evidence metadata の訂正のみ

marker / actors の値は変更していません。seed に残っていた「この entry の actors と
marker は未実測」という古い notes を、real PR の run で実測済みという current evidence へ
更新しました。

`observed_at` は既に実測日と一致していたため据え置きです（canonical evidence comment は
2026-09-02 付で、stage-tracker consumer record の claude entry も `2026-09-02` です）。
不要な値変更を避ける方針に従いました。

Claude mention workflow は consumer repository が個別に用意するという既存境界は維持し、
Foundation からの workflow 配布は行っていません。

## synchronization

current tooling の sync ownership を fresh 確認しました。`tooling/sync.mjs` は reviewer
record を consumer へ materialize せず、`tooling/check.mjs` は consumer record の
presence/parse/validity のみを検査します（contents は consumer-owned）。

Foundation-maintained な 2 copy については、
`test/reviewer-capability-record.test.mjs` の
"the two Foundation-maintained record instances stay identical to the example" が
example との byte-identical を強制しています。これが正規の sync ownership なので、
3 ファイルを独立編集せず、seed を編集して残り 2 つへ byte-identical に複製しました。

## behavior fixture

実 provider body を **shipped seed 経由で**現行 evaluator へ replay する test を
`test/reviewer-capability-record.test.mjs` へ追加しました。synthetic record では
evaluator の動作しか証明できないため、shipped record 自体を使っています。

production tooling への provider-specific parser 追加は行っていません。

| replay | 結果 |
| --- | --- |
| Codex quota 2 文字列 | `rate-limited`（`completed@target` にならず、completion signal も立たない） |
| Codex 実 review 結果 | `completed@target`（marker 追加による regression なし） |
| CodeRabbit 0-finding body | completion signal accepted |
| CodeRabbit `Actionable comments posted:` | completion signal accepted（regression なし） |
| Claude completion / in-flight | `completed@target` / `in-flight`（変化なし） |

CodeRabbit は `target_pattern` を宣言していないため、どちらの body も commit へ bind せず
`target_binding_missing` になります。これは従来どおりで、今回追加した marker が advisory
reviewer に `completed@target` を作り出さないことを意味します。

## verification

- `npm test`: 268 tests / 267 pass / 0 fail / 1 skipped（skip は base と同じ既存 skip。
  base は 264/263/0/1）
- `npm run test:guardrails`: Verified 8 guardrail fixtures
- `npm run check:fixture`: green
- reviewer record validation: green（seed / Foundation-owned record / consumer fixture の
  3 つとも schema OK かつ byte-identical）
- formatting: reviewer record 3 ファイルは prettier clean。JS test file は repo 既存 style に
  一致（Foundation の JS は prettier 管理下になく、base の同ファイルも同様に非準拠）
- `git diff --check`: clean

## Out of Scope（未着手であることの確認）

`policy/core.md` の Review Protocol、reviewer state evaluator、merge-ready fence、
provider-specific production parser、reviewer capability schema v2、generic provider
DSL / registry、retry scheduler / fallback executor、required reviewer count /
provider diversity、fallback order、Claude workflow 配布、CodeRabbit CI、
stage-tracker 側 record、safe-base-drift / review carry-forward、#70 / #71、
v0.5.0 tag / release — いずれも変更していません。

changed files は以下 4 つのみです。

- `templates/reviewers.example.json`
- `.ai-dev-foundation/reviewers.json`
- `test/fixtures/consumer/.ai-dev-foundation/reviewers.json`
- `test/reviewer-capability-record.test.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Codex usage-limit notifications so they are handled as rate limits rather than completed reviews.
  - Codex review results continue to be recognized correctly after rate-limit handling.
  - Improved detection of CodeRabbit completion results for both actionable findings and zero-finding reviews.
  - Confirmed Claude completion and in-progress behavior through real review scenarios.

- **Tests**
  - Added coverage for observed provider messages and review outcome handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->