### PR TITLE
fix: CodeRabbit rate_limit_marker を real terminal evidence に限定する

### DIFF
--- a/.ai-dev-foundation/reviewers.json
+++ b/.ai-dev-foundation/reviewers.json
@@ -85,13 +85,13 @@
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
-        "any_of": ["Review rate limited", "0 remain"]
+        "any_of": ["Review rate limited"]
       },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-03",
-      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-05",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。included review 枠は 1 件/時と実測されているため、rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。rate limit の terminal evidence は、trigger への返信 comment が `⚠️ Action not completed` と `Review rate limited.` を含み review 自体が実行されない形で実測した。一方、review が正常完了した 0-finding result の本文には `**Included review availability:** Your plan provides up to 1 included review per hour; 0 remain after this review.` という残枠表示が含まれることを実測した。これは review 実行後の availability 表示であって terminal rate limit ではない。したがって bare `0 remain` を rate_limit_marker に置くと成功 result が completion と rate-limited の両方へ一致し、state が conflicting_signals へ倒れるため、rate_limit_marker には terminal 実測の `Review rate limited` だけを置く。"
     }
   ]
 }

--- a/templates/reviewers.example.json
+++ b/templates/reviewers.example.json
@@ -85,13 +85,13 @@
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
-        "any_of": ["Review rate limited", "0 remain"]
+        "any_of": ["Review rate limited"]
       },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-03",
-      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-05",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。included review 枠は 1 件/時と実測されているため、rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。rate limit の terminal evidence は、trigger への返信 comment が `⚠️ Action not completed` と `Review rate limited.` を含み review 自体が実行されない形で実測した。一方、review が正常完了した 0-finding result の本文には `**Included review availability:** Your plan provides up to 1 included review per hour; 0 remain after this review.` という残枠表示が含まれることを実測した。これは review 実行後の availability 表示であって terminal rate limit ではない。したがって bare `0 remain` を rate_limit_marker に置くと成功 result が completion と rate-limited の両方へ一致し、state が conflicting_signals へ倒れるため、rate_limit_marker には terminal 実測の `Review rate limited` だけを置く。"
     }
   ]
 }

--- a/test/fixtures/consumer/.ai-dev-foundation/reviewers.json
+++ b/test/fixtures/consumer/.ai-dev-foundation/reviewers.json
@@ -85,13 +85,13 @@
       },
       "non_participation_marker": null,
       "rate_limit_marker": {
-        "any_of": ["Review rate limited", "0 remain"]
+        "any_of": ["Review rate limited"]
       },
       "failure_marker": null,
       "in_flight_marker": null,
       "fallback_order": [],
-      "observed_at": "2026-09-03",
-      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。無料枠は 1 件/時のため rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。"
+      "observed_at": "2026-09-05",
+      "notes": "actionable finding がある run では review submission（state=COMMENTED、本文冒頭が `Actionable comments posted: N`）として投稿されるのを実測している。actionable finding が 0 件の run では、review submission ではなく conversation comment（本文冒頭 `No actionable comments were generated in the recent review.`）として結果が観測された。したがって review submission だけを唯一の結果 surface と仮定しない。この対応が今後も固定されるとは限らないため、surface は再検証の対象として扱う。結果 comment は複数 section から成るため、冒頭 1 行だけで finding/warning 無しと判断しない。冒頭が `No actionable comments...` でも、同一 comment 内の Pre-merge checks section に advisory な warning が含まれることがある。trigger への `Action performed` 返信と walkthrough comment も投稿されるが、いずれも完了根拠にしない。advisory member のため completion を待たず、未参加・rate limit でも blocker にしない。ただし到着した finding の triage / Resolution obligation は class に関係なく残る。included review 枠は 1 件/時と実測されているため、rate limit は fallback ではなく advisory 継続の根拠として扱い、復帰を待たない。`success` の commit status が automatic review 無効化による review スキップを表すことがあり、green な status が review 完了ではなく review 未実施を意味する。status の state だけを completion へ変換しない。rate limit の terminal evidence は、trigger への返信 comment が `⚠️ Action not completed` と `Review rate limited.` を含み review 自体が実行されない形で実測した。一方、review が正常完了した 0-finding result の本文には `**Included review availability:** Your plan provides up to 1 included review per hour; 0 remain after this review.` という残枠表示が含まれることを実測した。これは review 実行後の availability 表示であって terminal rate limit ではない。したがって bare `0 remain` を rate_limit_marker に置くと成功 result が completion と rate-limited の両方へ一致し、state が conflicting_signals へ倒れるため、rate_limit_marker には terminal 実測の `Review rate limited` だけを置く。"
     }
   ]
 }

