### PR TITLE
Codex Local / Desktopのstartup budget超過をfoundation:checkでadvisory検出

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ non-zero で終了し、`node tooling/bootstrap-next-supabase.mjs --consumer <pa
 忘れると、この quality profile の drift 検知だけが non-zero になります。
 
 `check` は最後に、`policy/core.md`・`skills/*.md`・生成した `AGENTS.md` の byte 数を
-advisory として標準出力へ出します。threshold は持たず、exit code にも影響しません。
+`Artifact sizes (advisory, no threshold)` として標準出力へ出します。さらに、生成した
+`AGENTS.md` が Codex Local CLI / Desktop Local/Worktree の current default startup
+project-doc budget（32 KiB）を超える場合は、trusted consumer projectで
+`project_doc_max_bytes` を明示するための bounded advisoryを出します。いずれの
+advisoryも exit code には影響しません。
 
 同梱の reference consumer は `npm test` で検証できます。
 

--- a/test/reviewer-capability-record.test.mjs
+++ b/test/reviewer-capability-record.test.mjs
@@ -8,6 +8,10 @@ import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { REVIEWER_RECORD_SCHEMA_ID, readReviewerRecordFile, validateReviewerRecord } from "../tooling/reviewer-record-lib.mjs";
 import { evaluateReviewerTargetStates } from "../tooling/review-evidence-state-lib.mjs";
+import {
+  CODEX_LOCAL_STARTUP_BUDGET_BYTES,
+  codexLocalStartupBudgetAdvisory,
+} from "../tooling/check-lib.mjs";
 
 // Issue #72 Phase 1: the reviewer capability record makes "which reviewers
 // exist, how are they triggered, what counts as completion" machine-readable
@@ -234,6 +238,16 @@ test("duplicate reviewer ids are rejected", () => {
 
 // --- check.mjs --------------------------------------------------------------
 
+test("Codex Local/Desktop startup advisory has a strict 32 KiB byte boundary", () => {
+  assert.equal(codexLocalStartupBudgetAdvisory(CODEX_LOCAL_STARTUP_BUDGET_BYTES - 1), null);
+  assert.equal(codexLocalStartupBudgetAdvisory(CODEX_LOCAL_STARTUP_BUDGET_BYTES), null);
+
+  const advisory = codexLocalStartupBudgetAdvisory(CODEX_LOCAL_STARTUP_BUDGET_BYTES + 1);
+  assert.match(advisory, /Codex Local CLI \/ Desktop Local\/Worktree/);
+  assert.match(advisory, /32 KiB \/ 32,768 bytes/);
+  assert.match(advisory, /project_doc_max_bytes/);
+});
+
 function runCheck(consumer) {
   return spawnSync(process.execPath, [path.join(root, "tooling", "check.mjs"), "--consumer", consumer], {
     encoding: "utf8",
@@ -284,9 +298,12 @@ test("check reports artifact byte sizes as advisory output that never changes th
     assert.ok(green.stdout.includes(label), `advisory size output missing: ${label}`);
   }
   assert.match(green.stdout, /^ {2}total: \d+ bytes$/m);
+  assert.match(green.stdout, /Codex Local CLI \/ Desktop Local\/Worktree advisory/);
+  assert.match(green.stdout, /current default startup project-doc budget/);
+  assert.match(green.stdout, /project_doc_max_bytes/);
 
-  // No threshold: the sizes are reported, never enforced. The only thing that
-  // moves the exit code here is real drift.
+  // The size measurement remains advisory, and the new budget advisory is also
+  // non-blocking. The only thing that moves the exit code here is real drift.
   await writeFile(path.join(consumer, "AGENTS.md"), "drift\n");
   const drifted = runCheck(consumer);
   assert.notEqual(drifted.status, 0);

--- a/tooling/check-lib.mjs
+++ b/tooling/check-lib.mjs
@@ -1,0 +1,13 @@
+export const CODEX_LOCAL_STARTUP_BUDGET_BYTES = 32_768;
+
+export function codexLocalStartupBudgetAdvisory(generatedAgentsBytes) {
+  if (generatedAgentsBytes <= CODEX_LOCAL_STARTUP_BUDGET_BYTES) return null;
+
+  return (
+    `Codex Local CLI / Desktop Local/Worktree advisory: generated AGENTS.md ` +
+    `(${generatedAgentsBytes} bytes) exceeds the current default startup project-doc budget ` +
+    `(32 KiB / ${CODEX_LOCAL_STARTUP_BUDGET_BYTES.toLocaleString("en-US")} bytes). ` +
+    "Local startup instructions may be truncated unless the trusted consumer project sets a " +
+    "sufficient project_doc_max_bytes."
+  );
+}

--- a/tooling/check-lib.mjs
+++ b/tooling/check-lib.mjs
@@ -3,10 +3,11 @@ export const CODEX_LOCAL_STARTUP_BUDGET_BYTES = 32_768;
 export function codexLocalStartupBudgetAdvisory(generatedAgentsBytes) {
   if (generatedAgentsBytes <= CODEX_LOCAL_STARTUP_BUDGET_BYTES) return null;
 
+  const budgetKiB = CODEX_LOCAL_STARTUP_BUDGET_BYTES / 1024;
   return (
     `Codex Local CLI / Desktop Local/Worktree advisory: generated AGENTS.md ` +
     `(${generatedAgentsBytes} bytes) exceeds the current default startup project-doc budget ` +
-    `(32 KiB / ${CODEX_LOCAL_STARTUP_BUDGET_BYTES.toLocaleString("en-US")} bytes). ` +
+    `(${budgetKiB} KiB / ${CODEX_LOCAL_STARTUP_BUDGET_BYTES.toLocaleString("en-US")} bytes). ` +
     "Local startup instructions may be truncated unless the trusted consumer project sets a " +
     "sufficient project_doc_max_bytes."
   );

--- a/tooling/check.mjs
+++ b/tooling/check.mjs
@@ -9,6 +9,7 @@ import {
   parseConsumerArgument,
   skillsSourceDirectory,
 } from "./lib.mjs";
+import { codexLocalStartupBudgetAdvisory } from "./check-lib.mjs";
 import { REVIEWER_RECORD_RELATIVE_PATH, loadReviewerRecord } from "./reviewer-record-lib.mjs";
 
 const foundationRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -82,11 +83,15 @@ const sizes = [["policy/core.md", Buffer.byteLength(await readFile(path.join(fou
 for (const file of skillFiles) {
   sizes.push([`skills/${file}`, Buffer.byteLength(await readFile(path.join(skillsSourceDirectory, file)))]);
 }
-sizes.push([`generated AGENTS.md (${consumerDirectory})`, Buffer.byteLength(agentsContent)]);
+const generatedAgentsBytes = Buffer.byteLength(agentsContent);
+sizes.push([`generated AGENTS.md (${consumerDirectory})`, generatedAgentsBytes]);
 
 console.log("Artifact sizes (advisory, no threshold):");
 for (const [label, bytes] of sizes) console.log(`  ${label}: ${bytes} bytes`);
 console.log(`  total: ${sizes.reduce((sum, [, bytes]) => sum + bytes, 0)} bytes`);
+
+const codexAdvisory = codexLocalStartupBudgetAdvisory(generatedAgentsBytes);
+if (codexAdvisory) console.log(codexAdvisory);
 
 if (hasDrift) {
   process.exitCode = 1;


### PR DESCRIPTION
## 概要

Issue #105に対し、生成 `AGENTS.md` のbyte数が current Codex Local CLI / Desktop Local/Worktree の既定 startup project-doc budget（32 KiB）を超えた場合の bounded advisoryを `foundation:check` に追加しました。

- 既存の `Artifact sizes (advisory, no threshold)` の生成byte測定を再利用
- 32,768 bytes以下は非超過、32,769 bytes以上は超過とするpure helper
- advisoryはstdoutのみで、checkのexit codeを変更しない
- `project_doc_max_bytes` は案内のみ。consumerの `.codex/config.toml` は読み書きしない
- Cloud Review、provider/surface registry、生成AGENTS/Review Protocol semantics、version/releaseは変更なし

## 検証

- focused reviewer/check tests
- `npm test`: 281 pass / 1 skipped / 0 fail、guardrail 8件green
- reference consumer smoke: 58,012 bytesでadvisory、exit 0
- stage-tracker smoke: 105,245 bytes、`.codex/config.toml` の `project_doc_max_bytes = 200000` が存在してもadvisory、exit 0
- `git diff --check`

IssueのAcceptance Criteria確認とmergeは別途行わず、このPRではmerge-ready確認後に停止します。