### PR TITLE
chore: v0.5.0 release preparation — version bump と release evidence を確定する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-dev-foundation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-foundation",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-dev-foundation",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "sync:fixture": "node tooling/sync.mjs --consumer test/fixtures/consumer",


### PR DESCRIPTION
## Release v0.5.0 準備（version bump / release evidence）

Refs #90

本 PR は **v0.5.0 release preparation** であり、変更は version-bearing artifact の
`0.4.0` -> `0.5.0` bump のみです。Foundation semantics / dependency / generated artifact は
一切変更していません。release delta の実体は、この PR より前に main へ land 済みの
46 commit です。

`v0.5.0` tag の作成、GitHub Release object の作成、stage-tracker repin は本 PR の scope 外です。

---

## Release boundary

| 項目 | 値 |
| --- | --- |
| frozen semantic/content baseline | `8e43daa77f48e819268d4e87d6c83db35081bfb4` |
| v0.4.0 release commit | `245625d3458a86925e2c0c907bd7f83213c8a1e0`（annotated tag object `706ba5db`） |
| `v0.4.0...baseline` | ahead 46 / behind 0 |
| baseline の changed files | 30 files, +7500 / -1453 |
| final candidate SHA | `f46cb5726e2881edc3e3a65e6a2c6684928bab0c` |
| base branch tip（freeze 時点） | `8e43daa77f48e819268d4e87d6c83db35081bfb4` |
| pre-existing `v0.5.0` tag | なし（local / remote いずれも。remote tags は v0.1.0 / v0.2.0 / v0.3.0 / v0.4.0 のみ） |
| GitHub Release object | 0 件（既存運用に無いため本 Task でも導入しない） |

freeze 開始時の fresh state（current main / open PR 0 / tags / `v0.4.0...main` / package version）は
planning-time の想定と一致しており、baseline 以降に release preparation 以外の semantic change は
land していません。

---

## Exact changed files（本 PR）

```text
package.json        1 行（"version"）
package-lock.json   2 行（root "version" と packages[""] の "version"）
```

2 files / 3 insertions / 3 deletions。dependency 更新、formatting churn、semantic change は含みません。

---

## Why v0.5.0（minor release rationale）

- **consumer-visible な新 contract を追加した**: `.ai-dev-foundation/reviewers.json`
  （reviewer capability record）が Selection Contract の参照先として Kernel から要求され、
  `tooling/check.mjs` の pass 条件に加わった。v0.4.0 の consumer が repin すると
  `check` の判定が厳格化する。
- **consumer-visible な新 entrypoint を追加した**: `tooling/merge-ready-fence.mjs`、
  および `tooling/review-evidence.mjs` の `--state` 系 flag。
- 一方で、`sync` の出力 path、generated adapter の形式、quality profile bootstrap の contract は
  互換であり、major を要求する破壊的再設計ではない。private package であり public API surface を持たない。

patch-level bugfix の集合ではなく、Review Protocol の operability と deterministic
enforcement を前進させる minor release です。

---

## Release delta classification（`v0.4.0...8e43daa7` を fresh 照合）

### A. Review Protocol Phase 1 / 1b — reviewer capability record と target-bound completion state

- **consumer-owned reviewer capability record を導入**（新規）
  - `templates/reviewers.example.json`（seed / template）
  - `.ai-dev-foundation/reviewers.json`（Foundation 自身を consumer として扱う copy）
  - `test/fixtures/consumer/.ai-dev-foundation/reviewers.json`（reference consumer copy）
  - 3 copy は byte-identical に維持され、drift は `test/reviewer-capability-record.test.mjs` が禁止する。
- **`tooling/reviewer-record-lib.mjs`（新規）** — schema `ai-dev-foundation/reviewer-capability-record@1`。
  `completion_marker` は必須。`result_surfaces` / marker の `surfaces` / marker の `target_field` は
  provider 応答形式の決め打ち（Review Adapter boundary が禁じる negative claim）であるため schema が reject する。
  top-level に `required_selection`（必須）と `durable_record`（`new-comment-per-stage` のみ supported）を持つ。