--- a/test/review-runtime-preference.test.mjs
+++ b/test/review-runtime-preference.test.mjs
@@ -49,9 +49,11 @@ test("the reviewer capability record materializes the reviewer portfolio without
     "advisory must not read as permission to ignore the findings that did arrive",
   );
 
-  // Rate limit stays a first-class, detectable state that routes to a fallback
-  // instead of being converted to success or 0 findings.
-  assert.deepEqual(byId.coderabbitai.rate_limit_marker.any_of, ["Review rate limited", "0 remain"]);
+  // Rate limit stays a first-class, detectable state instead of being converted
+  // to success or 0 findings. Which texts are the observed evidence for that
+  // state is owned by the replay fixtures in reviewer-capability-record.test.mjs,
+  // so refreshing an observed marker does not have to be done in two places.
+  assert.ok(byId.coderabbitai.rate_limit_marker.any_of.includes("Review rate limited"));
 
   // Required slot: one slot, filled preferring a different provider family from
   // the implementer, with an explicit successor when the first choice is

--- a/test/reviewer-capability-record.test.mjs
+++ b/test/reviewer-capability-record.test.mjs
@@ -503,6 +503,109 @@ test("both observed CodeRabbit result bodies replay as positive completion evide
   }
 });
 
+// Issue #92: the two bodies below are the real ones observed on stage-tracker.
+// They are the pair that a bare `0 remain` rate-limit marker cannot tell apart,
+// so they are replayed through the evaluator rather than asserted as strings.
+
+// stage-tracker PR #334, comment 5550394802. A review that RAN and found
+// nothing. Its availability footer states the quota left AFTER the review, so
+// it is a success report that happens to contain the digits `0 remain`.
+const CODERABBIT_SUCCESS_BODY = [
+  "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+  "<!-- recent_review_start -->",
+  "",
+  "No actionable comments were generated in the recent review. \u{1F389}",
+  "",
+  "<details>",
+  "<summary>\u2139\uFE0F Recent review info</summary>",
+  "",
+  "**Review profile**: CHILL",
+  "",
+  "**Included review availability:** Your plan provides up to 1 included review per hour; 0 remain after this review.",
+  "",
+  "</details>",
+].join("\n");
+
+// stage-tracker PR #267, comment 5489197879. A review that did NOT run.
+const CODERABBIT_RATE_LIMITED_BODY = [
+  "<!-- This is an auto-generated reply by CodeRabbit -->",
+  "<details>",
+  "<summary>\u26A0\uFE0F Action not completed</summary>",
+  "",
+  "Review rate limited.",
+  "",
+  "> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.",
+  "",
+  "</details>",
+].join("\n");
+
+test("a successful CodeRabbit review is not read as rate-limited because its availability footer says `0 remain`", () => {
+  // The body carries both texts at once, which is the whole difficulty: a
+  // marker wide enough to catch `0 remain` fires on a review that succeeded.
+  assert.ok(CODERABBIT_SUCCESS_BODY.includes("No actionable comments were generated in the recent review."));
+  assert.ok(CODERABBIT_SUCCESS_BODY.includes("0 remain after this review."));
+
+  const state = replayState("coderabbitai", "coderabbitai[bot]", CODERABBIT_SUCCESS_BODY);
+  const kinds = acceptedSignalKinds(state);
+
+  assert.ok(kinds.includes("completion"), "the run completed, so its completion evidence must survive");
+  assert.ok(
+    !kinds.includes("rate-limited"),
+    "an availability footer reporting the quota left after a review is not a rate limit",
+  );
+  // Accepting both is what produced the observed `unknown / conflicting_signals`
+  // on PR #334. The evaluator collapsing that conflict to `unknown` is correct
+  // fail-safe behavior, so the seed is what has to stop raising the conflict.
+  assert.ok(!state.reason_codes.includes("conflicting_signals"));
+
+  // Unchanged by this Issue: CodeRabbit declares no target_pattern, so a
+  // completion still does not bind itself to a commit. The fix must not
+  // manufacture a binding to make the state look better.
+  assert.notEqual(state.state, "completed@target");
+  assert.ok(state.reason_codes.includes("target_binding_missing"));
+});
+
+test("a real CodeRabbit terminal rate limit is still detected after `0 remain` is dropped", () => {
+  // The guard that matters in the other direction: dropping the ambiguous
+  // marker must not cost the detection of a review that never ran.
+  const state = replayState("coderabbitai", "coderabbitai[bot]", CODERABBIT_RATE_LIMITED_BODY);
+  const kinds = acceptedSignalKinds(state);
+
+  assert.equal(state.state, "rate-limited");
+  assert.ok(kinds.includes("rate-limited"));
+  assert.ok(
+    !kinds.includes("completion"),
+    "a review that did not run must never register as completion evidence",
+  );
+});
+
+test("the CodeRabbit rate-limit marker carries only the observed terminal text", () => {
+  const coderabbit = JSON.parse(
+    readFileSync(path.join(root, "templates", "reviewers.example.json"), "utf8"),
+  ).reviewers.find((reviewer) => reviewer.id === "coderabbitai");
+
+  assert.deepEqual(coderabbit.rate_limit_marker.any_of, ["Review rate limited"]);
+  // Named explicitly so re-adding the substring has to be a deliberate act with
+  // fresh evidence, not an unnoticed widening.
+  assert.ok(
+    !coderabbit.rate_limit_marker.any_of.some((marker) => CODERABBIT_SUCCESS_BODY.includes(marker)),
+    "no rate-limit marker may appear in the body of a review that succeeded",
+  );
+  assert.ok(
+    coderabbit.rate_limit_marker.any_of.some((marker) => CODERABBIT_RATE_LIMITED_BODY.includes(marker)),
+    "some rate-limit marker must still appear in the body of a review that was refused",
+  );
+
+  // The advisory contract around the marker is untouched by this correction.
+  assert.equal(coderabbit.default_class, "advisory");
+  assert.deepEqual(coderabbit.fallback_order, []);
+  assert.deepEqual(coderabbit.completion_marker.any_of, [
+    "Actionable comments posted:",
+    "No actionable comments were generated in the recent review.",
+  ]);
+  assert.equal(coderabbit.completion_marker.target_pattern, undefined);
+});
+
 test("the Claude completion and in-flight behavior is unchanged by the notes correction", () => {
   const completed = replayState(
     "claude",


### PR DESCRIPTION
## 背景

Refs #92
Refs reitojike/stage-tracker#334
Refs reitojike/stage-tracker#267

v0.5.0 の seed では CodeRabbit の `rate_limit_marker` が次の形だった。

```json
"rate_limit_marker": {
  "any_of": ["Review rate limited", "0 remain"]
}
```

stage-tracker PR #334（comment `5550394802`）の実 run では、CodeRabbit review は
正常に実行され actionable finding 0 件で完了した。その成功 result 本文には
completion marker と同時に availability footer が含まれる。

```
No actionable comments were generated in the recent review. 🎉
...
**Included review availability:** Your plan provides up to 1 included review per hour; 0 remain after this review.
```

この footer は **review 実行後の残枠表示** であって terminal rate limit ではない。
bare `0 remain` がこれに一致するため、同一 result から `completion` と
`rate-limited` の両 signal が accepted され、state が `conflicting_signals` へ倒れていた。

evaluator が conflict を `unknown` へ倒すこと自体は fail-safe として正しいため、
本 PR は state semantics を変更せず、seed 側の marker を実測へ合わせる bounded correction を行う。

terminal rate limit は stage-tracker PR #267（comment `5489197879`）で実測済み。

```
⚠️ Action not completed

Review rate limited.
```

`Review rate limited` は terminal result にのみ現れ、成功 result 本文には含まれない
(`grep -c "Review rate limited"` → PR #334 body: `0` / PR #267 body: `1`)。
よって terminal marker を保持し、曖昧な bare `0 remain` のみを外す。

推測による provider-specific marker の追加は行っていない。

## 変更

| file | 変更 |
| --- | --- |
| `templates/reviewers.example.json` | CodeRabbit `rate_limit_marker.any_of` を `["Review rate limited"]` へ / `observed_at` を `2026-09-05` へ / notes に実測 evidence を追記 |
| `.ai-dev-foundation/reviewers.json` | 同上（byte-identical 同期） |
| `test/fixtures/consumer/.ai-dev-foundation/reviewers.json` | 同上（byte-identical 同期） |
| `test/reviewer-capability-record.test.mjs` | 両 real body を actual evaluator path で replay する behavior fixture を追加 |
| `test/review-runtime-preference.test.mjs` | 同一 marker list を二重に pin していた portfolio assertion を portfolio 水準へ戻す |

### old / new

```diff
-        "any_of": ["Review rate limited", "0 remain"]
+        "any_of": ["Review rate limited"]
```

CodeRabbit entry で維持したもの: `default_class = advisory` / `fallback_order = []` /
completion markers（`Actionable comments posted:` と
`No actionable comments were generated in the recent review.`）/ `target_pattern` 不在。

Codex entry・Claude entry・reviewer portfolio・fallback semantics・advisory semantics は未変更。

### reviewer record 3 copy

`sha256` byte-identical。

```
81d25270cc298cd8d6b1dd06482f27de0addd354632453f8f3b16ad2dbfc5e0e  templates/reviewers.example.json
81d25270cc298cd8d6b1dd06482f27de0addd354632453f8f3b16ad2dbfc5e0e  .ai-dev-foundation/reviewers.json
81d25270cc298cd8d6b1dd06482f27de0addd354632453f8f3b16ad2dbfc5e0e  test/fixtures/consumer/.ai-dev-foundation/reviewers.json
```

## Machine evidence — real body replay

`evaluateReviewerTargetStates()` に stage-tracker から取得した実 body を通した結果。

### 修正前（v0.5.0 seed）

```
### PR#334 success 0-finding
state: unknown
accepted signals: [ 'completion', 'rate-limited' ]
reason_codes: conflicting_signals

### PR#267 terminal rate-limit
state: rate-limited
accepted signals: [ 'rate-limited' ]
reason_codes:
```

### 修正後（final candidate）

```
### PR#334 success 0-finding
state: unknown
accepted signals: [ 'completion' ]
reason_codes: binding_unresolved, target_binding_missing

### PR#267 terminal rate-limit
state: rate-limited
accepted signals: [ 'rate-limited' ]
reason_codes:
```

successful PR #334 body 相当は completion のみ、terminal PR #267 body 相当は
rate-limited のみになり、`conflicting_signals` は解消した。

PR #334 側が `completed@target` にならず `target_binding_missing` を残すのは
本 PR による変化ではない。CodeRabbit は `target_pattern` を宣言しないため
completion が commit へ binding しない既存の semantics であり、
既存 test が従来から assert している内容と一致する。marker 修正で
binding を捏造していないことの確認でもある。

## Verification

| check | 結果 |
| --- | --- |
| targeted replay tests（`reviewer-capability-record` / `review-runtime-preference` / `review-evidence-state`） | pass 61 / fail 0 |
| `npm test` | pass 270 / fail 0 / skipped 1 |
| `npm run test:guardrails` | `Verified 8 guardrail fixtures.` |
| `npm run check:fixture` | generated adapters・quality profile・skill bundle・reviewer capability record すべて current |
| reviewer record 3 copy byte-identical | 一致（上記 sha256） |
| `git diff --check` | clean |

### 既存 replay の regression

| case | 結果 |
| --- | --- |
| CodeRabbit finding あり completion（`Actionable comments posted: 3`） | completion accepted のまま |
| CodeRabbit 0-finding completion | completion accepted のまま |
| Codex quota notification 2 種 | rate-limited のまま |
| Codex 通常 completion | `completed@target` のまま |
| Claude completion / in-flight | 変化なし |

### formatting / static check

このリポジトリは自身の source 用の root Prettier / ESLint config を持たず、
`tooling/verify-guardrails.mjs` の Prettier / ESLint は配布物である
`profiles/next-supabase/quality` と guardrail fixture を対象にする。
applicable な static check は guardrails であり green。

なお stock 設定の `npx prettier --check` は変更した 2 つの test file を warn するが、
これは変更前の `main` でも同一に warn する既存状態であり、本 PR による regression ではない。
gate 対象外の file を再整形する diff は scope 外として持ち込んでいない。

## Scope

`tooling/review-evidence-state-lib.mjs` の state semantics、marker matching engine、
reviewer record schema、`policy/core.md`、`skills/review-code.md` / `review-doc.md`、
provider plugin / registry / DSL、CodeRabbit GitHub 設定、trigger runtime、
advisory semantics、reviewer selection、fallback order、stage-tracker 側 `reviewers.json`、
package version、`v0.5.1` release はいずれも未変更。

seed correction だけで real body を正しく分類できたため、tooling semantics 変更は不要だった。

version bump / tag / consumer repin は #92 の Post-merge sequence として別 Task で扱う。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review status detection so successful reviews showing “0 remain” are not incorrectly classified as rate-limited.
  * Preserved accurate handling of genuine rate-limit messages.

* **Tests**
  * Added regression coverage for successful reviews, rate-limited reviews, and conflicting-status prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->