### PR TITLE
fix: review skill の helper path と consumer review state の解決を直す (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,20 @@ record と run anchor を指定します。
 
 ```text
 node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
-  --target-sha <sha> --run-after <ISO timestamp> --reviewer <reviewer-id> --json
+  --target-sha <sha> --run-after <ISO timestamp> --reviewer <reviewer-id> \
+  --record .ai-dev-foundation/reviewers.json --json
 ```
+
+helper は Foundation checkout の `tooling/` にあり、consumer へは配布されません
+（`sync` が materialize するのは `AGENTS.md`、`CLAUDE.md`、`.ai-dev-foundation/skills/`
+だけです）。consumer repository を review する場合は、cwd をその consumer repository
+root のまま維持し、helper を `node <foundation-checkout>/tooling/...` として起動します
+（`skills/review-code.md` の `## Foundation helper の実行（consumer cwd）`）。
+`--record` の既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` なので、helper を
+起動するために Foundation checkout へ `cd` すると Foundation 自身の reviewer capability
+record を読むことになります。helper はこの 1 ケース（cwd が Foundation checkout root で
+`--record` 省略）を exit 2 の setup error として拒否します。Foundation リポジトリ自身を
+review する場合も含め、`--record` は明示的に渡してください。
 
 state output は `state`、`coverage_complete`、`evidence`、`observed_signals`、
 `reason_codes` を持ちます。`completed@target` は current target に構造化または
@@ -212,6 +224,17 @@ node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
   [--acknowledged-file <path>] [--acknowledged <canonical_id>=<body_digest>]... \
   [--run-after <ISO timestamp>] [--run-anchor-id <id>] [--record <path>] [--token <token>]
 ```
+
+helper は Foundation checkout の `tooling/` にあり、consumer へは配布されません
+（`sync` が materialize するのは `AGENTS.md`、`CLAUDE.md`、`.ai-dev-foundation/skills/`
+だけです）。consumer repository を review する場合は、cwd をその consumer repository
+root のまま維持し、helper を `node <foundation-checkout>/tooling/...` として起動します
+（`skills/review-code.md` の `## Foundation helper の実行（consumer cwd）`）。
+`--record` の既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` なので、helper を
+起動するために Foundation checkout へ `cd` すると Foundation 自身の reviewer capability
+record を読むことになります。helper はこの 1 ケース（cwd が Foundation checkout root で
+`--record` 省略）を exit 2 の setup error として拒否します。Foundation リポジトリ自身を
+review する場合も含め、`--record` は明示的に渡してください。
 
 `--artifacts-file` と `--acknowledged-file` はいずれも改行区切りの plain text です
 （`#` 始まりの行と空行は無視します）。**snapshot file を引数に取りません。** 会話内で

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -36,13 +36,21 @@ consumer へは配布されません（`sync` が materialize するのは `AGEN
 - consumer-owned な path 引数（`--record` / `--artifacts-file` /
   `--acknowledged-file`）は、その consumer repository root を基準に明示的に渡します。
 
-`<foundation-checkout>` が実際にこの consumer を sync している checkout かどうかは、
-新しい discovery 機構を作らず、既存の drift check で確認します。skill bundle が
-drift していれば、その checkout はこの consumer が現在使っているものではありません。
+実行される helper 実装は、command で addressing した checkout のものそのものです。
+残る問いは「その checkout が、この consumer を sync した checkout と同じか」だけで、
+これは新しい discovery 機構を作らず、既存の drift check で狭めます。
 
 ```text
 node <foundation-checkout>/tooling/check.mjs --consumer .
 ```
+
+この check が比較するのは、consumer へ配布済みの Foundation-owned artifact
+（generated `AGENTS.md` / `CLAUDE.md`、`.ai-dev-foundation/skills/`、quality profile）と、
+この checkout 側の canonical source です。drift があれば、その checkout はこの consumer が
+現在使っているものではありません。**逆は成り立ちません。** `tooling/` は比較対象ではなく
+consumer へ配布もされないため、配布 artifact が同一で `tooling/` だけが異なる checkout は
+この check を通過します。したがってこの check を helper revision の同一性証明として
+扱わず、どの checkout を addressing したかは review evidence として記録します。
 
 helper を起動するために Foundation checkout へ `cd` しないでください。`--record` の
 既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` であり、Foundation checkout を

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -23,6 +23,35 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
 
+## Foundation helper の実行（consumer cwd）
+
+`review-evidence` / `merge-ready-fence` は Foundation checkout の `tooling/` にあり、
+consumer へは配布されません（`sync` が materialize するのは `AGENTS.md`、`CLAUDE.md`、
+`.ai-dev-foundation/skills/` だけです）。consumer で `node tooling/...` と書いても
+解決しないため、本 skill の command 例は次の形を canonical とします。
+
+- cwd は review 対象の **consumer repository root** のまま維持します。
+- helper は Foundation checkout 側の path で起動します。以降 `<foundation-checkout>`
+  は、**この consumer を sync している Foundation checkout** の path を指します。
+- consumer-owned な path 引数（`--record` / `--artifacts-file` /
+  `--acknowledged-file`）は、その consumer repository root を基準に明示的に渡します。
+
+`<foundation-checkout>` が実際にこの consumer を sync している checkout かどうかは、
+新しい discovery 機構を作らず、既存の drift check で確認します。skill bundle が
+drift していれば、その checkout はこの consumer が現在使っているものではありません。
+
+```text
+node <foundation-checkout>/tooling/check.mjs --consumer .
+```
+
+helper を起動するために Foundation checkout へ `cd` しないでください。`--record` の
+既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` であり、Foundation checkout を
+cwd にすると、Foundation 自身の reviewer capability record を consumer の record として
+読む経路になります。helper 側はこの 1 ケース（cwd が Foundation checkout root で
+`--record` 省略）を **exit 2 の setup error** として拒否し、既定値へ silent fallback
+しません。Foundation リポジトリ自身を review する場合も同じで、`--record` を明示的に
+渡します。
+
 ## Happy path
 
 迷ったらこの順に進めます。各 step の詳細・分岐・例外は `## 手順` にあります。
@@ -42,8 +71,9 @@ review でも同じ意味で適用します。
    `--run-after` として渡す。
 
    ```text
-   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
-     --target-sha <sha> --run-after <手順 5 で記録した run anchor> --json
+   node <foundation-checkout>/tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
+     --target-sha <sha> --run-after <手順 5 で記録した run anchor> \
+     --record .ai-dev-foundation/reviewers.json --json
    ```
 
 7. fresh snapshot を state evaluator へ渡して target completion state を読み、
@@ -62,10 +92,10 @@ review でも同じ意味で適用します。
    記録したものを再利用する。
 
    ```text
-   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+   node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path> \
+     --acknowledged-file <path> --record .ai-dev-foundation/reviewers.json \
      --run-after <手順 5（または closure 時は手順 8）で記録した run anchor>
    ```
 
@@ -185,8 +215,8 @@ required/expected review の消化根拠にしてはいけません。この区�
    の merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
    closure run の anchor です。
 
-5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
-   fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
+5. **Acquisition & state** — reviewer の run ごとに `review-evidence` helper を
+   fresh に実行し（起動形式は `## Foundation helper の実行（consumer cwd）`）、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
    `--run-after <timestamp>` として渡し、state evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
@@ -314,11 +344,12 @@ required/expected review の消化根拠にしてはいけません。この区�
     記録したものを再利用します。
 
     ```text
-    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+    node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
       --target-sha <frozen target> --base-sha <frozen base> \
       --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
       --required <reviewer-id> --declared-skill review-code \
       --acknowledged-file <手順 5（または closure 時は手順 11）で記録した canonical_id=body_digest> \
+      --record .ai-dev-foundation/reviewers.json \
       --run-after <手順 4（または closure 時は手順 10）で記録した run anchor>
     ```
 
@@ -394,8 +425,8 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 `collectOutputs()` / `normalizeFindings()` を人手で埋めます。
 
 - `trigger()`: record の `trigger` に従って起動し、どう起動したかを記録します。
-- `pollCompletion()`: `tooling/review-evidence.mjs --state` を fresh target と
-  run anchor 付きで実行し、reduced state output と canonical object の sources /
+- `pollCompletion()`: `review-evidence` helper を `--state` 付きで、fresh target と
+  run anchor を渡して実行し（起動形式は `## Foundation helper の実行（consumer cwd）`）、reduced state output と canonical object の sources /
   current revision を記録します。`completed@target` だけを target-bound completion
   として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -40,6 +40,15 @@ artifact classification に関わらず共通であり、Foundation リポジト
 `.ai-dev-foundation/skills/review-code.md` として配布）の「reviewer capability
 record」節および「Adapter boundary」節に従います。この skill では重複定義しません。
 
+## Foundation helper の実行（consumer cwd）
+
+本 skill の command 例（`merge-ready-fence` 等）も、Foundation リポジトリの
+`skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md`
+として配布）の `## Foundation helper の実行（consumer cwd）` 節に従います。cwd は
+consumer repository root のまま維持し、helper は `<foundation-checkout>/tooling/` の
+path で起動し、`--record` / `--artifacts-file` / `--acknowledged-file` は consumer
+repository root を基準に明示的に渡します。ここでは重複定義しません。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical
@@ -170,11 +179,12 @@ record」節および「Adapter boundary」節に従います。この skill で
    を経由していなければ手順 4、経由していれば手順 7）で記録したものを再利用します。
 
    ```text
-   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+   node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <frozen target> --base-sha <frozen base> \
      --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
      --required <reviewer-id> --declared-skill review-doc \
      --acknowledged-file <手順 4（または closure 時は手順 7）で記録した canonical_id=body_digest> \
+     --record .ai-dev-foundation/reviewers.json \
      --run-after <手順 3（または closure 時は手順 7）で記録した run anchor>
    ```
 

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -36,13 +36,21 @@ consumer へは配布されません（`sync` が materialize するのは `AGEN
 - consumer-owned な path 引数（`--record` / `--artifacts-file` /
   `--acknowledged-file`）は、その consumer repository root を基準に明示的に渡します。
 
-`<foundation-checkout>` が実際にこの consumer を sync している checkout かどうかは、
-新しい discovery 機構を作らず、既存の drift check で確認します。skill bundle が
-drift していれば、その checkout はこの consumer が現在使っているものではありません。
+実行される helper 実装は、command で addressing した checkout のものそのものです。
+残る問いは「その checkout が、この consumer を sync した checkout と同じか」だけで、
+これは新しい discovery 機構を作らず、既存の drift check で狭めます。
 
 ```text
 node <foundation-checkout>/tooling/check.mjs --consumer .
 ```
+
+この check が比較するのは、consumer へ配布済みの Foundation-owned artifact
+（generated `AGENTS.md` / `CLAUDE.md`、`.ai-dev-foundation/skills/`、quality profile）と、
+この checkout 側の canonical source です。drift があれば、その checkout はこの consumer が
+現在使っているものではありません。**逆は成り立ちません。** `tooling/` は比較対象ではなく
+consumer へ配布もされないため、配布 artifact が同一で `tooling/` だけが異なる checkout は
+この check を通過します。したがってこの check を helper revision の同一性証明として
+扱わず、どの checkout を addressing したかは review evidence として記録します。
 
 helper を起動するために Foundation checkout へ `cd` しないでください。`--record` の
 既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` であり、Foundation checkout を

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -23,6 +23,35 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
 
+## Foundation helper の実行（consumer cwd）
+
+`review-evidence` / `merge-ready-fence` は Foundation checkout の `tooling/` にあり、
+consumer へは配布されません（`sync` が materialize するのは `AGENTS.md`、`CLAUDE.md`、
+`.ai-dev-foundation/skills/` だけです）。consumer で `node tooling/...` と書いても
+解決しないため、本 skill の command 例は次の形を canonical とします。
+
+- cwd は review 対象の **consumer repository root** のまま維持します。
+- helper は Foundation checkout 側の path で起動します。以降 `<foundation-checkout>`
+  は、**この consumer を sync している Foundation checkout** の path を指します。
+- consumer-owned な path 引数（`--record` / `--artifacts-file` /
+  `--acknowledged-file`）は、その consumer repository root を基準に明示的に渡します。
+
+`<foundation-checkout>` が実際にこの consumer を sync している checkout かどうかは、
+新しい discovery 機構を作らず、既存の drift check で確認します。skill bundle が
+drift していれば、その checkout はこの consumer が現在使っているものではありません。
+
+```text
+node <foundation-checkout>/tooling/check.mjs --consumer .
+```
+
+helper を起動するために Foundation checkout へ `cd` しないでください。`--record` の
+既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` であり、Foundation checkout を
+cwd にすると、Foundation 自身の reviewer capability record を consumer の record として
+読む経路になります。helper 側はこの 1 ケース（cwd が Foundation checkout root で
+`--record` 省略）を **exit 2 の setup error** として拒否し、既定値へ silent fallback
+しません。Foundation リポジトリ自身を review する場合も同じで、`--record` を明示的に
+渡します。
+
 ## Happy path
 
 迷ったらこの順に進めます。各 step の詳細・分岐・例外は `## 手順` にあります。
@@ -42,8 +71,9 @@ review でも同じ意味で適用します。
    `--run-after` として渡す。
 
    ```text
-   node tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
-     --target-sha <sha> --run-after <手順 5 で記録した run anchor> --json
+   node <foundation-checkout>/tooling/review-evidence.mjs --repo <owner/repo> --pr <number> --state \
+     --target-sha <sha> --run-after <手順 5 で記録した run anchor> \
+     --record .ai-dev-foundation/reviewers.json --json
    ```
 
 7. fresh snapshot を state evaluator へ渡して target completion state を読み、
@@ -62,10 +92,10 @@ review でも同じ意味で適用します。
    記録したものを再利用する。
 
    ```text
-   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+   node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <sha> --base-sha <sha> --artifacts-file <path> \
      --verify-sha <sha> --required <reviewer-id> --declared-skill review-code \
-     --acknowledged-file <path> \
+     --acknowledged-file <path> --record .ai-dev-foundation/reviewers.json \
      --run-after <手順 5（または closure 時は手順 8）で記録した run anchor>
    ```
 
@@ -185,8 +215,8 @@ required/expected review の消化根拠にしてはいけません。この区�
    の merge-ready fence が使う run anchor は手順 4 のものではなく、手順 10 で記録した
    closure run の anchor です。
 
-5. **Acquisition & state** — reviewer の run ごとに `tooling/review-evidence.mjs` を
-   fresh に実行し、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
+5. **Acquisition & state** — reviewer の run ごとに `review-evidence` helper を
+   fresh に実行し（起動形式は `## Foundation helper の実行（consumer cwd）`）、`--state --target-sha <sha>` に加えて手順 4 で記録した run anchor を
    `--run-after <timestamp>` として渡し、state evaluator を実行します。
    state output の `state`、`coverage_complete`、`evidence`、`reason_codes` を記録します。
    **あわせて、triage の対象にする result の `canonical_id` と
@@ -314,11 +344,12 @@ required/expected review の消化根拠にしてはいけません。この区�
     記録したものを再利用します。
 
     ```text
-    node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+    node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
       --target-sha <frozen target> --base-sha <frozen base> \
       --artifacts-file <frozen artifact set> --verify-sha <手順 1/8 の verify SHA> \
       --required <reviewer-id> --declared-skill review-code \
       --acknowledged-file <手順 5（または closure 時は手順 11）で記録した canonical_id=body_digest> \
+      --record .ai-dev-foundation/reviewers.json \
       --run-after <手順 4（または closure 時は手順 10）で記録した run anchor>
     ```
 
@@ -394,8 +425,8 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
 `collectOutputs()` / `normalizeFindings()` を人手で埋めます。
 
 - `trigger()`: record の `trigger` に従って起動し、どう起動したかを記録します。
-- `pollCompletion()`: `tooling/review-evidence.mjs --state` を fresh target と
-  run anchor 付きで実行し、reduced state output と canonical object の sources /
+- `pollCompletion()`: `review-evidence` helper を `--state` 付きで、fresh target と
+  run anchor を渡して実行し（起動形式は `## Foundation helper の実行（consumer cwd）`）、reduced state output と canonical object の sources /
   current revision を記録します。`completed@target` だけを target-bound completion
   として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -40,6 +40,15 @@ artifact classification に関わらず共通であり、Foundation リポジト
 `.ai-dev-foundation/skills/review-code.md` として配布）の「reviewer capability
 record」節および「Adapter boundary」節に従います。この skill では重複定義しません。
 
+## Foundation helper の実行（consumer cwd）
+
+本 skill の command 例（`merge-ready-fence` 等）も、Foundation リポジトリの
+`skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md`
+として配布）の `## Foundation helper の実行（consumer cwd）` 節に従います。cwd は
+consumer repository root のまま維持し、helper は `<foundation-checkout>/tooling/` の
+path で起動し、`--record` / `--artifacts-file` / `--acknowledged-file` は consumer
+repository root を基準に明示的に渡します。ここでは重複定義しません。
+
 ## 手順
 
 1. **Mechanical check** — その時点の target SHA / range と、その mechanical
@@ -170,11 +179,12 @@ record」節および「Adapter boundary」節に従います。この skill で
    を経由していなければ手順 4、経由していれば手順 7）で記録したものを再利用します。
 
    ```text
-   node tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
+   node <foundation-checkout>/tooling/merge-ready-fence.mjs --repo <owner/repo> --pr <number> \
      --target-sha <frozen target> --base-sha <frozen base> \
      --artifacts-file <frozen artifact set> --verify-sha <手順 1 の check SHA> \
      --required <reviewer-id> --declared-skill review-doc \
      --acknowledged-file <手順 4（または closure 時は手順 7）で記録した canonical_id=body_digest> \
+     --record .ai-dev-foundation/reviewers.json \
      --run-after <手順 3（または closure 時は手順 7）で記録した run anchor>
    ```
 

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -1030,7 +1030,7 @@ test("the Normative review procedure reaches the fence and the expected review s
   // Freshness is no longer a sentence the agent has to remember: the fence CLI
   // accepts no snapshot argument, so a remembered snapshot cannot reach it.
   // test/merge-ready-fence-lib.test.mjs owns that property.
-  assert.ok(containsText(doc, "node tooling/merge-ready-fence.mjs"));
+  assert.ok(containsText(doc, "node <foundation-checkout>/tooling/merge-ready-fence.mjs"));
   assert.ok(containsText(doc, "`fail`（exit 1）と `unknown`（exit 2）はどちらも merge-ready ではありません"));
   assert.ok(containsText(doc, "target completion state"));
 });