- **`policy/core.md` Selection Contract の変更** — reviewer を required / configured automatic / advisory の
  いずれとして宣言するかの置き場所を「consumer product rules または当該 Task の Selection 記録」から
  **consumer-owned reviewer capability record** へ移した。Kernel は record の存在と Selection 時の参照を
  要求し、schema / template / check は Foundation tooling が所有する。record 内容は consumer-owned のまま。
  record は portfolio 上の default であり、当該 Task の required / expected obligation の正本ではない
  （それは従来どおり Selection Contract が確定する）。
- **`tooling/check.mjs`** — record の presence / parse / 最小妥当性を検証し、missing / invalid なら non-zero。
  併せて `policy/core.md`・`skills/*.md`・生成 `AGENTS.md` の byte size を **advisory**（threshold なし、
  exit code に影響しない）として stdout へ出力する。
- **target-bound reviewer completion state evaluator（新規 `tooling/review-evidence-state-lib.mjs`）** —
  `completed@target` / `not-bound` / `rate-limited` / `failed` / `declined` / `in-flight` / `unknown`。
  `completed@target` は current target への構造化または explicit な binding があり、かつ snapshot coverage が
  complete な場合に限る。
- **durable cross-surface evidence の canonicalization（`tooling/review-evidence-lib.mjs`）** —
  canonical object は `review` / `review_comment` / `conversation_comment` の 3 種。GitHub の stable object ID を
  先に使って REST / GraphQL の projection を canonicalize し、各 object は current body / `updated_at` /
  body digest / actor stable ID / ownership / binding candidates / `{surface, surface_id}` の sources を持つ。
  GraphQL review thread は child comment の source・`thread_id` としてのみ保持する。履歴は保存しない。
- **fail-safe reviewer lifecycle** — silence / preamble / acknowledgement / 空 snapshot / fetch incomplete を
  0 findings や failure へ変換しない。`unknown` と `in-flight` は terminal failure ではない。
  quota / rate limit は success へ潰さない。
- **`tooling/review-evidence.mjs` の invocation 拡張** —
  `--state` / `--target-sha` / `--run-after` / `--run-anchor-id` / `--reviewer` / `--record` を追加。
- **Foundation-owned skill から provider 固有の routing 記述を除去** — v0.4.0 の
  `skills/review-code.md` にあった「Claude formal acquisition routing」「Manual review pilot」
  「Manual-on-demand review runtime preference（Issue #59）」の各節を削除し、その決定
  （どの reviewer が required / advisory か、どの acquisition route を使うか、unavailable なら何が起きるか）を
  consumer-owned な reviewer capability record へ移した。`skills/review-code.md` 内の provider 名の
  出現は 24 箇所から 3 箇所へ減り、残る 3 箇所は Issue #49 の preflight/local 境界
  （「この区別は Claude に限らず、他 provider の local/preflight 利用にも同様に適用します」と
  明示的に一般化されている箇所）のみ。`skills/review-doc.md` からも「Claude formal acquisition
  routing」節への参照が外れ、reviewer capability record 節と Adapter boundary 節への参照へ
  置き換わった。**この決定自体は失われておらず**、machine-readable な home へ移動している
  （`test/review-runtime-preference.test.mjs` が record 側でこれを固定している）。

### B. Review Protocol Phase 2 — deterministic merge-ready fence と responsibility split

- **`tooling/merge-ready-fence.mjs`（新規 CLI）と `tooling/merge-ready-fence-lib.mjs`（新規）** —
  merge-ready 宣言直前に 1 回実行する deterministic checker。CLI 引数として渡された frozen 宣言と、
  **1 回の fresh acquisition** で得た fact だけを照合する。snapshot file を引数に取らないことが、
  会話内で見た evidence を渡す経路が存在しないことの構造的保証。
