### PR TITLE
Release v0.5.2: #96 consumer review helper correctness fix を freeze する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-dev-foundation",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-dev-foundation",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "devDependencies": {
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-dev-foundation",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "sync:fixture": "node tooling/sync.mjs --consumer test/fixtures/consumer",


### PR DESCRIPTION
## 目的

Issue #99 の Task Contract に従い、post-#96 current main を `v0.5.2` semantic
baseline として freeze し、version-bearing artifact を `0.5.1 -> 0.5.2` へ bump
して **tag-ready state** を成立させる。

本 PR は git tag を作成しない。GitHub Release object も作成しない。

Refs #99
Refs #96
Refs #98

## Fresh release preflight

Task 開始時に fresh 再取得した state（Issue #99 作成時の参考値と一致）:

| 項目 | fresh 実測 |
| --- | --- |
| current `main` | `4c7c959de02ba5e9346345a4a8bde57cc9d3551b` |
| open PR（本 PR 作成前） | 0 |
| `package.json` version | `0.5.1` |
| `package-lock.json` root / `packages[""]` | `0.5.1` / `0.5.1` |
| `v0.5.1` tag | annotated、peeled = `f873e9d20e7264f1df0fd8e980e03948ec17983e` |
| `v0.5.2` tag | local / remote ともに absent |
| Issue #96 / PR #97 | closed / merged（`f881dd5` `3f0b578` `e81d8d4` の 3 commit + merge commit `4c7c959`） |
| stage-tracker #339 / PR #340 | closed / merged（`4c7c959` への repin + real consumer smoke） |
| Issue #98 | closed（adjudication 完了、GO for v0.5.2） |

## Release boundary（frozen semantic baseline）

semantic baseline = `4c7c959de02ba5e9346345a4a8bde57cc9d3551b`

`v0.5.1 (f873e9d) .. 4c7c959` の delta は 4 commit（#96 implementation 3 commit +
PR #97 merge commit）のみで、changed file は次の 11 件に閉じている。

```
README.md
skills/review-code.md
skills/review-doc.md
test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
test/merge-ready-fence.test.mjs
test/review-helper-consumer-binding.test.mjs
test/review-protocol.test.mjs
tooling/merge-ready-fence.mjs
tooling/review-evidence.mjs
tooling/reviewer-record-lib.mjs
```

すなわち v0.5.1 以降の consumer-facing semantic delta は **Issue #96 / PR #97 の
bounded correctness fix だけ**である。

### 含まれる semantic correction（#96 / PR #97）

- consumer cwd を維持したまま Foundation review helper を正しい Foundation
  checkout から実行可能にした
- consumer reviewer record を明示的に consumer へ bind した
  （`--record` / `--artifacts-file` / `--acknowledged-file` 等 path-based input
  を consumer cwd へ bind）
- Foundation-local reviewer record への silent fallback を fail-safe に拒否した
  （`resolveConsumerReviewerRecordPath()` が cwd = Foundation checkout root か
  つ `--record` 省略の 1 ケースだけを exit 2 の setup error として拒否）
- Review Protocol / reviewer state / merge-ready semantics 自体は変更していない
- generalized checkout discovery / registry / runtime manager は追加していない
- stage-tracker #339 / PR #340 で real consumer smoke 済み（`4c7c959` への repin
  後、consumer cwd から helper invocation が実際に成功することを確認）

### 含めない delta（Issue #98 adjudication）

Issue #98 は post-#96 checkpoint として Kernel / Review Skills の情報配置を
再評価し、**A1+A2（navigation depth / repeated procedure 等の observation）は
現時点では実装しない**、**C（Review contracts の再配置 candidate）も現時点では
実装しない**と結論して completed close された。

- A1 / A2 implementation: 含めない（observation として保持のみ）
- C structural implementation: 含めない（deferred design candidate として保持、
  follow-up Issue も起票しない。#70/#71 の design 再開時にセットで再評価する）
- #70 / #71: 未着手のため含めない

## Version bump（本 PR の diff）

fresh inventory の結果、repository 内の version-bearing artifact は
`package.json` と `package-lock.json` のみだった。

exact changed files（2 file / 3 line）:

```
package-lock.json | 4 ++--   (root "version", packages[""].version)
package.json      | 2 +-     ("version")
```

- `package.json` version: `0.5.1` -> `0.5.2`
- `package-lock.json` root `version`: `0.5.1` -> `0.5.2`
- `package-lock.json` `packages[""].version`: `0.5.1` -> `0.5.2`

dependency update / semantic implementation / unrelated formatting は含まない。

## Final deterministic verification

final candidate `c11eb70be0cefa942090e3f826ab8dc5cc2aacff`（後述の値を fresh 実行
時点の HEAD として記録）に対して fresh 実行。

| check | 結果 |
| --- | --- |
| `npm test` | tests 281 / pass 280 / fail 0 / skipped 1 |
| `npm run test:guardrails` | `Verified 8 guardrail fixtures.` |
| `npm run check:fixture` | generated adapters / quality profile / skill bundle / reviewer capability record すべて current |
| `npm run test:client-role-table-privileges-guardrail` | tests 13 / pass 13 / fail 0 |
| generated / fixture currentness | current（`check:fixture` で確認、total artifact size 164,392 bytes。Issue #98 記載の post-#96 実測値と一致） |
| `git diff --check` | clean（exit 0） |
| clean working tree | clean（`git status` porcelain 空） |

`npm run test:guardrails` は release candidate 上で fresh green を確認した
（#98 second opinion 側で環境都合により未実行だったものを本 release candidate で
確定させた）。

### #96 regression coverage（final candidate 上で保持を確認）

`test/review-helper-consumer-binding.test.mjs`（9 test、`npm test` に含まれ green）
が少なくとも次を保持していることを確認:

- consumer cwd から helper invocation 可能
- intended consumer reviewer record が読まれる（Foundation record ではなく）
- Foundation-local implicit default fallback を拒否する
- consumer-owned file input（`--record` / `--artifacts-file` /
  `--acknowledged-file`）の cwd binding

stage-tracker #339 と同じ consumer smoke は、version-only な release-prep のため
新たに manufacture していない（#339 の real consumer smoke evidence を参照）。

## Release candidate integrity

- `package.json` = `0.5.2` ✔
- `package-lock.json` root = `0.5.2` ✔
- `package-lock.json` `packages[""]` = `0.5.2` ✔
- `v0.5.2` tag はまだ存在しない（local / remote ともに absent）✔
- changed file は version-bearing artifact に限定 ✔
- semantic baseline の #96 / PR #97 correction が byte-for-byte 含まれる ✔
- Issue #98 C / A1+A2 は含まれない ✔
- #70 / #71 は含まれない ✔
- unrelated semantic change なし ✔
- stage-tracker #339 で real consumer smoke 済み ✔

## Out of scope（本 PR で行わないこと）

`v0.5.2` git tag 作成 / GitHub Release object 作成 / stage-tracker 変更 /
repin / A1 / A2 implementation / Issue #98 C structural work / #70 / #71 /
#39 / #64 / Review Protocol semantic change / reviewer portfolio・schema・
fallback 変更 / generalized checkout discovery・runtime / unrelated cleanup。

release preparation 中に新しい Foundation defect を見つけても本 PR へ便乗 fix
しない。

## Post-merge sequence（authority holder 向け）

1. merged main を fresh 確認
2. annotated `v0.5.2` tag を exact merged release commit へ作成
3. remote peeled target / version artifact を再確認
4. GitHub Release object は作成しない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.5.1 to 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->