@@ -1052,7 +1052,7 @@ test("review-code skill carries the procedural detail for the fence", async () =
   // Merge-ready: the fence runs last, and neither of its non-pass states is
   // merge-ready.
   assert.ok(containsText(skill, "宣言の直前の最後の action として merge-ready fence を実行します"));
-  assert.ok(containsText(skill, "node tooling/merge-ready-fence.mjs"));
+  assert.ok(containsText(skill, "node <foundation-checkout>/tooling/merge-ready-fence.mjs"));
   assert.ok(containsText(skill, "`unknown` を `pass` として扱わないでください"));
 
   // Provider observations stay observations — and, since Issue #72 Phase 1,

--- a/test/review-helper-consumer-binding.test.mjs
+++ b/test/review-helper-consumer-binding.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -239,6 +239,30 @@ test("record resolution binds to the cwd it is given, and refuses only the Found
     FOUNDATION_REVIEWER_RECORD_PATH,
   );
   assert.throws(() => resolveConsumerReviewerRecordPath(undefined, root), /Refusing to default/);
+});
+
+test("the Foundation default is refused however that checkout path is spelled", async (t) => {
+  // The guard has to be about directory IDENTITY, not spelling. On Windows a
+  // differently-cased cwd names the same directory, so a string compare would
+  // hand back Foundation's own record — silently, which is the entire failure
+  // this guard exists to prevent.
+  if (process.platform === "win32") {
+    assert.throws(() => resolveConsumerReviewerRecordPath(undefined, root.toLowerCase()), /Refusing to default/);
+    assert.throws(() => resolveConsumerReviewerRecordPath(undefined, root.toUpperCase()), /Refusing to default/);
+  }
+
+  // The other way to spell the same directory, on every platform: reach it
+  // through a link. Creating one can be denied (unprivileged Windows), and a
+  // skip there is honest — the case-identity assertions above still ran.
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "adf-link-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const link = path.join(temporary, "foundation-link");
+  try {
+    await symlink(root, link, "junction");
+  } catch {
+    return t.skip("creating a directory link is not permitted in this environment");
+  }
+  assert.throws(() => resolveConsumerReviewerRecordPath(undefined, link), /Refusing to default/);
 });
 
 test("both review skills document a helper path that does not depend on a consumer-local tooling/", async () => {

--- a/test/review-helper-consumer-binding.test.mjs
+++ b/test/review-helper-consumer-binding.test.mjs
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  FOUNDATION_REVIEWER_RECORD_PATH,
+  readReviewerRecordFile,
+  resolveConsumerReviewerRecordPath,
+} from "../tooling/reviewer-record-lib.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fenceCli = path.join(root, "tooling", "merge-ready-fence.mjs");
+const evidenceCli = path.join(root, "tooling", "review-evidence.mjs");
+
+// ---------------------------------------------------------------------------
+// Issue #96: the review helpers live in the Foundation checkout's tooling/, but
+// a consumer following review-code.md / review-doc.md runs them with the
+// CONSUMER repository as cwd. Two things have to hold at once, and asserting
+// either alone hides the other:
+//
+//   1. the helper module is reachable from a consumer that has no tooling/ of
+//      its own (the documented `node tooling/...` form was not);
+//   2. the reviewer capability record it reads is the CONSUMER's, not this
+//      Foundation checkout's — the failure the obvious remedy (cd to the
+//      Foundation root) would introduce silently.
+//
+// Path existence proves neither. So the fixtures below give the consumer a
+// record that is DISTINGUISHABLE from Foundation's by behaviour: Foundation's
+// own record is valid, the consumer's is deliberately invalid and names a
+// reviewer id that exists nowhere else. If a run ever fell back to the
+// Foundation-local record it would sail past record loading instead of
+// reporting that reviewer id, so the assertions below cannot pass by accident.
+//
+// Every invocation stops before any network call: the record is resolved and
+// loaded first, and `--artifacts-file` is read before the acquisition. `--help`
+// is deliberately not used — it proves nothing about which record was read.
+// ---------------------------------------------------------------------------
+
+const CONSUMER_ONLY_REVIEWER = "consumer-only-reviewer";
+
+function consumerRecord({ valid }) {
+  return {
+    schema: "ai-dev-foundation/reviewer-capability-record@1",
+    required_selection: { count: 1, prefer: "record-order" },
+    reviewers: [
+      {
+        id: CONSUMER_ONLY_REVIEWER,
+        display_name: "Consumer Only Reviewer",
+        default_class: "required",
+        actors: ["consumer-only-bot"],
+        trigger: { kind: "comment_command", value: "@consumer-only-bot review" },
+        completion_marker: { any_of: ["consumer review complete"] },
+        fallback_order: [],
+        // The single field that separates the two fixtures. An invalid
+        // observed_at makes the helper name this reviewer in its setup error,
+        // which is what turns "which record was read" into an observable fact.
+        observed_at: valid ? "2026-01-01" : "not-a-date",
+      },
+    ],
+  };
+}
+
+async function makeConsumer(t, { valid }) {
+  const consumer = await mkdtemp(path.join(os.tmpdir(), "adf-consumer-"));
+  t.after(() => rm(consumer, { recursive: true, force: true }));
+  await mkdir(path.join(consumer, ".ai-dev-foundation"), { recursive: true });
+  await writeFile(
+    path.join(consumer, ".ai-dev-foundation", "reviewers.json"),
+    `${JSON.stringify(consumerRecord({ valid }), null, 2)}\n`,
+    "utf8",
+  );
+  return consumer;
+}
+
+// The documented consumer command path, minus the placeholders: the helper is
+// addressed inside the Foundation checkout while cwd stays the consumer.
+function runFenceFromConsumer(consumer, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [
+      fenceCli,
+      "--repo", "org/repo",
+      "--pr", "1",
+      "--target-sha", "abc1234",
+      "--declared-skill", "review-code",
+      "--required", CONSUMER_ONLY_REVIEWER,
+      "--run-after", "2026-01-01T00:00:00Z",
+      "--artifacts-file", path.join(consumer, "frozen-artifacts.txt"),
+      "--token", "dummy",
+      ...extraArgs,
+    ],
+    { cwd: consumer, encoding: "utf8" },
+  );
+}
+
+function runEvidenceStateFromConsumer(consumer, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    [
+      evidenceCli,
+      "--repo", "org/repo",
+      "--pr", "1",
+      "--state",
+      "--target-sha", "abc1234",
+      "--run-after", "2026-01-01T00:00:00Z",
+      "--token", "dummy",
+      ...extraArgs,
+    ],
+    { cwd: consumer, encoding: "utf8" },
+  );
+}
+
+test("Foundation's own reviewer record stays valid, so a fallback to it is observable", async () => {
+  // The whole discriminator below rests on this: Foundation's record loads
+  // cleanly. If it ever stopped doing so, a run that silently read it would
+  // fail for the same reason a consumer-bound run does, and the tests in this
+  // file would stop distinguishing the two.
+  const foundation = await readReviewerRecordFile(FOUNDATION_REVIEWER_RECORD_PATH);
+  assert.equal(foundation.status, "ok");
+  assert.ok(
+    !foundation.record.reviewers.some((reviewer) => reviewer.id === CONSUMER_ONLY_REVIEWER),
+    "the consumer-only reviewer id must not exist in Foundation's own record",
+  );
+});
+
+test("merge-ready-fence run from a consumer cwd reads the CONSUMER reviewer record", async (t) => {
+  const consumer = await makeConsumer(t, { valid: false });
+
+  const result = runFenceFromConsumer(consumer);
+
+  // Reachability: a consumer has no tooling/ of its own, so this only runs at
+  // all because the helper is addressed inside the Foundation checkout.
+  assert.equal(result.status, 2, result.stderr);
+  assert.doesNotMatch(result.stderr, /Cannot find module|ERR_MODULE_NOT_FOUND/);
+
+  // Consumer binding, by content: the reviewer id and the invalid field come
+  // from the consumer's record. Foundation's record is valid and contains
+  // neither, so this output is unreachable from a Foundation-local read.
+  assert.match(result.stderr, /Reviewer record invalid/);
+  assert.match(result.stderr, new RegExp(CONSUMER_ONLY_REVIEWER));
+  assert.match(result.stderr, /observed_at/);
+  assert.ok(
+    result.stderr.includes(path.join(consumer, ".ai-dev-foundation", "reviewers.json")),
+    "the helper must report the consumer record path it read",
+  );
+  assert.ok(
+    !result.stderr.includes(FOUNDATION_REVIEWER_RECORD_PATH),
+    "the helper must not have touched this Foundation checkout's own record",
+  );
+  assert.equal(result.stdout.trim(), "", "a setup failure is not a fence verdict");
+});
+
+test("a valid consumer record is accepted and the documented fence arguments are consumed", async (t) => {
+  const consumer = await makeConsumer(t, { valid: true });
+
+  const result = runFenceFromConsumer(consumer);
+
+  // Same invocation, valid consumer record: the run now gets PAST record
+  // loading and stops at the next consumer-owned input on the documented
+  // command path, which is where a supported path is meant to stop when the
+  // frozen artifact list is absent. That is the proof the record was used
+  // rather than merely located.
+  assert.equal(result.status, 2, result.stderr);
+  assert.doesNotMatch(result.stderr, /Reviewer record/);
+  assert.match(result.stderr, /frozen-artifacts\.txt/);
+  assert.match(result.stderr, /Usage: node tooling\/merge-ready-fence\.mjs/);
+});
+
+test("review-evidence --state run from a consumer cwd reads the CONSUMER reviewer record", async (t) => {
+  const consumer = await makeConsumer(t, { valid: false });
+
+  const result = runEvidenceStateFromConsumer(consumer);
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.doesNotMatch(result.stderr, /Cannot find module|ERR_MODULE_NOT_FOUND/);
+  assert.match(result.stderr, /Reviewer record invalid/);
+  assert.match(result.stderr, new RegExp(CONSUMER_ONLY_REVIEWER));
+  assert.ok(
+    !result.stderr.includes(FOUNDATION_REVIEWER_RECORD_PATH),
+    "the helper must not have touched this Foundation checkout's own record",
+  );
+});
+
+test("no cwd switch lets a helper consume Foundation-local record state silently", () => {
+  // The remedy Issue #96 rules out: `cd` to the Foundation checkout so the
+  // relative `node tooling/...` command resolves. The helper refuses instead of
+  // substituting its own record, and refuses BEFORE the acquisition, so the
+  // substitution can never reach a verdict.
+  for (const [label, cli] of [["fence", fenceCli], ["evidence", evidenceCli]]) {
+    const args = cli === fenceCli
+      ? [cli, "--repo", "org/repo", "--pr", "1", "--target-sha", "abc1234", "--token", "dummy"]
+      : [cli, "--repo", "org/repo", "--pr", "1", "--state", "--target-sha", "abc1234",
+         "--run-after", "2026-01-01T00:00:00Z", "--token", "dummy"];
+    const result = spawnSync(process.execPath, args, { cwd: root, encoding: "utf8" });
+
+    assert.equal(result.status, 2, `${label}: ${result.stderr}`);
+    assert.match(result.stderr, /Refusing to default the reviewer capability record/, label);
+    assert.match(result.stderr, /--record/, label);
+    assert.equal(result.stdout.trim(), "", `${label}: a setup failure emits no verdict`);
+  }
+});
+
+test("Foundation reviewing itself still works, by naming the record explicitly", () => {
+  // The guard is on the SILENT default only. Foundation is a consumer of its
+  // own skills, and an explicit --record — the form the skills document — keeps
+  // that path open.
+  const result = spawnSync(
+    process.execPath,
+    [
+      fenceCli,
+      "--repo", "org/repo",
+      "--pr", "1",
+      "--target-sha", "abc1234",
+      "--record", ".ai-dev-foundation/reviewers.json",
+      "--artifacts-file", "no-such-artifacts-file.txt",
+      "--token", "dummy",
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.doesNotMatch(result.stderr, /Refusing to default/);
+  assert.match(result.stderr, /no-such-artifacts-file/);
+});
+
+test("record resolution binds to the cwd it is given, and refuses only the Foundation default", () => {
+  const consumer = path.join(os.tmpdir(), "adf-resolve-consumer");
+
+  assert.equal(
+    resolveConsumerReviewerRecordPath(undefined, consumer),
+    path.join(consumer, ".ai-dev-foundation", "reviewers.json"),
+  );
+  // An explicit path is honoured even when it IS Foundation's own record.
+  assert.equal(
+    resolveConsumerReviewerRecordPath(".ai-dev-foundation/reviewers.json", root),
+    FOUNDATION_REVIEWER_RECORD_PATH,
+  );
+  assert.throws(() => resolveConsumerReviewerRecordPath(undefined, root), /Refusing to default/);
+});
+
+test("both review skills document a helper path that does not depend on a consumer-local tooling/", async () => {
+  for (const name of ["review-code.md", "review-doc.md"]) {
+    const skill = await readFile(path.join(root, "skills", name), "utf8");
+
+    // Every runnable example addresses the Foundation checkout explicitly. The
+    // bare `node tooling/...` form is what a consumer cannot resolve, so its
+    // absence is the contract, not a style preference.
+    assert.ok(
+      !/^\s*node tooling\//m.test(skill),
+      `${name} must not tell a consumer to run a consumer-local tooling/ path`,
+    );
+    for (const helper of ["review-evidence.mjs", "merge-ready-fence.mjs", "check.mjs"]) {
+      const bare = new RegExp(`node (?!<foundation-checkout>/)\\S*tooling/${helper.replace(".", "\\.")}`);
+      assert.ok(!bare.test(skill), `${name} must address ${helper} inside <foundation-checkout>/`);
+    }
+
+    // The consumer-owned record is named on the documented command path rather
+    // than left to a cwd default.
+    for (const start of [...skill.matchAll(/node <foundation-checkout>\/tooling\/(merge-ready-fence|review-evidence)\.mjs/g)]) {
+      const end = skill.indexOf("```", start.index);
+      const block = skill.slice(start.index, end === -1 ? undefined : end);
+      assert.ok(
+        block.includes("--record .ai-dev-foundation/reviewers.json"),
+        `${name}: every helper example must bind --record to the consumer record`,
+      );
+    }
+  }
+
+  // review-doc defers rather than duplicating, in the consumer-resolvable form.
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+  assert.ok(reviewDoc.includes("## Foundation helper の実行（consumer cwd）"));
+  assert.ok(reviewDoc.includes(".ai-dev-foundation/skills/review-code.md"));
+});
+
+test("the distributed consumer skill bundle carries the same helper path contract", async () => {
+  // A consumer reads .ai-dev-foundation/skills/, never skills/. If the fixture
+  // bundle still carried the old command the contract would be fixed only in
+  // the source the consumer does not read.
+  for (const name of ["review-code.md", "review-doc.md"]) {
+    const distributed = await readFile(
+      path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "skills", name),
+      "utf8",
+    );
+    assert.ok(!/^\s*node tooling\//m.test(distributed), `distributed ${name} still uses a consumer-local tooling/ path`);
+    assert.ok(distributed.includes("node <foundation-checkout>/tooling/"), `distributed ${name} must address the Foundation checkout`);
+  }
+});

--- a/test/review-helper-consumer-binding.test.mjs
+++ b/test/review-helper-consumer-binding.test.mjs
@@ -269,6 +269,16 @@ test("both review skills document a helper path that does not depend on a consum
     }
   }
 
+  // The drift check narrows which checkout is in use; it does not compare
+  // tooling/, which is neither distributed nor diffed. Stating only the half
+  // that holds would let a reader treat a passing check as proof that the
+  // helper revision matches the one the consumer was synced from.
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  assert.ok(
+    reviewCode.includes("helper revision の同一性証明として"),
+    "review-code.md must state that the drift check is not proof of helper-revision identity",
+  );
+
   // review-doc defers rather than duplicating, in the consumer-resolvable form.
   const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
   assert.ok(reviewDoc.includes("## Foundation helper の実行（consumer cwd）"));

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -878,7 +878,7 @@ test("both review skills define a run-anchor source and reuse it through to the 
     let searchFrom = 0;
     let blockCount = 0;
     for (;;) {
-      const start = skill.indexOf("node tooling/merge-ready-fence.mjs", searchFrom);
+      const start = skill.indexOf("node <foundation-checkout>/tooling/merge-ready-fence.mjs", searchFrom);
       if (start === -1) break;
       const end = skill.indexOf("```", start);
       const block = skill.slice(start, end === -1 ? undefined : end);

--- a/tooling/merge-ready-fence.mjs
+++ b/tooling/merge-ready-fence.mjs
@@ -2,7 +2,11 @@ import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { collectReviewEvidence } from "./review-evidence-lib.mjs";
-import { readReviewerRecordFile } from "./reviewer-record-lib.mjs";
+import {
+  describeUnusableReviewerRecord,
+  readReviewerRecordFile,
+  resolveConsumerReviewerRecordPath,
+} from "./reviewer-record-lib.mjs";
 import { evaluateReviewerTargetStates } from "./review-evidence-state-lib.mjs";
 import {
   MERGE_READY_FENCE_USAGE,
@@ -79,10 +83,14 @@ async function main() {
     throw new Error("No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.");
   }
 
-  const recordPath = path.resolve(args.record ?? ".ai-dev-foundation/reviewers.json");
+  // Consumer-bound, never silently Foundation-bound (Issue #96): this helper is
+  // run from the Foundation checkout with the consumer as cwd, so the cwd
+  // default is the consumer's record everywhere except inside the Foundation
+  // checkout itself, where it is refused instead of substituted.
+  const recordPath = resolveConsumerReviewerRecordPath(args.record);
   const loaded = await readReviewerRecordFile(recordPath);
   if (loaded.status !== "ok") {
-    throw new Error(`Reviewer record ${loaded.status}: ${recordPath}`);
+    throw new Error(describeUnusableReviewerRecord(loaded));
   }
 
   const [artifacts, acknowledged] = await Promise.all([

--- a/tooling/review-evidence.mjs
+++ b/tooling/review-evidence.mjs
@@ -1,11 +1,14 @@
 import { execFileSync } from "node:child_process";
-import path from "node:path";
 import {
   collectReviewEvidence,
   formatHumanSummary,
   parseReviewEvidenceArgs,
 } from "./review-evidence-lib.mjs";
-import { readReviewerRecordFile } from "./reviewer-record-lib.mjs";
+import {
+  describeUnusableReviewerRecord,
+  readReviewerRecordFile,
+  resolveConsumerReviewerRecordPath,
+} from "./reviewer-record-lib.mjs";
 import { evaluateReviewerTargetStates } from "./review-evidence-state-lib.mjs";
 
 // Snapshot tool only (Issue #62): one fresh fetch per invocation, no
@@ -21,47 +24,64 @@ function resolveToken(explicitToken) {
   }
 }
 
-const args = parseReviewEvidenceArgs(process.argv.slice(2));
-const [owner, repo] = args.repo.split("/");
-const token = resolveToken(args.token);
+const EXIT_SETUP_ERROR = 2;
 
-if (!token) {
-  console.error(
-    "No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.",
-  );
-  process.exitCode = 2;
-} else {
+// Setup before acquisition (Issue #96): the reviewer capability record is
+// resolved and loaded BEFORE the fresh fetch, so a record that cannot be used —
+// including one this helper refuses to resolve from the Foundation checkout's
+// own cwd default — is reported as a setup failure instead of after spending an
+// acquisition. Ordering only; the state projection itself is unchanged.
+async function main() {
+  const args = parseReviewEvidenceArgs(process.argv.slice(2));
+  const token = resolveToken(args.token);
+  if (!token) {
+    console.error(
+      "No GitHub token available. Set GH_TOKEN/GITHUB_TOKEN, pass --token, or run `gh auth login`.",
+    );
+    return EXIT_SETUP_ERROR;
+  }
+
+  let record = null;
+  if (args.state) {
+    const recordPath = resolveConsumerReviewerRecordPath(args.record);
+    const loaded = await readReviewerRecordFile(recordPath);
+    if (loaded.status !== "ok") {
+      console.error(describeUnusableReviewerRecord(loaded));
+      return EXIT_SETUP_ERROR;
+    }
+    record = loaded.record;
+  }
+
+  const [owner, repo] = args.repo.split("/");
   const result = await collectReviewEvidence({
     owner,
     repo,
     pullNumber: Number(args.pr),
     token,
   });
+
   if (!args.state) {
     console.log(
       args.json ? JSON.stringify(result, null, 2) : formatHumanSummary(result),
     );
-    process.exitCode = result.fetch_failures > 0 ? 1 : 0;
   } else {
-    const recordPath = path.resolve(
-      args.record ?? ".ai-dev-foundation/reviewers.json",
-    );
-    const loaded = await readReviewerRecordFile(recordPath);
-    if (loaded.status !== "ok") {
-      console.error("Reviewer record " + loaded.status + ": " + recordPath);
-      process.exitCode = 2;
-    } else {
-      const state = evaluateReviewerTargetStates(result, {
-        record: loaded.record,
-        reviewerId: args.reviewer ?? null,
-        target: { sha: args.targetSha },
-        runAnchor: {
-          ids: args.runAnchorId ? [args.runAnchorId] : [],
-          after: args.runAfter ?? null,
-        },
-      });
-      console.log(JSON.stringify(state, null, 2));
-      process.exitCode = result.fetch_failures > 0 ? 1 : 0;
-    }
+    const state = evaluateReviewerTargetStates(result, {
+      record,
+      reviewerId: args.reviewer ?? null,
+      target: { sha: args.targetSha },
+      runAnchor: {
+        ids: args.runAnchorId ? [args.runAnchorId] : [],
+        after: args.runAfter ?? null,
+      },
+    });
+    console.log(JSON.stringify(state, null, 2));
   }
+  return result.fetch_failures > 0 ? 1 : 0;
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(error?.message ?? String(error));
+  process.exitCode = EXIT_SETUP_ERROR;
 }

--- a/tooling/reviewer-record-lib.mjs
+++ b/tooling/reviewer-record-lib.mjs
@@ -15,6 +15,7 @@
 // judge completion, and does not rank fallbacks. It only answers "is this file
 // present, parseable, and minimally well-formed".
 
+import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -331,10 +332,27 @@ const foundationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 
 export const FOUNDATION_REVIEWER_RECORD_PATH = reviewerRecordPath(foundationRoot);
 
+// Whether two directories are the SAME directory, not whether they are spelled
+// the same way. Windows path identity is case-insensitive and a checkout can
+// also be reached through a symlink, so a raw string compare lets a
+// differently-spelled cwd walk straight past the guard below and read
+// Foundation's record anyway. The directory is canonicalized rather than the
+// record file because the directory always exists — it is either a cwd or this
+// module's own checkout — while the record file legitimately may not.
+function canonicalDirectory(directory) {
+  let canonical;
+  try {
+    canonical = realpathSync.native(directory);
+  } catch {
+    canonical = path.resolve(directory);
+  }
+  return process.platform === "win32" ? canonical.toLowerCase() : canonical;
+}
+
 export function resolveConsumerReviewerRecordPath(explicitPath, cwd = process.cwd()) {
   if (explicitPath) return path.resolve(cwd, explicitPath);
   const resolved = path.resolve(cwd, ...REVIEWER_RECORD_RELATIVE_PATH.split("/"));
-  if (resolved !== FOUNDATION_REVIEWER_RECORD_PATH) return resolved;
+  if (canonicalDirectory(cwd) !== canonicalDirectory(foundationRoot)) return resolved;
   throw new Error(
     `Refusing to default the reviewer capability record to this Foundation checkout's own ${REVIEWER_RECORD_RELATIVE_PATH} (${resolved}). ` +
       "Run the helper with the consumer repository as cwd, or pass --record <path> explicitly.",

--- a/tooling/reviewer-record-lib.mjs
+++ b/tooling/reviewer-record-lib.mjs
@@ -17,6 +17,7 @@
 
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const REVIEWER_RECORD_SCHEMA_ID = "ai-dev-foundation/reviewer-capability-record@1";
 export const REVIEWER_RECORD_RELATIVE_PATH = ".ai-dev-foundation/reviewers.json";
@@ -306,6 +307,46 @@ export async function readReviewerRecordFile(filePath) {
 // consumer directory, at the schema's canonical relative path.
 export async function loadReviewerRecord(consumerDirectory) {
   return readReviewerRecordFile(reviewerRecordPath(consumerDirectory));
+}
+
+// ---------------------------------------------------------------------------
+// Consumer binding for the helper CLIs (Issue #96)
+//
+// The review helpers live in this Foundation checkout's tooling/ but are run
+// with the CONSUMER repository as cwd, so their cwd-relative record default is
+// the consumer's own record — which is exactly what the review procedure means
+// by "the reviewer capability record". There is one cwd where that default
+// silently means something else: this Foundation checkout itself, where it
+// resolves to Foundation's record. Nothing in a helper's output distinguishes
+// "read the consumer's record" from "read Foundation's", so that single case is
+// refused rather than defaulted. Naming --record explicitly always works,
+// including when Foundation is the consumer being reviewed.
+//
+// This is a guard on one path, not a checkout-discovery mechanism: it never
+// searches for a Foundation checkout and never resolves anything on the
+// consumer's behalf.
+// ---------------------------------------------------------------------------
+
+const foundationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export const FOUNDATION_REVIEWER_RECORD_PATH = reviewerRecordPath(foundationRoot);
+
+export function resolveConsumerReviewerRecordPath(explicitPath, cwd = process.cwd()) {
+  if (explicitPath) return path.resolve(cwd, explicitPath);
+  const resolved = path.resolve(cwd, ...REVIEWER_RECORD_RELATIVE_PATH.split("/"));
+  if (resolved !== FOUNDATION_REVIEWER_RECORD_PATH) return resolved;
+  throw new Error(
+    `Refusing to default the reviewer capability record to this Foundation checkout's own ${REVIEWER_RECORD_RELATIVE_PATH} (${resolved}). ` +
+      "Run the helper with the consumer repository as cwd, or pass --record <path> explicitly.",
+  );
+}
+
+// One actionable line per problem, so a helper that cannot use the record says
+// which record file it actually read as well as what is wrong with it.
+export function describeUnusableReviewerRecord(loaded) {
+  const lines = [`Reviewer record ${loaded.status}: ${loaded.path}`];
+  for (const message of loaded.errors) lines.push(`  - ${message}`);
+  return lines.join("\n");
 }
 
 // The record's own declared posting convention, defaulting to the schema's


### PR DESCRIPTION
Refs #96

（Issue close authority は本 Task Contract で付与されていないため、autoclose keyword は使いません。）

## 問題

consumer-facing な review skill は documented command path として
`node tooling/review-evidence.mjs` / `node tooling/merge-ready-fence.mjs` を
持っていましたが、`tooling/sync.mjs` が consumer へ materialize するのは
`AGENTS.md` / `CLAUDE.md` / `.ai-dev-foundation/skills/` だけで、Foundation の
`tooling/` は配布されません。consumer cwd からこの command は解決しません
（baseline 実測: `MODULE_NOT_FOUND`）。

素朴な回避である「Foundation checkout へ `cd` する」は second defect を生みます。
helper の `--record` 既定値は cwd 相対の `.ai-dev-foundation/reviewers.json` なので、
Foundation 自身の reviewer capability record を consumer の record として silent に
読みます（baseline 実測: record 読み込みを通過して次の input へ進む）。

## 変更

**skills（canonical form）**

- `skills/review-code.md` に `## Foundation helper の実行（consumer cwd）` を追加。
  cwd は consumer repository root のまま維持し、helper は
  `<foundation-checkout>/tooling/...` として起動します。
- `skills/review-doc.md` は同節へ defer し、重複定義しません。
- consumer-owned な path 引数（`--record` / `--artifacts-file` /
  `--acknowledged-file`）は consumer root を基準に明示的に渡します。
- `<foundation-checkout>` がその consumer を sync している checkout かどうかは、
  **新しい discovery 機構を作らず**、既存の `check.mjs --consumer` の drift check
  で確認します。

**tooling（最小の guard）**

- `resolveConsumerReviewerRecordPath()`: `--record` 省略かつ cwd が Foundation
  checkout root という 1 ケースだけを exit 2 の setup error として拒否し、既定値へ
  silent fallback しません。明示的な `--record` は常に通るため、Foundation 自身を
  review する経路は開いたままです。
- record が使えない場合は field error まで報告します（どの record を読んだかが
  output から判別可能になります）。
- `review-evidence.mjs` は record の解決・読み込みを acquisition の前へ移しました
  （順序のみ。state projection は不変）。

## Regression test

`test/review-helper-consumer-binding.test.mjs`（9 test）。path 存在確認ではなく
behaviour を証明します。

- consumer を cwd として実行し、Foundation checkout 側の helper へ到達する
- Foundation の record は valid、consumer の record は意図的に invalid かつ
  `consumer-only-reviewer` という他に存在しない id を持つ → **どちらを読んだかが
  output から判別可能**
- consumer record の内容（reviewer id / 不正 field）が helper output に現れることを
  assert
- cwd を Foundation へ移した場合に silent fallback が起きず exit 2 で拒否されることを
  assert
- 明示的 `--record` による Foundation 自身の review が引き続き成立することを assert
- 配布側 `.ai-dev-foundation/skills/` の bundle も同じ contract を持つことを assert

`--help` は supported command path の証明にならないため health check に使っていません。

baseline（`f873e9d`）に対して behaviour 部分のみを実行すると 9 中 6 が fail します。

## 検証

- `npm test`: 280 tests / 279 pass / 1 skipped / 0 fail、`test:guardrails` は
  `Verified 8 guardrail fixtures.`
- `npm run check:fixture`: drift なし（generated adapters / quality profile /
  skill bundle / reviewer capability record すべて current）
- `git diff --check`: clean

## 変更していないもの

Review Protocol semantics、reviewer completion state semantics、merge-ready fence
semantics、artifact classification / routing semantics、provider-neutrality、
#70 / #71、progressive disclosure architecture、#39、#64。

generalized Foundation checkout discovery framework / checkout registry /
helper registry / runtime manager / provider-specific routing / generic
orchestration layer は導入していません。A1+A2 や他の architecture 改善へも
広げていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review helpers now use the consumer repository’s reviewer record when run from a consumer project.
  - Clear setup errors are shown for missing or unusable reviewer records.
  - Running from the Foundation checkout requires an explicit record path.

- **Documentation**
  - Updated review guidance and examples to use Foundation helper paths and explicit consumer-owned record, artifact, and acknowledgement files.

- **Tests**
  - Added coverage for consumer-bound records, setup failures, and updated command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