- **10 check**: `target-head` / `target-base` / `artifact-set` / `skill-routing` /
  `reviewer-completion` / `result-revision-coherence` / `acquisition-coverage` /
  `review-threads` / `verify-coherence` / `autoclose-hygiene`。
  集約規則は「1 つでも `fail` があれば `fail`、無ければ 1 つでも `unknown` があれば `unknown`、全部 `pass` なら `pass`」。
  exit code は `pass` = 0 / `fail` = 1 / `unknown` = 2。**setup error は stdout 出力を伴わない exit 2** として
  `fail`（fence が到達した判定）と区別する。GitHub API failure は setup error ではなく、
  `acquisition-coverage` が `unknown` になる経路へ落ちる。
- **artifact classification / required skill routing を code へ移管** —
  changed artifact set から required skill を導出する判定を agent の自己申告に委ねず、
  Foundation-owned な deterministic checker が導出して Selection の宣言と照合する。
  path から class を確実に導出できない artifact を勝手に class 化せず unresolved として報告する。
- **`policy/core.md` Merge-ready completion fence の再構成** — 従来の手順 1〜7 の散文を
  「1. machine-checkable な precondition（Foundation-owned checker が所有）/ 2. semantic judgment
  （finding の意味と triage、Resolution の完了、expected review set 各 member の review obligation。agent が所有）」
  という responsibility split へ書き換えた。**checker の `pass` は merge-ready の成立ではない**ことを明記。
- **triage した review result の revision を判断対象に追加**（Acquisition & Validity Contract）—
  review result は in-place で編集され得るため、triage / Resolution の対象とした result の revision が
  判断時点の current revision と同一であることを確認する。異なる場合は「まだ triage されていない result」として扱う。
  これを `result-revision-coherence` check が機械照合する。
- **Review stopping rules から deterministic な照合手順を削除** — target / range / artifact set の drift と、
  precondition evidence が確定した target SHA を指しているかは checker が機械判定する。
  checker が判定しない「precondition check がどの artifact scope を対象としたか」の確認は agent が行う、と境界を明記。
- **Skill routing contract の統合** — `#### Mixed-classification review target` の独立 section を
  Skill routing contract 本体へ折り込み、mixed target で該当 classification すべての skill を load する MUST を維持。
- **skill 側の縮小と手順の実体化** —
  `skills/review-code.md` 35,706 -> 30,789 bytes（deterministic 判定を fence へ移し、Happy path を
  run anchor / acknowledged revision を運ぶ 9 step へ）。
  `skills/review-doc.md` 13,422 -> 16,055 bytes（no-fix branch でも merge-ready fence を必須化し、
  fence 実行例と run anchor の受け渡しを追加）。
  `policy/core.md` 54,609 -> 55,853 bytes。

### C. consumer validation から入った correctness corrections

- **#82 target-base correction** — `target-base` を PR snapshot の base SHA ではなく
  **base branch の現在の tip** で判定する。`base_branch` surface を `tooling/review-evidence-lib.mjs` へ追加
  （v0.4.0 には存在しない surface）。base ref の読み取り失敗は実 failure として surface 単位に報告する。
- **#83 classifier / skill-routing correction** — 既知 artifact を classifier で resolve し、
  under-routing を machine 検出可能にする。併せて Normative path segment を **whole-segment 照合**へ変更し、
  `docs/software-architecture/notes.md` や `mypolicy/core.md` を substring 一致で Normative と誤判定しないようにした。
- **#86 / #87 `.css` classification** — `.css` を Executable extension として machine-resolve する。
  `.module.css`（CSS Modules）も `extensionOf()` が最終 `.` セグメントを取るため同じ経路で resolve され、
  compound-extension 用の別 rule を必要としない。
- **#76 系の fence / evaluator correctness** — fence CLI の setup error を verdict と区別、
  mandatory skill set を表から導出、review thread の GraphQL query が Actor interface で `id` 選択に失敗する不具合、
  短縮 claim を介して異なる full SHA を同一視しない、target claim を抽出時に正規化し生の長さで代表 claim を選ばない。
- **#78 / #79 / #80** — review-doc の no-fix branch が fence 前に review completion を宣言しないようにし、
  regression guard の正規表現が禁止文言に一致しない問題を修正。fence 例が run anchor を欠落させない記述へ。
- **review session の scratch file を target artifact set から除く運用修正**。
- **stage-tracker real PR による consumer validation** — Canary A および natural Mixed Canary B を実 PR で通し、
  上記 correction 群はその実測から入っている。

### D. #88 reviewer seed evidence の currentization

`templates/reviewers.example.json` を seed source として、stage-tracker の real PR で実測した
observed evidence へ更新した（Foundation core / tooling の semantics は変更していない）。

- **Codex** — quota 上限時に観測した 2 文字列
  `You have reached your Codex usage limits.`（cloud task 側）と
  `You have reached your Codex usage limits for code reviews.`（code review 側）を
  `rate_limit_marker.any_of` へ実観測どおり列挙。前者は後者の prefix にならないため両方を列挙する。
  これは non-success state であり completion / 0 findings へ変換しない。`observed_at` は 2026-09-05。
- **CodeRabbit** — actionable finding 0 件の run が review submission ではなく conversation comment
  （冒頭 `No actionable comments were generated in the recent review.`）として観測されたため、
  同文字列を `completion_marker.any_of` へ追加。既存の `Actionable comments posted:` は維持。
  surface を固定する negative claim は追加していない。`observed_at` は 2026-09-03。
- **Claude** — marker / actors は変更せず、「actors と marker は未実測」という古い notes を
  real PR で実測済みという current evidence へ更新。`observed_at` は 2026-09-02。
- 実 provider body を **shipped seed 経由で現行 evaluator へ replay する behavior fixture** を追加。
  production tooling へ provider-specific parser は追加していない。

### E. Artifact classification の consumer-visible 追記

`policy/core.md` の Informational に、PNG / JPEG 等の **raster image asset** を
product asset か documentation image かを問わず含めることを明記した
（open-ended AI review が読む text semantics を持たず、この性質は用途で変わらないため）。
SVG は text であり実行され得る内容を持ち得るため raster image に含めない。

### F. Generated / fixture impact

- `test/fixtures/consumer/AGENTS.md`（generated）— policy 変更に追随。
- `test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md` と `review-doc.md` — skill bundle に追随。
- 新規 test: `test/merge-ready-fence-lib.test.mjs`（1,110 行）、
  `test/review-evidence-state.test.mjs`（881 行）、`test/reviewer-capability-record.test.mjs`（516 行）。
- 既存 test の更新: `agent-rules-check` / `claude-review-acquisition-routing` /
  `foundation-change-and-merge-authority` / `merge-ready-fence` / `migration-version-collision` /
  `review-evidence` / `review-protocol` / `review-runtime-preference` / `sync-check` / `task-protocol`。

### deterministic fact と semantic judgment の責務分割（明示）

- **deterministic fact -> mechanism / checker**: target / base / artifact-set の drift、
  skill routing の導出と照合、reviewer の target completion state、acquisition coverage、
  triage 対象 result の revision 同一性、unresolved review thread の有無、
  deterministic verify target との一致、auto-close hygiene。
- **semantic judgment -> agent**: finding の意味付けと triage、Resolution の完了、
  expected review set 各 member の review obligation の充足、merge authority。
- **provider-specific behavior** は reviewer capability record の observed evidence
  （marker / actors / `observed_at` / notes）にのみ置き、core / tooling へ hard-code していない。
  production tooling に provider-specific parser は存在しない。

---

## Version bump

| artifact | before | after |
| --- | --- | --- |
| `package.json` の `version` | `0.4.0` | `0.5.0` |
| `package-lock.json` root の `version` | `0.4.0` | `0.5.0` |
| `package-lock.json` の `packages[""]` の `version` | `0.4.0` | `0.5.0` |

machine 確認: `package.json` / lockfile root / lockfile `packages[""]` の 3 箇所すべてが `0.5.0`、
`name` は 3 箇所一致、`devDependencies` は package.json と lockfile で identical。
`npm pkg get version` は `"0.5.0"`。tracked file に残る `"version": "0.4.0"` は
`package-lock.json:1579` の transitive dependency `type-check@0.4.0` のみで、本 project の version ではありません。

`package.json` の `scripts` と `devDependencies` は v0.4.0 から一切変更していません。

---

## Verification（final candidate `f46cb5726e2881edc3e3a65e6a2c6684928bab0c`）

Node.js v24.18.0 / npm 11.16.0、`npm ci` 済みの clean checkout で実行。

| check | 結果 |
| --- | --- |
| `npm test` | **pass** — tests 268 / pass 267 / fail 0 / skipped 1（下記 limitation 参照）。末尾で `test:guardrails` も実行され `Verified 8 guardrail fixtures.` |
| `npm run test:guardrails` | **pass** — `Verified 8 guardrail fixtures.` |
| `npm run check:fixture` | **pass**（exit 0）— `Generated adapters, quality profile, skill bundle, and reviewer capability record are current` |
| `npm run test:client-role-table-privileges-guardrail` | **pass** — tests 13 / pass 13 / fail 0 / skipped 0。実 PostgreSQL runtime に対して実行済み（MAINTAIN が version-gated に明示 skip されクラッシュしないことも確認） |
| reviewer capability record validation | **pass** — `check:fixture` が presence / parse / 最小妥当性を検証。`test/reviewer-capability-record.test.mjs` の unit / behavior fixture も green |
| Foundation-maintained reviewer records の sync | **pass** — `.ai-dev-foundation/reviewers.json` / `templates/reviewers.example.json` / `test/fixtures/consumer/.ai-dev-foundation/reviewers.json` の md5 が 3 者一致（`7efae44f20bcd82e070e3aad0923f217`） |
| generated consumer artifacts currentness | **pass** — `check:fixture` が `AGENTS.md` / `CLAUDE.md` / quality profile の drift なしを確認 |
| Foundation-owned skill bundle currentness | **pass** — `check:fixture` の skill bundle drift 検知 green。`diff -r skills test/fixtures/consumer/.ai-dev-foundation/skills` も差分なし |
| `git diff --check` | **pass** — `v0.4.0..HEAD` と `HEAD~1..HEAD` のいずれも exit 0、whitespace error なし |
| formatting / static check | repository root に lint / format の npm script も eslint / prettier config も存在しない（eslint / prettier config は consumer 配布用の `profiles/next-supabase/quality/` 配下にのみ存在）。参考として default 設定の `npx prettier --check package.json package-lock.json` を実行し `All matched files use Prettier code style!`（exit 0） |
| `npm ci` 再検証（bump 後） | **pass** — 124 packages / 0 vulnerabilities。lockfile と package.json の整合を確認 |
| working tree | clean（`git status --porcelain` が空） |

advisory な artifact size（`check` の出力。threshold なし / exit code に影響しない）:
`policy/core.md` 55,853 B / `skills/review-code.md` 30,789 B / `skills/review-doc.md` 16,055 B /
生成 `AGENTS.md` 58,012 B / total 160,709 B。

---

## Compatibility / invocation notes

- **repin 時に consumer 側の対応が必要（最重要）** — v0.5.0 では
  `node tooling/check.mjs --consumer <path>` が `.ai-dev-foundation/reviewers.json` の
  presence / parse / 最小妥当性を要求します。この record は **consumer-owned であり
  `sync` / `bootstrap` は配布しません**。record を持たない consumer が v0.5.0 へ repin すると
  `check` は non-zero で終了します。移行手順:

  ```text
  cp templates/reviewers.example.json <consumer>/.ai-dev-foundation/reviewers.json
  ```

  を実行し、その repository の実測に合わせて編集してください。
- **新 entrypoint** — `node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> ...`。
  npm script は追加していません（`package.json` の scripts は v0.4.0 から不変）。
- **`tooling/review-evidence.mjs` の後方互換** — 既存の human-readable summary と `--json` の
  挙動は変わりません。`--state` 系 flag は追加のみです。
- **`check` の stdout 追加** — artifact size の advisory 行が増えますが exit code には影響しません。
- **Claude の mention trigger workflow** — review 対象 repository が個別に用意する必要があり、
  Foundation は配布しません（record の notes に記載済み）。workflow が無い repository では
  この trigger は unavailable であり、`fallback_order` に従います。
- `sync` の出力 path、generated adapter の形式、quality profile bootstrap の contract に
  破壊的変更はありません。dependency 更新もありません。

---

## Known non-blocking limitations / deferred items

- **review-evidence snapshot の既知 coverage 限界**（README に明記済み。v0.5.0 で解消していない）:
  `commit_status` / `check_runs` は snapshot 取得時点の PR head のみを対象とし ancestor SHA を含まない。
  `check_runs` は GitHub API の既定 filter（`latest`）を使い、`output.summary` / annotation /
  投稿元 App 情報を保持しない。`commit_status` は combined-status endpoint を使うため
  同一の `(headSha, context)` について上書き前の status を復元できず、この欠落は
  `fetch_status` の値だけでは検知できない。
- **symlink test の platform skip** — `test/migration-version-collision.test.mjs` の
  「a migration file that exists only as a symlink is still scanned」は Windows 上で
  `EPERM: symlink creation not permitted on this platform` により SKIP されます。
  pre-existing な platform 制約であり、本 release delta による regression ではありません
  （上記 `npm test` の skipped 1 はこれです）。
- **provider marker は observed evidence であり恒久仕様ではない** — record の marker と
  `observed_at` は実測時点の値です。実挙動と食い違った場合は待たず record を更新します
  （`policy/core.md` の Observed evidence is not a permanent provider rule）。

### v0.5.0 に **含まれない** もの（未実装。release 済みとして記述しません）

- **#70** — post-review verification で見つかった bounded correction を targeted closure で扱う条件の定義。**未 land であり v0.5.0 に含まれません。**
- **#71** — Review Protocol への change envelope（bounded change）軸の追加。**未 land であり v0.5.0 に含まれません。**
- **safe-base-drift** — 安全な base drift の許容判定。**未実装であり v0.5.0 に含まれません。**
  v0.5.0 の `target-base` check は base branch の現在の tip との**厳密一致**のみを判定し、drift を許容しません。
- **review carry-forward** — target 移動をまたぐ review evidence の持ち越し機構。**未実装であり v0.5.0 に含まれません。**
- **新しい reviewer selection redesign** — **未実装であり v0.5.0 に含まれません。**
- 上記はいずれも future improvement として defer します。

### 本 Task の scope 外（実施していないこと）

- `v0.5.0` git tag の作成（PR land 後に authority holder が merged main を fresh 確認して annotated tag を作成）
- GitHub Release object の作成（repository の既存運用に存在しないため導入しない）
- CHANGELOG / release-notes framework の新規導入（本 PR body と durable evidence で足りるため作成しない）
- stage-tracker repin、consumer smoke / canary の再実施
- PR merge、Issue #90 の close

---

## Review target

本 PR の review は version bump の 3 行だけでなく、**v0.5.0 として freeze する release delta 全体の
integrity**（semver / lockfile 整合、release notes の欠落と過大主張、generated / fixture 整合、
reviewer seed の currentness、scope 外 change の混入、未実装 future feature を release 済みと
誤記していないか）を対象とします。

target artifact set:

```text
package.json
package-lock.json
```

artifact classification: **Executable**（`.json`）/ required skill: `review-code`。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
