### PR TITLE
C-1: Review contractsのreview-phase detailをReview Skillsへconditional化する

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -259,7 +259,15 @@ Review 強度と停止条件は artifact の種類で分けます。
 ### Review contracts
 
 Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
-Adapter boundary へ閉じ込め、Kernel に固定しません。
+Adapter boundary へ閉じ込め、Kernel に固定しません。**Selection Contract、Execution
+Contract、および Acquisition & Validity Contract / Resolution Contract の手続き的
+detail（membership 確定手順、trigger 手順、record schema、triage category 等）の
+canonical source は Foundation-owned な review skill
+（`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section）です。
+本節は、review を実行しない Task でも成立していなければならない minimum safety
+boundary、および Merge readiness and merge authority が前提とする語彙・不変条件のみを
+保持します。**該当する review 手順へ入る前に、Skill routing contract に従って対応する
+skill を load することは引き続き **MUST** です。
 
 各 Contract は discovery だけでなく、同じ Contract を使って起動する closure review run
 にも適用されます。closure target も Selection Contract で expected target として確定し、
@@ -277,122 +285,10 @@ Resolution が完了している必要があります。discovery Resolution を
 より先に完了させる順序を強制するものではなく、merge / review completion
 の時点で揃っていれば十分です。
 
-#### Selection Contract
-
-- artifact classification
-- reviewer / capability の選択
-- required review 数
-- expected review set（下記）
-- target artifact set
-- expected target SHA / commit range
-
-**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
-選択していなくても、その repository / review target に対して review を行う reviewer が
-存在し得ます。Selection では次の和集合を expected review set として確定します。
-
-1. **required** — Selection Contract で明示的に required とした reviewer。
-   required review 数を満たす対象であり、その review obligation は merge /
-   review completion の blocker です。
-2. **expected** — required ではないが、次のいずれかに該当する reviewer。
-   required review 数には算入しませんが、その review obligation は merge /
-   review completion の blocker です。
-   - consumer が configured automatic reviewer として明示している
-   - 取得済み evidence が、その actor による review 行為をその review target 上で
-     識別させる。**この判定は current target に限りません。** 同じ review flow の
-     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
-     actor は、以降の target でも expected member として残ります。target が移動
-     しただけで member から外してはいけません
-3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
-   completion state が `unknown` であること自体は blocker にしません。ただし actual
-   finding が観測された場合、その finding は Resolution Contract の対象です。
-
-一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
-observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
-review 行為を行っても optional のままです（その finding は Resolution Contract の対象
-です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
-
-consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
-するかは、consumer-owned な **reviewer capability record** に置きます。Kernel はこの
-record が存在すること、および Selection がそれを参照することを要求します。record の
-schema / template と、その存在 / parse / 最小妥当性の check は Foundation tooling /
-profile 側が提供し、record の内容は consumer-owned のままです。record は portfolio 上の
-default を表すものであり、当該 Task の required / expected obligation の正本ではありません。
-それは従来どおり Selection Contract が確定します。
-
-2 の後者について、actor を expected member とする根拠は、その surface item 自体が
-**review participation として識別できる**ことです。review target 上に presence が
-あるだけでは足りず、次は単独では expected member 化の根拠になりません。
-
-- 通常の human comment（議論・質問・進捗報告等）
-- CI actor（workflow / status / check の author であること）
-- review 以外の目的で投稿する bot
-
-どの surface item が review participation を構成するかの識別は Review Adapter
-boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
-member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
-持ちません。
-
-reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、**expected / optional の member については、その reviewer の target
-completion state を理由に blocker としません**。
-
-**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
-discharge しません。** ancestor target で出した finding についても同じです。非参加の
-宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
-
-**required member は非参加の宣言によって blocker から外れません。** required とした
-reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
-代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
-まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
-gate を迂回する経路にしてはいけません。
-
-expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
-target 上にも**まだ review participation evidence を出していない reviewer を含め
-られません。ancestor target で participation evidence を出している reviewer は、
-上記の carry-over により member です。この residual
-limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
-configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
-
-#### Execution Contract
-
-- trigger 方法
-- Selection で確定した expected target SHA / commit range
-- Selection で確定した target artifact set
-- required context
-- timeout / retry policy
-
-Selection Contract で確定した expected target（SHA / commit range）と
-target artifact set は、Execution で reviewer の trigger へ渡し、実際に
-渡した target と artifact set を記録します。commit range を選択した場合に
-head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
-黙って縮小・変更しません。
-
-provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
-
 #### Acquisition & Validity Contract
 
 **CI status は review completion と同義ではありません。** status/check の green 化のみを
 review 完了の証跡にしてはいけません。
-
-review run ごとに少なくとも次を記録可能にします。
-
-```json
-{
-  "reviewer": "...",
-  "target_sha": "...",
-  "status": "completed",
-  "validity": "valid",
-  "finding_count": 0,
-  "result_locator": "...",
-  "started_at": "...",
-  "completed_at": "...",
-  "failure": null
-}
-```
-
-record の `target_sha` は、Selection Contract の expected target（SHA / commit
-range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
-`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。
 
 Completion は少なくとも次を要求します。
 
@@ -420,23 +316,13 @@ Foundation-owned な deterministic evaluator が所有します。その手順�
   invalid です。この場合、record は `status: completed` かつ `validity: invalid` として
   表現します。intended artifact set が review されていない場合も invalid です。
 
-**acquisition の record は、後続 session から独立に recoverable な場所へ
-persist されて初めて durable evidence です。** review を行った
-agent/session が終了した後、別の後続 session が session の記憶に頼らず、
-本 Contract が定義する Completion と Validity の要求事項を独立に判定
-できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
-上の comment 等）に存在しない限り、その run を merge / review completion
-の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
-へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
-自体をこの record の recoverable な representation として扱ってよく、
-別途 record を post し直す必要はありません。含まれていない場合
-（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
-例えば実装 session 内で動く subagent review を含む）は、上記の record
-schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
-情報を、そのような場所へ明示的に persist しない限り、session 終了後には
-recoverable な evidence として扱いません。record schema 自体（特に
-`validity` field）は判定結果の要約であり、その根拠情報の代わりには
-なりません。
+**acquisition の record は、後続 session から独立に recoverable な場所へ persist
+されて初めて durable evidence です。** どのような persistence が独立 recoverable と
+みなせるかの手続き的 detail（reviewer mechanism 自身が外部から確認可能な surface を
+残す場合の扱い、残さない場合の代替 persist 手順を含む）の canonical source は
+`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section です。
+record schema 自体（特に `validity` field）は判定結果の要約であり、その根拠情報の
+代わりにはなりません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
@@ -457,21 +343,15 @@ item のうち、その target への resolvable な参照を持つ positive com
 （または、reviewed target を確定できた上で一致しない場合は `not-bound`）であり、
 `0 findings` へ変換してはいけません。
 
-**triage した review result の revision は、判断の対象です。** review result は
-in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
-その reviewer の target completion state は変わりません。したがって、ある run を
-merge / review completion の根拠とするには、triage / Resolution の対象とした result の
-revision が、判断時点の current revision と同一であることを確認します。この確認は
-deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+**triage した review result の revision は、判断の対象です。** review result の
+in-place 編集を検出し、triage / Resolution の対象とした result の revision と
+判断時点の current revision の同一性を確認する手続き的 detail の canonical source は
+`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section です。
 current revision が異なる場合、その result はまだ triage されていない result として
-扱います。
-
-本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
-membership class とその根拠、target completion state とその binding の根拠、triage の
-対象とした result の revision、および current target の clean / discovery evidence として
-採用した run——は、個々の run record schema ではなく、その review stage の Selection /
-fence 記録として persist します。これらは run 単位ではなく reviewer 単位・stage 単位の
-情報であるためです。
+扱います。この Contract および Selection Contract が「記録すること」を要求する事項が、
+個々の run record schema ではなくその review stage の Selection / fence 記録として
+persist される理由（reviewer 単位・stage 単位の情報であること）も同じ canonical source
+に従います。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -486,16 +366,15 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 
 #### Resolution Contract
 
-- finding を fix / false-positive / needs-verification / technical-dispute /
-  intent-question へ triage する
-- human を raw finding の message bus にしない
-- pure technical dispute は technical adjudication で解決する
-- human escalation は product intent / authority に限る
-- P0/P1 相当の重大 finding を dismiss する場合は、
-  必要に応じて独立 reviewer の確認を要求する
-- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
-- fix 後は全 discovery をやり直さず、targeted closure を基本とする
-- review を新しい scope の探索に使わない
+finding を fix / false-positive / needs-verification / technical-dispute /
+intent-question へ triage する手続き（human を raw finding の message bus にしない、
+pure technical dispute は technical adjudication で解決する、human escalation は
+product intent / authority に限る、P0/P1 相当の重大 finding を dismiss する場合の
+確認要否、accepted finding の batch fix / root-cause 確認、targeted closure を基本
+とする範囲限定、review を新しい scope の探索に使わないという運用境界を含む）の
+canonical source は `.ai-dev-foundation/skills/review-code.md` の
+`## Review contracts` section です。
+
 - discovery（2nd full discovery を含む）と targeted closure / closure
   verification のいずれの finding も Resolution Contract の対象であり、
   triage category を付けただけでは Resolution 完了ではない。unresolved

--- a/policy/core.md
+++ b/policy/core.md
@@ -22,6 +22,20 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
+policy は、review 実行 agent のみが必要とする conditional な必須事項・禁止事項
+について、その canonical ownership を Foundation-owned な skill へ明示的に
+委譲してよいです。この委譲は次をすべて満たす場合に限ります。
+
+- policy 自身が、委譲先の skill を one-hop pointer として名指しする
+- 委譲後も policy に、review を実行しない Task でも成立していなければ
+  ならない minimum safety boundary（authority 分離、fail-closed な
+  uncertainty rule 等）が残る
+- 同じ規範的なルールを policy と skill の両方に重複して記述しない
+
+この場合、skill が記述する必須事項・禁止事項は policy の複製ではなく、
+委譲された canonical source です。委譲していない規範的なルールについては、
+上記の原則どおり skill は複製しません。
+
 ## Generated adapters
 
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。

--- a/skills/review-code.md
+++ b/skills/review-code.md
@@ -2,10 +2,16 @@
 
 このファイルは `policy/core.md` の Review Protocol（Artifact classification の
 Executable、Review contracts、Review Adapter boundary、Failure / retry、Review
-stopping rules）を使った実行手順です。規範的なルールはここで再定義せず、
-`policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先します。
-Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
-canonical source は本 skill であり、`policy/core.md` には置きません。
+stopping rules）を使った実行手順です。`policy/core.md` が保持する minimum safety
+boundary（CI status ≠ review completion、0 findings の positive evidence 要件、
+target completion state / run record state の区別、merge execution authority の
+分離等）はここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
+矛盾する場合は policy が優先します。
+Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）、
+および Selection Contract / Execution Contract、Acquisition & Validity Contract /
+Resolution Contract の手続き的 detail（`## Review contracts` section。membership
+確定手順、trigger 手順、record schema、durable evidence の persist 手順、triage
+category 等）の canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-code.md` です。consumer には `.ai-dev-foundation/skills/review-code.md`
@@ -22,6 +28,184 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 場合は commit range、および target artifact set を含みます。以降の手順で
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
+
+## Review contracts
+
+Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は
+Review Adapter boundary（`policy/core.md`）へ閉じ込め、ここに固定しません。本
+section は Selection Contract / Execution Contract / Acquisition & Validity
+Contract / Resolution Contract の手続き的 detail の canonical source です。
+`policy/core.md` の Review Protocol が保持する minimum safety boundary（CI status
+≠ review completion、0 findings の positive evidence 要件、target completion
+state / run record state の区別、reviewed target の binding が確認できない場合は
+`unknown`、一致しない場合は `invalid`、Resolution Contract の stage 非依存性・
+ancestor target scope、merge execution authority の分離）と矛盾する場合は
+`policy/core.md` が優先します。review-doc.md（Normative artifact の review）も
+これらの Contract は本 section を canonical source として参照し、重複定義しません。
+
+### Selection Contract
+
+- artifact classification
+- reviewer / capability の選択
+- required review 数
+- expected review set（下記）
+- target artifact set
+- expected target SHA / commit range
+
+**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
+選択していなくても、その repository / review target に対して review を行う reviewer が
+存在し得ます。Selection では次の和集合を expected review set として確定します。
+
+1. **required** — Selection Contract で明示的に required とした reviewer。
+   required review 数を満たす対象であり、その review obligation は merge /
+   review completion の blocker です。
+2. **expected** — required ではないが、次のいずれかに該当する reviewer。
+   required review 数には算入しませんが、その review obligation は merge /
+   review completion の blocker です。
+   - consumer が configured automatic reviewer として明示している
+   - 取得済み evidence が、その actor による review 行為をその review target 上で
+     識別させる。**この判定は current target に限りません。** 同じ review flow の
+     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
+     actor は、以降の target でも expected member として残ります。target が移動
+     しただけで member から外してはいけません
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
+   completion state が `unknown` であること自体は blocker にしません。ただし actual
+   finding が観測された場合、その finding は Resolution Contract の対象です。
+
+一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
+observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
+review 行為を行っても optional のままです（その finding は Resolution Contract の対象
+です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
+
+consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
+するかは、consumer-owned な **reviewer capability record** に置きます。Kernel はこの
+record が存在すること、および Selection がそれを参照することを要求します。record の
+schema / template と、その存在 / parse / 最小妥当性の check は Foundation tooling /
+profile 側が提供し、record の内容は consumer-owned のままです。record は portfolio 上の
+default を表すものであり、当該 Task の required / expected obligation の正本ではありません。
+それは従来どおり Selection Contract が確定します。
+
+2 の後者について、actor を expected member とする根拠は、その surface item 自体が
+**review participation として識別できる**ことです。review target 上に presence が
+あるだけでは足りず、次は単独では expected member 化の根拠になりません。
+
+- 通常の human comment（議論・質問・進捗報告等）
+- CI actor（workflow / status / check の author であること）
+- review 以外の目的で投稿する bot
+
+どの surface item が review participation を構成するかの識別は Review Adapter
+boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
+member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
+持ちません。
+
+reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
+表現してよく、**expected / optional の member については、その reviewer の target
+completion state を理由に blocker としません**。
+
+**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
+discharge しません。** ancestor target で出した finding についても同じです。非参加の
+宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
+
+**required member は非参加の宣言によって blocker から外れません。** required とした
+reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
+代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
+まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
+gate を迂回する経路にしてはいけません。
+
+expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
+target 上にも**まだ review participation evidence を出していない reviewer を含め
+られません。ancestor target で participation evidence を出している reviewer は、
+上記の carry-over により member です。この residual
+limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
+configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
+
+### Execution Contract
+
+- trigger 方法
+- Selection で確定した expected target SHA / commit range
+- Selection で確定した target artifact set
+- required context
+- timeout / retry policy
+
+Selection Contract で確定した expected target（SHA / commit range）と
+target artifact set は、Execution で reviewer の trigger へ渡し、実際に
+渡した target と artifact set を記録します。commit range を選択した場合に
+head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
+黙って縮小・変更しません。
+
+provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
+
+### Acquisition & Validity Contract
+
+review run ごとに少なくとも次を記録可能にします。
+
+```json
+{
+  "reviewer": "...",
+  "target_sha": "...",
+  "status": "completed",
+  "validity": "valid",
+  "finding_count": 0,
+  "result_locator": "...",
+  "started_at": "...",
+  "completed_at": "...",
+  "failure": null
+}
+```
+
+record の `target_sha` は、Selection Contract の expected target（SHA / commit
+range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
+`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します（`policy/core.md`
+の Completion / Validity 要求事項参照）。
+
+acquisition の record は、後続 session から独立に recoverable な場所へ
+persist されて初めて durable evidence です。review を行った
+agent/session が終了した後、別の後続 session が session の記憶に頼らず、
+Acquisition & Validity Contract が定義する Completion と Validity の要求事項を
+独立に判定できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
+上の comment 等）に存在しない限り、その run を merge / review completion
+の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
+へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
+自体をこの record の recoverable な representation として扱ってよく、
+別途 record を post し直す必要はありません。含まれていない場合
+（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
+例えば実装 session 内で動く subagent review を含む）は、上記の record
+schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
+情報を、そのような場所へ明示的に persist しない限り、session 終了後には
+recoverable な evidence として扱いません。
+
+triage した review result の revision は、判断の対象です。review result は
+in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
+その reviewer の target completion state は変わりません。したがって、ある run を
+merge / review completion の根拠とするには、triage / Resolution の対象とした result の
+revision が、判断時点の current revision と同一であることを確認します。この確認は
+deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+（`policy/core.md`: current revision が異なる場合、その result はまだ triage されて
+いない result として扱います。）
+
+Acquisition & Validity Contract および Selection Contract が「記録すること」を
+要求する事項——各 actor の membership class とその根拠、target completion state と
+その binding の根拠、triage の対象とした result の revision、および current target の
+clean / discovery evidence として採用した run——は、個々の run record schema ではなく、
+その review stage の Selection / fence 記録として persist します。これらは run 単位
+ではなく reviewer 単位・stage 単位の情報であるためです。
+
+### Resolution Contract
+
+- finding を fix / false-positive / needs-verification / technical-dispute /
+  intent-question へ triage する
+- human を raw finding の message bus にしない
+- pure technical dispute は technical adjudication で解決する
+- human escalation は product intent / authority に限る
+- P0/P1 相当の重大 finding を dismiss する場合は、
+  必要に応じて独立 reviewer の確認を要求する
+- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
+- fix 後は全 discovery をやり直さず、targeted closure を基本とする
+- review を新しい scope の探索に使わない
+
+discovery（2nd full discovery を含む）と targeted closure / closure verification の
+stage 非依存性、および ancestor target で発見された finding の scope は
+`policy/core.md` の Resolution Contract（Kernel-retained invariant）が定めます。
 
 ## Foundation helper の実行（consumer cwd）
 
@@ -310,9 +494,9 @@ required/expected review の消化根拠にしてはいけません。この区�
     closure 用 Selection Contract で required とした review 数ぶんの valid
     な closure run が揃うまで Closure Resolution へ進みません。不足する
     run の扱いは Failure / retry（`policy/core.md`）に従います。
-12. **Closure Resolution** — targeted closure の finding を Resolution
-    Contract（`policy/core.md`）に従って triage します。unresolved の
-    finding がある間は merge しません。
+12. **Closure Resolution** — targeted closure の finding を、上記
+    `## Review contracts` の Resolution Contract に従って triage します。
+    unresolved の finding がある間は merge しません。
     accepted な closure finding があれば、手順 7 と同じ batch fix
     semantics でまとめて fix し、手順 8 と同じ deterministic verify を
     行います。
@@ -439,11 +623,11 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存
   します。reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合
-  （例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition &
-  Validity Contract が定める durable evidence の要求を、その手段で満たします。何を
-  persist すれば足りるかは同 Contract が定めます。
+  （例: 実装 session 内で動く subagent review）は、本 skill の `## Review contracts`
+  （Acquisition & Validity Contract）が定める durable evidence の要求を、その手段で
+  満たします。何を persist すれば足りるかは同 Contract が定めます。
 - `normalizeFindings()`: finding の意味付けと Resolution はこの skill の機械判定へ
-  複製せず、`policy/core.md` の Resolution Contract に従います。
+  複製せず、`## Review contracts` の Resolution Contract に従います。
 
 record が、結果を durable な GitHub surface へ残す trigger 経路を宣言している場合は、
 その経路を preferred route として使います。宣言された経路が unavailable / unsuitable で、

--- a/skills/review-doc.md
+++ b/skills/review-doc.md
@@ -1,9 +1,14 @@
 # review-doc skill
 
 このファイルは `policy/core.md` の Review Protocol（Artifact classification の
-Normative、Review contracts、Review stopping rules）を使った実行手順です。規範的な
-ルールはここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
-矛盾する場合は policy が優先します。
+Normative、Review contracts、Review stopping rules）を使った実行手順です。
+`policy/core.md` が保持する minimum safety boundary はここで再定義せず、
+`policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先
+します。Selection Contract / Execution Contract、Acquisition & Validity Contract /
+Resolution Contract の手続き的 detail の canonical source は Foundation リポジトリの
+`skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md`
+として配布）の `## Review contracts` section です。本 skill ではこれらの Contract を
+重複定義しません。
 Normative artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
 canonical source は本 skill であり、`policy/core.md` には置きません。
 
@@ -55,11 +60,13 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    check が対象とした document / artifact scope を必要な精度で記録した
    上で、markdown の形式チェック（lint / format / link 切れ等、repository
    が持つ機械的な check）を実行します。
-2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
-   range、target artifact set、reviewer / capability、required review 数、
-   および expected review set を確定します。expected review set は自分が
-   trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
-   記録は Selection Contract（`policy/core.md`）に従います。
+2. **Selection** — Selection Contract（`.ai-dev-foundation/skills/review-code.md`
+   の `## Review contracts`）に従い、target SHA / range、target artifact set、
+   reviewer / capability、required review 数、および expected review set を
+   確定します。expected review set は自分が trigger した reviewer だけでは
+   閉じません。閉じ方と、member とした根拠の記録は Selection Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）に
+   従います。
    **Mixed classification の場合は、required な review skill をすべて宣言します。**
    手順 1 の mechanical check 対象と確定した target の一致、および宣言した routing と
    changed artifact set の整合は、手順 9 の fence が機械判定します。手順の各所で
@@ -95,7 +102,9 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    手順 3 の anchor をそのまま使い回しません）、closure verification と手順 9 の fence
    ではその closure run の anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
-   （`policy/core.md`）に従い、target SHA / range、target artifact set、
+   （`policy/core.md` の target completion state 等の invariant、および
+   `.ai-dev-foundation/skills/review-code.md` の `## Review contracts` の
+   手続き的 detail）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
    Selection Contract で required とした review 数ぶんの `validity: valid`
    な run が揃うまで triage へ進みません。
@@ -104,8 +113,9 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    required 数の valid run が揃うことは triage へ進むための gate ですが、
    finding の集約対象は valid な run に限りません。ancestor target に対する run の
    ように `validity: valid` でない run であっても、そこで既に発見された finding は
-   Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
-   判定であり、finding を捨ててよい根拠ではありません。
+   Resolution Contract（`.ai-dev-foundation/skills/review-code.md` の
+   `## Review contracts`）の対象です。`validity` は evidence 軸の判定であり、
+   finding を捨ててよい根拠ではありません。
    run record の `status` / `validity` とは別に、各 reviewer の target completion
    state を判定します。positive completion evidence の target-bound 要件、binding へ
    使う field / surface の安定性要件、および binding が成立しない場合の扱いは、
@@ -128,11 +138,13 @@ repository root を基準に明示的に渡します。ここでは重複定義�
 7. **Closure** — accepted finding の fix によって target SHA / range または
    target artifact set が変わった場合のみ行います。修正後の target に
    対して手順 1 の mechanical check を再実行し、成功したらその SHA / range を
-   closure target として re-freeze し、Selection Contract（`policy/core.md`）を
+   closure target として re-freeze し、Selection Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を
    この closure review run に適用します。
    確定した closure artifact set を、直近の mechanical-check evidence が
    カバーしていることを確認します。確認できない場合は、確定した closure target に
-   対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
+   対して mechanical check を再実行してから、Execution Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を
    closure review run に適用します。この closure run を起動した時点で、手順 3 と
    同様にこの run 専用の run anchor を新たに記録します。
    その上で、triage した finding に対応しているかの closure verification
@@ -157,8 +169,10 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    この branch でも、手順 9 の merge-ready fence を通る前に review completion /
    merge-ready を宣言しません。fence の要否は accepted fix の有無ではなく、
    その宣言を行うかどうかで決まります。
-8. **Closure Resolution** — closure verification（手順 7）の finding を
-   Resolution Contract（`policy/core.md`）に従って triage します。
+8. **Closure Resolution** — closure verification（手順 7）の finding を、
+   Foundation リポジトリの `skills/review-code.md`（consumer には
+   `.ai-dev-foundation/skills/review-code.md` として配布）の
+   `## Review contracts` の Resolution Contract に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。
    accepted な closure finding があれば、手順 6〜7 と同じ procedure（fix ->
    mechanical check -> closure verification -> closure Acquisition &

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-code.md
@@ -2,10 +2,16 @@
 
 このファイルは `policy/core.md` の Review Protocol（Artifact classification の
 Executable、Review contracts、Review Adapter boundary、Failure / retry、Review
-stopping rules）を使った実行手順です。規範的なルールはここで再定義せず、
-`policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先します。
-Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
-canonical source は本 skill であり、`policy/core.md` には置きません。
+stopping rules）を使った実行手順です。`policy/core.md` が保持する minimum safety
+boundary（CI status ≠ review completion、0 findings の positive evidence 要件、
+target completion state / run record state の区別、merge execution authority の
+分離等）はここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
+矛盾する場合は policy が優先します。
+Executable artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）、
+および Selection Contract / Execution Contract、Acquisition & Validity Contract /
+Resolution Contract の手続き的 detail（`## Review contracts` section。membership
+確定手順、trigger 手順、record schema、durable evidence の persist 手順、triage
+category 等）の canonical source は本 skill であり、`policy/core.md` には置きません。
 
 この skill の canonical source は Foundation リポジトリの `policy/core.md` および
 `skills/review-code.md` です。consumer には `.ai-dev-foundation/skills/review-code.md`
@@ -22,6 +28,184 @@ review target は Selection Contract に従い、candidate SHA、applicable な
 場合は commit range、および target artifact set を含みます。以降の手順で
 SHA について述べる箇所は、commit range や target artifact set を使う
 review でも同じ意味で適用します。
+
+## Review contracts
+
+Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は
+Review Adapter boundary（`policy/core.md`）へ閉じ込め、ここに固定しません。本
+section は Selection Contract / Execution Contract / Acquisition & Validity
+Contract / Resolution Contract の手続き的 detail の canonical source です。
+`policy/core.md` の Review Protocol が保持する minimum safety boundary（CI status
+≠ review completion、0 findings の positive evidence 要件、target completion
+state / run record state の区別、reviewed target の binding が確認できない場合は
+`unknown`、一致しない場合は `invalid`、Resolution Contract の stage 非依存性・
+ancestor target scope、merge execution authority の分離）と矛盾する場合は
+`policy/core.md` が優先します。review-doc.md（Normative artifact の review）も
+これらの Contract は本 section を canonical source として参照し、重複定義しません。
+
+### Selection Contract
+
+- artifact classification
+- reviewer / capability の選択
+- required review 数
+- expected review set（下記）
+- target artifact set
+- expected target SHA / commit range
+
+**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
+選択していなくても、その repository / review target に対して review を行う reviewer が
+存在し得ます。Selection では次の和集合を expected review set として確定します。
+
+1. **required** — Selection Contract で明示的に required とした reviewer。
+   required review 数を満たす対象であり、その review obligation は merge /
+   review completion の blocker です。
+2. **expected** — required ではないが、次のいずれかに該当する reviewer。
+   required review 数には算入しませんが、その review obligation は merge /
+   review completion の blocker です。
+   - consumer が configured automatic reviewer として明示している
+   - 取得済み evidence が、その actor による review 行為をその review target 上で
+     識別させる。**この判定は current target に限りません。** 同じ review flow の
+     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
+     actor は、以降の target でも expected member として残ります。target が移動
+     しただけで member から外してはいけません
+3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
+   completion state が `unknown` であること自体は blocker にしません。ただし actual
+   finding が観測された場合、その finding は Resolution Contract の対象です。
+
+一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
+observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
+review 行為を行っても optional のままです（その finding は Resolution Contract の対象
+です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
+
+consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
+するかは、consumer-owned な **reviewer capability record** に置きます。Kernel はこの
+record が存在すること、および Selection がそれを参照することを要求します。record の
+schema / template と、その存在 / parse / 最小妥当性の check は Foundation tooling /
+profile 側が提供し、record の内容は consumer-owned のままです。record は portfolio 上の
+default を表すものであり、当該 Task の required / expected obligation の正本ではありません。
+それは従来どおり Selection Contract が確定します。
+
+2 の後者について、actor を expected member とする根拠は、その surface item 自体が
+**review participation として識別できる**ことです。review target 上に presence が
+あるだけでは足りず、次は単独では expected member 化の根拠になりません。
+
+- 通常の human comment（議論・質問・進捗報告等）
+- CI actor（workflow / status / check の author であること）
+- review 以外の目的で投稿する bot
+
+どの surface item が review participation を構成するかの識別は Review Adapter
+boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
+member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
+持ちません。
+
+reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
+表現してよく、**expected / optional の member については、その reviewer の target
+completion state を理由に blocker としません**。
+
+**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
+discharge しません。** ancestor target で出した finding についても同じです。非参加の
+宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
+
+**required member は非参加の宣言によって blocker から外れません。** required とした
+reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
+代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
+まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
+gate を迂回する経路にしてはいけません。
+
+expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
+target 上にも**まだ review participation evidence を出していない reviewer を含め
+られません。ancestor target で participation evidence を出している reviewer は、
+上記の carry-over により member です。この residual
+limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
+configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
+
+### Execution Contract
+
+- trigger 方法
+- Selection で確定した expected target SHA / commit range
+- Selection で確定した target artifact set
+- required context
+- timeout / retry policy
+
+Selection Contract で確定した expected target（SHA / commit range）と
+target artifact set は、Execution で reviewer の trigger へ渡し、実際に
+渡した target と artifact set を記録します。commit range を選択した場合に
+head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
+黙って縮小・変更しません。
+
+provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
+
+### Acquisition & Validity Contract
+
+review run ごとに少なくとも次を記録可能にします。
+
+```json
+{
+  "reviewer": "...",
+  "target_sha": "...",
+  "status": "completed",
+  "validity": "valid",
+  "finding_count": 0,
+  "result_locator": "...",
+  "started_at": "...",
+  "completed_at": "...",
+  "failure": null
+}
+```
+
+record の `target_sha` は、Selection Contract の expected target（SHA / commit
+range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
+`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します（`policy/core.md`
+の Completion / Validity 要求事項参照）。
+
+acquisition の record は、後続 session から独立に recoverable な場所へ
+persist されて初めて durable evidence です。review を行った
+agent/session が終了した後、別の後続 session が session の記憶に頼らず、
+Acquisition & Validity Contract が定義する Completion と Validity の要求事項を
+独立に判定できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
+上の comment 等）に存在しない限り、その run を merge / review completion
+の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
+へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
+自体をこの record の recoverable な representation として扱ってよく、
+別途 record を post し直す必要はありません。含まれていない場合
+（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
+例えば実装 session 内で動く subagent review を含む）は、上記の record
+schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
+情報を、そのような場所へ明示的に persist しない限り、session 終了後には
+recoverable な evidence として扱いません。
+
+triage した review result の revision は、判断の対象です。review result は
+in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
+その reviewer の target completion state は変わりません。したがって、ある run を
+merge / review completion の根拠とするには、triage / Resolution の対象とした result の
+revision が、判断時点の current revision と同一であることを確認します。この確認は
+deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+（`policy/core.md`: current revision が異なる場合、その result はまだ triage されて
+いない result として扱います。）
+
+Acquisition & Validity Contract および Selection Contract が「記録すること」を
+要求する事項——各 actor の membership class とその根拠、target completion state と
+その binding の根拠、triage の対象とした result の revision、および current target の
+clean / discovery evidence として採用した run——は、個々の run record schema ではなく、
+その review stage の Selection / fence 記録として persist します。これらは run 単位
+ではなく reviewer 単位・stage 単位の情報であるためです。
+
+### Resolution Contract
+
+- finding を fix / false-positive / needs-verification / technical-dispute /
+  intent-question へ triage する
+- human を raw finding の message bus にしない
+- pure technical dispute は technical adjudication で解決する
+- human escalation は product intent / authority に限る
+- P0/P1 相当の重大 finding を dismiss する場合は、
+  必要に応じて独立 reviewer の確認を要求する
+- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
+- fix 後は全 discovery をやり直さず、targeted closure を基本とする
+- review を新しい scope の探索に使わない
+
+discovery（2nd full discovery を含む）と targeted closure / closure verification の
+stage 非依存性、および ancestor target で発見された finding の scope は
+`policy/core.md` の Resolution Contract（Kernel-retained invariant）が定めます。
 
 ## Foundation helper の実行（consumer cwd）
 
@@ -310,9 +494,9 @@ required/expected review の消化根拠にしてはいけません。この区�
     closure 用 Selection Contract で required とした review 数ぶんの valid
     な closure run が揃うまで Closure Resolution へ進みません。不足する
     run の扱いは Failure / retry（`policy/core.md`）に従います。
-12. **Closure Resolution** — targeted closure の finding を Resolution
-    Contract（`policy/core.md`）に従って triage します。unresolved の
-    finding がある間は merge しません。
+12. **Closure Resolution** — targeted closure の finding を、上記
+    `## Review contracts` の Resolution Contract に従って triage します。
+    unresolved の finding がある間は merge しません。
     accepted な closure finding があれば、手順 7 と同じ batch fix
     semantics でまとめて fix し、手順 8 と同じ deterministic verify を
     行います。
@@ -439,11 +623,11 @@ provider 固有 adapter がまだ無い間は、`trigger()` / `pollCompletion()`
   として扱い、`unknown` / `in-flight` を terminal failure にしません。
 - `collectOutputs()`: 同じ helper の `--json` output を durable evidence として保存
   します。reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合
-  （例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition &
-  Validity Contract が定める durable evidence の要求を、その手段で満たします。何を
-  persist すれば足りるかは同 Contract が定めます。
+  （例: 実装 session 内で動く subagent review）は、本 skill の `## Review contracts`
+  （Acquisition & Validity Contract）が定める durable evidence の要求を、その手段で
+  満たします。何を persist すれば足りるかは同 Contract が定めます。
 - `normalizeFindings()`: finding の意味付けと Resolution はこの skill の機械判定へ
-  複製せず、`policy/core.md` の Resolution Contract に従います。
+  複製せず、`## Review contracts` の Resolution Contract に従います。
 
 record が、結果を durable な GitHub surface へ残す trigger 経路を宣言している場合は、
 その経路を preferred route として使います。宣言された経路が unavailable / unsuitable で、

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/review-doc.md
@@ -1,9 +1,14 @@
 # review-doc skill
 
 このファイルは `policy/core.md` の Review Protocol（Artifact classification の
-Normative、Review contracts、Review stopping rules）を使った実行手順です。規範的な
-ルールはここで再定義せず、`policy/core.md` を参照します。本 skill と policy が
-矛盾する場合は policy が優先します。
+Normative、Review contracts、Review stopping rules）を使った実行手順です。
+`policy/core.md` が保持する minimum safety boundary はここで再定義せず、
+`policy/core.md` を参照します。本 skill と policy が矛盾する場合は policy が優先
+します。Selection Contract / Execution Contract、Acquisition & Validity Contract /
+Resolution Contract の手続き的 detail の canonical source は Foundation リポジトリの
+`skills/review-code.md`（consumer には `.ai-dev-foundation/skills/review-code.md`
+として配布）の `## Review contracts` section です。本 skill ではこれらの Contract を
+重複定義しません。
 Normative artifact の review 手順（`## 手順` と `## 停止条件` の finite flow）の
 canonical source は本 skill であり、`policy/core.md` には置きません。
 
@@ -55,11 +60,13 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    check が対象とした document / artifact scope を必要な精度で記録した
    上で、markdown の形式チェック（lint / format / link 切れ等、repository
    が持つ機械的な check）を実行します。
-2. **Selection** — Selection Contract（`policy/core.md`）に従い、target SHA /
-   range、target artifact set、reviewer / capability、required review 数、
-   および expected review set を確定します。expected review set は自分が
-   trigger した reviewer だけでは閉じません。閉じ方と、member とした根拠の
-   記録は Selection Contract（`policy/core.md`）に従います。
+2. **Selection** — Selection Contract（`.ai-dev-foundation/skills/review-code.md`
+   の `## Review contracts`）に従い、target SHA / range、target artifact set、
+   reviewer / capability、required review 数、および expected review set を
+   確定します。expected review set は自分が trigger した reviewer だけでは
+   閉じません。閉じ方と、member とした根拠の記録は Selection Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）に
+   従います。
    **Mixed classification の場合は、required な review skill をすべて宣言します。**
    手順 1 の mechanical check 対象と確定した target の一致、および宣言した routing と
    changed artifact set の整合は、手順 9 の fence が機械判定します。手順の各所で
@@ -95,7 +102,9 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    手順 3 の anchor をそのまま使い回しません）、closure verification と手順 9 の fence
    ではその closure run の anchor を使います。
 4. **Acquisition & Validity 確認** — Acquisition & Validity Contract
-   （`policy/core.md`）に従い、target SHA / range、target artifact set、
+   （`policy/core.md` の target completion state 等の invariant、および
+   `.ai-dev-foundation/skills/review-code.md` の `## Review contracts` の
+   手続き的 detail）に従い、target SHA / range、target artifact set、
    completion、acquisition、validity を確認します。
    Selection Contract で required とした review 数ぶんの `validity: valid`
    な run が揃うまで triage へ進みません。
@@ -104,8 +113,9 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    required 数の valid run が揃うことは triage へ進むための gate ですが、
    finding の集約対象は valid な run に限りません。ancestor target に対する run の
    ように `validity: valid` でない run であっても、そこで既に発見された finding は
-   Resolution Contract（`policy/core.md`）の対象です。`validity` は evidence 軸の
-   判定であり、finding を捨ててよい根拠ではありません。
+   Resolution Contract（`.ai-dev-foundation/skills/review-code.md` の
+   `## Review contracts`）の対象です。`validity` は evidence 軸の判定であり、
+   finding を捨ててよい根拠ではありません。
    run record の `status` / `validity` とは別に、各 reviewer の target completion
    state を判定します。positive completion evidence の target-bound 要件、binding へ
    使う field / surface の安定性要件、および binding が成立しない場合の扱いは、
@@ -128,11 +138,13 @@ repository root を基準に明示的に渡します。ここでは重複定義�
 7. **Closure** — accepted finding の fix によって target SHA / range または
    target artifact set が変わった場合のみ行います。修正後の target に
    対して手順 1 の mechanical check を再実行し、成功したらその SHA / range を
-   closure target として re-freeze し、Selection Contract（`policy/core.md`）を
+   closure target として re-freeze し、Selection Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を
    この closure review run に適用します。
    確定した closure artifact set を、直近の mechanical-check evidence が
    カバーしていることを確認します。確認できない場合は、確定した closure target に
-   対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を
+   対して mechanical check を再実行してから、Execution Contract
+   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を
    closure review run に適用します。この closure run を起動した時点で、手順 3 と
    同様にこの run 専用の run anchor を新たに記録します。
    その上で、triage した finding に対応しているかの closure verification
@@ -157,8 +169,10 @@ repository root を基準に明示的に渡します。ここでは重複定義�
    この branch でも、手順 9 の merge-ready fence を通る前に review completion /
    merge-ready を宣言しません。fence の要否は accepted fix の有無ではなく、
    その宣言を行うかどうかで決まります。
-8. **Closure Resolution** — closure verification（手順 7）の finding を
-   Resolution Contract（`policy/core.md`）に従って triage します。
+8. **Closure Resolution** — closure verification（手順 7）の finding を、
+   Foundation リポジトリの `skills/review-code.md`（consumer には
+   `.ai-dev-foundation/skills/review-code.md` として配布）の
+   `## Review contracts` の Resolution Contract に従って triage します。
    unresolved の finding がある間は review procedure を完了としません。
    accepted な closure finding があれば、手順 6〜7 と同じ procedure（fix ->
    mechanical check -> closure verification -> closure Acquisition &

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -267,7 +267,15 @@ Review 強度と停止条件は artifact の種類で分けます。
 ### Review contracts
 
 Review は次の 4 つの provider-neutral な contract で表現します。provider 差分は Review
-Adapter boundary へ閉じ込め、Kernel に固定しません。
+Adapter boundary へ閉じ込め、Kernel に固定しません。**Selection Contract、Execution
+Contract、および Acquisition & Validity Contract / Resolution Contract の手続き的
+detail（membership 確定手順、trigger 手順、record schema、triage category 等）の
+canonical source は Foundation-owned な review skill
+（`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section）です。
+本節は、review を実行しない Task でも成立していなければならない minimum safety
+boundary、および Merge readiness and merge authority が前提とする語彙・不変条件のみを
+保持します。**該当する review 手順へ入る前に、Skill routing contract に従って対応する
+skill を load することは引き続き **MUST** です。
 
 各 Contract は discovery だけでなく、同じ Contract を使って起動する closure review run
 にも適用されます。closure target も Selection Contract で expected target として確定し、
@@ -285,122 +293,10 @@ Resolution が完了している必要があります。discovery Resolution を
 より先に完了させる順序を強制するものではなく、merge / review completion
 の時点で揃っていれば十分です。
 
-#### Selection Contract
-
-- artifact classification
-- reviewer / capability の選択
-- required review 数
-- expected review set（下記）
-- target artifact set
-- expected target SHA / commit range
-
-**expected review set は、agent が選択した reviewer だけでは閉じません。** agent が
-選択していなくても、その repository / review target に対して review を行う reviewer が
-存在し得ます。Selection では次の和集合を expected review set として確定します。
-
-1. **required** — Selection Contract で明示的に required とした reviewer。
-   required review 数を満たす対象であり、その review obligation は merge /
-   review completion の blocker です。
-2. **expected** — required ではないが、次のいずれかに該当する reviewer。
-   required review 数には算入しませんが、その review obligation は merge /
-   review completion の blocker です。
-   - consumer が configured automatic reviewer として明示している
-   - 取得済み evidence が、その actor による review 行為をその review target 上で
-     識別させる。**この判定は current target に限りません。** 同じ review flow の
-     中で、ancestor target を含むいずれかの target 上で review 行為を識別できた
-     actor は、以降の target でも expected member として残ります。target が移動
-     しただけで member から外してはいけません
-3. **optional / advisory** — consumer が advisory と宣言した reviewer。target
-   completion state が `unknown` であること自体は blocker にしません。ただし actual
-   finding が観測された場合、その finding は Resolution Contract の対象です。
-
-一つの actor が複数の class の条件を満たす場合、**consumer による明示的な宣言が
-observed evidence に優先します**。consumer が advisory と宣言した reviewer は、実際に
-review 行為を行っても optional のままです（その finding は Resolution Contract の対象
-です）。consumer が required と宣言した reviewer は、他の条件にかかわらず required です。
-
-consumer が reviewer を required / configured automatic / advisory のいずれとして宣言
-するかは、consumer-owned な **reviewer capability record** に置きます。Kernel はこの
-record が存在すること、および Selection がそれを参照することを要求します。record の
-schema / template と、その存在 / parse / 最小妥当性の check は Foundation tooling /
-profile 側が提供し、record の内容は consumer-owned のままです。record は portfolio 上の
-default を表すものであり、当該 Task の required / expected obligation の正本ではありません。
-それは従来どおり Selection Contract が確定します。
-
-2 の後者について、actor を expected member とする根拠は、その surface item 自体が
-**review participation として識別できる**ことです。review target 上に presence が
-あるだけでは足りず、次は単独では expected member 化の根拠になりません。
-
-- 通常の human comment（議論・質問・進捗報告等）
-- CI actor（workflow / status / check の author であること）
-- review 以外の目的で投稿する bot
-
-どの surface item が review participation を構成するかの識別は Review Adapter
-boundary の責務です。Kernel は上記の membership 境界と、**その actor を expected
-member とした根拠を記録すること**のみを要求し、provider 名や surface 名の固定列挙を
-持ちません。
-
-reviewer が非参加を positive に宣言している場合、その状態を `unknown` と区別して
-表現してよく、**expected / optional の member については、その reviewer の target
-completion state を理由に blocker としません**。
-
-**非参加の宣言は、その reviewer が既に出した finding の Resolution obligation を
-discharge しません。** ancestor target で出した finding についても同じです。非参加の
-宣言が免除するのは、その target について新たな completion evidence を得ることだけです。
-
-**required member は非参加の宣言によって blocker から外れません。** required とした
-reviewer が非参加を宣言した場合、その required review obligation は消えず、valid な
-代替 run を得るか、Selection Contract を明示的に変更して required 構成を確定し直す
-まで、merge / review completion へ進みません。非参加の宣言を、required review 数の
-gate を迂回する経路にしてはいけません。
-
-expected review set は、consumer が明示しておらず、かつ**この review flow のいずれの
-target 上にも**まだ review participation evidence を出していない reviewer を含め
-られません。ancestor target で participation evidence を出している reviewer は、
-上記の carry-over により member です。この residual
-limitation を、reviewer の不在を `0 findings` とみなす根拠にしてはいけません。
-configured automatic reviewer を明示するかどうかは consumer-owned な選択です。
-
-#### Execution Contract
-
-- trigger 方法
-- Selection で確定した expected target SHA / commit range
-- Selection で確定した target artifact set
-- required context
-- timeout / retry policy
-
-Selection Contract で確定した expected target（SHA / commit range）と
-target artifact set は、Execution で reviewer の trigger へ渡し、実際に
-渡した target と artifact set を記録します。commit range を選択した場合に
-head SHA だけへ黙って縮退させないのと同様に、target artifact set も途中で
-黙って縮小・変更しません。
-
-provider 固有の surface や capability は adapter/profile 側へ置き、Kernel に固定しません。
-
 #### Acquisition & Validity Contract
 
 **CI status は review completion と同義ではありません。** status/check の green 化のみを
 review 完了の証跡にしてはいけません。
-
-review run ごとに少なくとも次を記録可能にします。
-
-```json
-{
-  "reviewer": "...",
-  "target_sha": "...",
-  "status": "completed",
-  "validity": "valid",
-  "finding_count": 0,
-  "result_locator": "...",
-  "started_at": "...",
-  "completed_at": "...",
-  "failure": null
-}
-```
-
-record の `target_sha` は、Selection Contract の expected target（SHA / commit
-range）ではなく、実際に reviewed された SHA / range（observed target）を表します。
-`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。
 
 Completion は少なくとも次を要求します。
 
@@ -428,23 +324,13 @@ Foundation-owned な deterministic evaluator が所有します。その手順�
   invalid です。この場合、record は `status: completed` かつ `validity: invalid` として
   表現します。intended artifact set が review されていない場合も invalid です。
 
-**acquisition の record は、後続 session から独立に recoverable な場所へ
-persist されて初めて durable evidence です。** review を行った
-agent/session が終了した後、別の後続 session が session の記憶に頼らず、
-本 Contract が定義する Completion と Validity の要求事項を独立に判定
-できるだけの情報が、その後続 session からアクセス可能な場所（PR/Issue
-上の comment 等）に存在しない限り、その run を merge / review completion
-の根拠として扱いません。reviewer mechanism が外部から確認可能な surface
-へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface
-自体をこの record の recoverable な representation として扱ってよく、
-別途 record を post し直す必要はありません。含まれていない場合
-（reviewer mechanism 自身がそのような surface へ結果を残さない場合、
-例えば実装 session 内で動く subagent review を含む）は、上記の record
-schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる
-情報を、そのような場所へ明示的に persist しない限り、session 終了後には
-recoverable な evidence として扱いません。record schema 自体（特に
-`validity` field）は判定結果の要約であり、その根拠情報の代わりには
-なりません。
+**acquisition の record は、後続 session から独立に recoverable な場所へ persist
+されて初めて durable evidence です。** どのような persistence が独立 recoverable と
+みなせるかの手続き的 detail（reviewer mechanism 自身が外部から確認可能な surface を
+残す場合の扱い、残さない場合の代替 persist 手順を含む）の canonical source は
+`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section です。
+record schema 自体（特に `validity` field）は判定結果の要約であり、その根拠情報の
+代わりにはなりません。
 
 **0 findings は positive evidence を必要とします。** reaction なし、comment なし、
 parser 0 件、status success のみを `no findings` へ変換してはいけません。positive
@@ -465,21 +351,15 @@ item のうち、その target への resolvable な参照を持つ positive com
 （または、reviewed target を確定できた上で一致しない場合は `not-bound`）であり、
 `0 findings` へ変換してはいけません。
 
-**triage した review result の revision は、判断の対象です。** review result は
-in-place で編集され得ます。completion evidence を保ったまま内容だけが変わった場合、
-その reviewer の target completion state は変わりません。したがって、ある run を
-merge / review completion の根拠とするには、triage / Resolution の対象とした result の
-revision が、判断時点の current revision と同一であることを確認します。この確認は
-deterministic な同一性の照合であり、finding の意味を読み直すことを要求しません。
+**triage した review result の revision は、判断の対象です。** review result の
+in-place 編集を検出し、triage / Resolution の対象とした result の revision と
+判断時点の current revision の同一性を確認する手続き的 detail の canonical source は
+`.ai-dev-foundation/skills/review-code.md` の `## Review contracts` section です。
 current revision が異なる場合、その result はまだ triage されていない result として
-扱います。
-
-本 Contract および Selection Contract が「記録すること」を要求する事項——各 actor の
-membership class とその根拠、target completion state とその binding の根拠、triage の
-対象とした result の revision、および current target の clean / discovery evidence として
-採用した run——は、個々の run record schema ではなく、その review stage の Selection /
-fence 記録として persist します。これらは run 単位ではなく reviewer 単位・stage 単位の
-情報であるためです。
+扱います。この Contract および Selection Contract が「記録すること」を要求する事項が、
+個々の run record schema ではなくその review stage の Selection / fence 記録として
+persist される理由（reviewer 単位・stage 単位の情報であること）も同じ canonical source
+に従います。
 
 target completion state が `not-bound` である reviewer（reviewed target が expected
 target と一致しない completed run を持つ reviewer）は、次の 2 軸で扱いを分けます。
@@ -494,16 +374,15 @@ review run の状態は少なくとも `none` / `unknown` / `failure` を区別�
 
 #### Resolution Contract
 
-- finding を fix / false-positive / needs-verification / technical-dispute /
-  intent-question へ triage する
-- human を raw finding の message bus にしない
-- pure technical dispute は technical adjudication で解決する
-- human escalation は product intent / authority に限る
-- P0/P1 相当の重大 finding を dismiss する場合は、
-  必要に応じて独立 reviewer の確認を要求する
-- accepted finding は drip fix せず、root-cause を確認した上で batch で fix する
-- fix 後は全 discovery をやり直さず、targeted closure を基本とする
-- review を新しい scope の探索に使わない
+finding を fix / false-positive / needs-verification / technical-dispute /
+intent-question へ triage する手続き（human を raw finding の message bus にしない、
+pure technical dispute は technical adjudication で解決する、human escalation は
+product intent / authority に限る、P0/P1 相当の重大 finding を dismiss する場合の
+確認要否、accepted finding の batch fix / root-cause 確認、targeted closure を基本
+とする範囲限定、review を新しい scope の探索に使わないという運用境界を含む）の
+canonical source は `.ai-dev-foundation/skills/review-code.md` の
+`## Review contracts` section です。
+
 - discovery（2nd full discovery を含む）と targeted closure / closure
   verification のいずれの finding も Resolution Contract の対象であり、
   triage category を付けただけでは Resolution 完了ではない。unresolved

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -30,6 +30,20 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
+policy は、review 実行 agent のみが必要とする conditional な必須事項・禁止事項
+について、その canonical ownership を Foundation-owned な skill へ明示的に
+委譲してよいです。この委譲は次をすべて満たす場合に限ります。
+
+- policy 自身が、委譲先の skill を one-hop pointer として名指しする
+- 委譲後も policy に、review を実行しない Task でも成立していなければ
+  ならない minimum safety boundary（authority 分離、fail-closed な
+  uncertainty rule 等）が残る
+- 同じ規範的なルールを policy と skill の両方に重複して記述しない
+
+この場合、skill が記述する必須事項・禁止事項は policy の複製ではなく、
+委譲された canonical source です。委譲していない規範的なルールについては、
+上記の原則どおり skill は複製しません。
+
 ## Generated adapters
 
 `AGENTS.md` は三つの composition input から生成されます。直接編集しないでください。

--- a/test/merge-ready-fence.test.mjs
+++ b/test/merge-ready-fence.test.mjs
@@ -702,8 +702,15 @@ test("fence blocks while a finding on a review surface has not been triaged", ()
 // review skills so the two cannot drift apart silently.
 // ---------------------------------------------------------------------------
 
-test("core policy states the expected review set closure rule", async () => {
-  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+// #110 C-1: Selection Contract's expected review set membership algorithm
+// moved from the Kernel to skills/review-code.md's `## Review contracts`
+// section. The Merge-ready completion fence (policy/core.md, unaffected by
+// this move) uses the required/expected/optional vocabulary these rules
+// define, but a review-executing agent has always already MUST-loaded this
+// skill (Skill routing contract) before reaching the fence, so the
+// one-hop-reachable detail can move without weakening the fence.
+test("review-code skill states the expected review set closure rule", async () => {
+  const core = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
   assert.ok(containsText(core, "expected review set は、agent が選択した reviewer だけでは閉じません"));
   assert.ok(containsText(core, "consumer が configured automatic reviewer として明示している"));
@@ -759,8 +766,8 @@ test("core policy states the expected review set closure rule", async () => {
   assert.ok(containsText(core, "actual finding が観測された場合、その finding は Resolution Contract の対象です"));
 });
 
-test("a required member cannot be exempted by declaring non-participation", async () => {
-  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+test("review-code skill: a required member cannot be exempted by declaring non-participation", async () => {
+  const core = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
   assert.ok(
     containsText(core, "expected / optional の member については、その reviewer の target completion state を理由に blocker としません"),
@@ -799,6 +806,7 @@ test("core policy separates run record state from target completion state", asyn
 
 test("core policy requires target-bound positive completion evidence on stable fields", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
   assert.ok(containsText(core, "positive completion evidence は target-bound です"));
   assert.ok(containsText(core, "その target への resolvable な参照を持つ positive completion evidence"));
@@ -811,7 +819,10 @@ test("core policy requires target-bound positive completion evidence on stable f
   assert.ok(
     containsText(core, "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません"),
   );
-  assert.ok(containsText(core, "target completion state とその binding の根拠"));
+  // #110 C-1: the recording-duty phrasing for "target completion state とその
+  // binding の根拠" moved to review-code.md's `## Review contracts` section
+  // alongside the rest of the persist-location paragraph it belongs to.
+  assert.ok(containsText(reviewCode, "target completion state とその binding の根拠"));
   assert.ok(
     containsText(
       core,
@@ -828,6 +839,7 @@ test("core policy requires target-bound positive completion evidence on stable f
 
 test("core policy defines the merge-ready completion fence without overriding stopping rules", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
 
   assert.ok(core.includes("#### Merge-ready completion fence"));
 
@@ -935,12 +947,15 @@ test("core policy defines the merge-ready completion fence without overriding st
   assert.ok(containsText(core, "ここで待つ対象は run record state であり、target completion state ではありません"));
 
   // The residual-limitation sentence must not re-assert current-target-only
-  // membership after the carry-over rule above it.
+  // membership after the carry-over rule above it. #110 C-1: this sentence is
+  // Selection Contract's own text (not the fence's), and moved to
+  // review-code.md's `## Review contracts` section along with the rest of
+  // Selection Contract.
   assert.ok(
-    containsText(core, "**この review flow のいずれの target 上にも**まだ review participation evidence を出していない reviewer"),
+    containsText(reviewCode, "**この review flow のいずれの target 上にも**まだ review participation evidence を出していない reviewer"),
   );
   assert.ok(
-    containsText(core, "ancestor target で participation evidence を出している reviewer は、上記の carry-over により member です"),
+    containsText(reviewCode, "ancestor target で participation evidence を出している reviewer は、上記の carry-over により member です"),
   );
   assert.ok(
     containsText(core, "agent の内心の申告（「この member の沈黙には依拠していない」等）で満たしたことにしてはいけません"),
@@ -1090,7 +1105,6 @@ test("both skills reference the Kernel rules rather than restating them", async 
   const kernelSentences = [
     "全 member が final target で completed であることを要求するものではありません",
     "同じ reviewer による final target の full re-review を強制しません",
-    "review target 上に presence があるだけでは足りず",
     "review target の移動に追随して値が変化する field / surface を binding の根拠にしてはいけません",
     // the review-doc paraphrase of the same rule
     "review target の移動に追随して値が変化するものを根拠にしません",
@@ -1114,6 +1128,13 @@ test("both skills reference the Kernel rules rather than restating them", async 
     );
   }
 
+  // #110 C-1: "review target 上に presence があるだけでは足りず" is no longer a
+  // Kernel-only rule the skills must avoid restating — Selection Contract's
+  // membership algorithm (which states it) is now canonically owned by
+  // review-code.md itself, and review-doc.md correctly does not duplicate it.
+  assert.ok(containsText(code, "review target 上に presence があるだけでは足りず"));
+  assert.ok(!containsText(doc, "review target 上に presence があるだけでは足りず"));
+
   assert.ok(containsText(code, "は、いずれも `policy/core.md` が定めます"));
   assert.ok(containsText(code, "`policy/core.md` の Merge-ready completion fence が定めます"));
   assert.ok(
@@ -1123,7 +1144,11 @@ test("both skills reference the Kernel rules rather than restating them", async 
 
 test("the Kernel states the fence without hard-coding provider specifics", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
-  const added = core.slice(core.indexOf("#### Selection Contract"));
+  // #110 C-1 moved "#### Selection Contract" out of the Kernel; the fence and
+  // its surrounding Merge readiness section are the actual subject of this
+  // guard, so anchor on that heading instead.
+  const added = core.slice(core.indexOf("### Merge readiness and merge authority"));
+  assert.ok(added.length > 0);
 
   for (const providerToken of [
     "Codex",

--- a/test/review-protocol.test.mjs
+++ b/test/review-protocol.test.mjs
@@ -38,8 +38,6 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     "## Review Protocol",
     "### Artifact classification",
     "### Review contracts",
-    "#### Selection Contract",
-    "#### Execution Contract",
     "#### Acquisition & Validity Contract",
     "#### Resolution Contract",
     "### Review Adapter boundary",
@@ -48,6 +46,14 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   ]) {
     assert.ok(core.includes(heading), `missing Review Protocol heading: ${heading}`);
   }
+
+  // #110 C-1: Selection Contract and Execution Contract's own headings no
+  // longer live in the Kernel — their procedural detail moved to the
+  // Foundation-owned review skill (see the "skill owns the Review contracts
+  // procedural detail" test below). Only the Kernel-retained invariant
+  // subsets of Acquisition & Validity Contract and Resolution Contract stay.
+  assert.ok(!core.includes("#### Selection Contract"));
+  assert.ok(!core.includes("#### Execution Contract"));
 
   // Artifact classification
   for (const artifactClass of ["**Executable**", "**Normative**", "**Informational**"]) {
@@ -109,21 +115,6 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     "this fix is a merge/completion gate, not a new precondition for starting closure",
   );
 
-  // Pass the selected commit range to Execution: Execution Contract's
-  // target field is bound to Selection's expected target (SHA or commit range),
-  // not reduced to a bare "target SHA" that Selection's range would silently
-  // narrow down to. Since Step 9 (2nd discovery) and Step 10 (targeted closure)
-  // both already say "Execution Contract に従って", fixing the Contract's own
-  // definition is enough to cover them without restating range semantics there.
-  assert.ok(
-    containsText(core, "Selection で確定した expected target SHA / commit range"),
-  );
-  assert.doesNotMatch(
-    core,
-    /#### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*target SHA\s*\n/,
-    "Execution Contract must not regress to a bare, Selection-unbound 'target SHA' field",
-  );
-
   // Invalidate discovery on artifact-set-only target changes: the
   // review target is explicitly defined as the (SHA/range, artifact set)
   // pair, and the Execution Contract propagates the confirmed artifact set
@@ -144,21 +135,6 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "precondition evidence、discovery evidence、closure evidence はいずれも target-specific であり、確定した target と一致しない evidence を review / closure / merge の根拠にしません。",
     ),
   );
-  assert.ok(
-    containsText(core, "Selection で確定した target artifact set"),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "Selection Contract で確定した expected target（SHA / commit range）と target artifact set は、Execution で reviewer の trigger へ渡し、実際に渡した target と artifact set を記録します。",
-    ),
-  );
-  assert.doesNotMatch(
-    core,
-    /#### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*Selection で確定した expected target SHA \/ commit range\s*\n\s*-\s*required context\s*\n/,
-    "Execution Contract must not regress to omitting the confirmed target artifact set field",
-  );
-
   // Principle B (review evidence is target-specific): discovery evidence, not just
   // precondition evidence, does not carry over to a new target unless the change
   // was the accepted-fix-driven closure path.
@@ -201,50 +177,18 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
       "acquisition の record は、後続 session から独立に recoverable な場所へpersist されて初めて durable evidence です。",
     ),
   );
-  // An existing provider surface that
-  // already carries enough information in a later-session-recoverable form
-  // counts as the record itself — this must not be read as requiring every
-  // already-durable run to additionally post a normalized record.
-  //
-  // Root-cause fix: the first two
-  // closure attempts hand-enumerated which elements the surface must carry
-  // (target, then +artifact set), and each round a reviewer found one more
-  // Validity/Completion element missing from the hand-kept list (required
-  // context accessibility was still absent after round 2). Rather than
-  // enumerate a 3rd time, this defers to "Completion と Validity の要求事項"
-  // as a whole, so no future element can be missing from this sufficiency
-  // bar without also being missing from the Contract's own definition above.
+  // #110 C-1: the detailed sufficiency-bar mechanics for what counts as
+  // independently-recoverable persistence moved to the Foundation-owned
+  // review skill (see "skill owns the Review contracts procedural detail"
+  // below). The Kernel keeps only the top-level persistence requirement
+  // (asserted above) and the record-schema-is-not-evidence invariant
+  // (asserted below).
   assert.ok(
-    containsText(
-      core,
-      "本 Contract が定義する Completion と Validity の要求事項を独立に判定できるだけの情報が",
-    ),
-  );
-  assert.ok(
-    containsText(
+    !containsText(
       core,
       "reviewer mechanism が外部から確認可能な surface へ残す結果に、その判定に必要な情報が既に含まれていれば、その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
     ),
-  );
-  // Root-cause fix #2: the first root-cause fix
-  // still let the no-surface fallback path point at the bare record schema,
-  // whose `validity` field is only a self-asserted conclusion — so a later
-  // session had no way to independently re-derive it, unlike the surface
-  // branch which requires independently-judgable raw information. Unify both
-  // branches under one bar (enough info to independently judge Completion/
-  // Validity) so the schema's summary fields can never again be mistaken for
-  // a substitute for the evidence behind them.
-  assert.ok(
-    containsText(
-      core,
-      "含まれていない場合（reviewer mechanism 自身がそのような surface へ結果を残さない場合、例えば実装 session 内で動く subagent review を含む）は、上記の record schema の各 field に加え、Completion と Validity の要求事項",
-    ),
-  );
-  assert.ok(
-    containsText(
-      core,
-      "を独立に判定できる情報を、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
-    ),
+    "Kernel must not carry the migrated durable-evidence sufficiency mechanics",
   );
   assert.ok(
     containsText(
@@ -277,31 +221,14 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.ok(containsText(core, "reviewed SHA / range が intended target と一致している"));
   assert.ok(containsText(core, "quota / timeout / structural な execution / acquisition failure がない"));
 
-  // Acquisition record schema fields
-  for (const field of [
-    '"reviewer"',
-    '"target_sha"',
-    '"status"',
-    '"validity"',
-    '"finding_count"',
-    '"result_locator"',
-    '"started_at"',
-    '"completed_at"',
-    '"failure"',
-  ]) {
-    assert.ok(core.includes(field), `missing record schema field: ${field}`);
-  }
-
-  // The record's target_sha is the reviewed/observed target, not the Selection
-  // Contract's expected target, and completed-but-invalid must be expressible via
-  // status/validity together, without expanding the schema beyond this one field.
+  // #110 C-1: the raw JSON record schema example and the target_sha /
+  // validity field-level explanation are review-execution detail that moved
+  // to the Foundation-owned review skill (see below). The Kernel keeps only
+  // the completed-but-invalid expressibility consequence (asserted next).
   assert.ok(
-    containsText(
-      core,
-      "record の `target_sha` は、Selection Contract の expected target（SHA / commit range）ではなく、実際に reviewed された SHA / range（observed target）を表します。",
-    ),
+    !core.includes('"target_sha": "..."'),
+    "Kernel must not carry the migrated Acquisition & Validity record schema example",
   );
-  assert.ok(containsText(core, "`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します。"));
   assert.ok(
     containsText(core, "この場合、record は `status: completed` かつ `validity: invalid` として表現します。"),
   );
@@ -332,22 +259,15 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
     ),
   );
 
-  // Resolution Contract
+  // #110 C-1: the Resolution Contract's triage-category / message-bus /
+  // technical-dispute / P0-P1-dismiss / drip-fix / batch-fix / scope-creep
+  // procedural bullets moved to the Foundation-owned review skill (see below).
+  // The Kernel keeps only the stage-independence and ancestor-scope bullets
+  // (asserted in the "Review stopping rules" block further down).
   assert.ok(
-    containsText(
-      core,
-      "fix / false-positive / needs-verification / technical-dispute / intent-question へ triage する",
-    ),
+    !containsText(core, "accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"),
+    "Kernel must not carry the migrated Resolution Contract procedural bullets",
   );
-  assert.ok(containsText(core, "human を raw finding の message bus にしない"));
-  assert.ok(containsText(core, "pure technical dispute は technical adjudication で解決する"));
-  assert.ok(containsText(core, "human escalation は product intent / authority に限る"));
-  assert.ok(
-    containsText(core, "P0/P1 相当の重大 finding を dismiss する場合は、必要に応じて独立 reviewer の確認を要求する"),
-  );
-  assert.ok(containsText(core, "accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"));
-  assert.ok(containsText(core, "fix 後は全 discovery をやり直さず、targeted closure を基本とする"));
-  assert.ok(containsText(core, "review を新しい scope の探索に使わない"));
 
   // Review Adapter boundary
   for (const fn of ["trigger()", "pollCompletion()", "collectOutputs()", "normalizeFindings()"]) {
@@ -527,6 +447,102 @@ test("core policy defines the provider-neutral Review Protocol", async () => {
   assert.doesNotMatch(core, /(?<!\.ai-dev-foundation\/)skills\/review-doc\.md/);
 });
 
+// #110 C-1 (progressive disclosure, Review contracts): Selection Contract,
+// Execution Contract, and the procedural (non-invariant) portions of
+// Acquisition & Validity Contract / Resolution Contract moved from the
+// Kernel to skills/review-code.md's `## Review contracts` section. Every
+// assertion below previously ran against `policy/core.md`; the semantics are
+// unchanged, only the canonical location moved.
+test("review-code skill owns the Review contracts procedural detail (#110 C-1)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+
+  for (const heading of [
+    "## Review contracts",
+    "### Selection Contract",
+    "### Execution Contract",
+    "### Acquisition & Validity Contract",
+    "### Resolution Contract",
+  ]) {
+    assert.ok(reviewCode.includes(heading), `missing Review contracts heading: ${heading}`);
+  }
+
+  // Execution Contract
+  assert.ok(containsText(reviewCode, "Selection で確定した expected target SHA / commit range"));
+  assert.ok(containsText(reviewCode, "Selection で確定した target artifact set"));
+  assert.doesNotMatch(
+    reviewCode,
+    /### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*target SHA\s*\n/,
+    "Execution Contract must not regress to a bare, Selection-unbound 'target SHA' field",
+  );
+  assert.doesNotMatch(
+    reviewCode,
+    /### Execution Contract\s*\n\s*-\s*trigger 方法\s*\n\s*-\s*Selection で確定した expected target SHA \/ commit range\s*\n\s*-\s*required context\s*\n/,
+    "Execution Contract must not regress to omitting the confirmed target artifact set field",
+  );
+  assert.ok(
+    containsText(
+      reviewCode,
+      "Selection Contract で確定した expected target（SHA / commit range）と target artifact set は、Execution で reviewer の trigger へ渡し、実際に渡した target と artifact set を記録します。",
+    ),
+  );
+
+  // Selection Contract's expected review set membership algorithm (the
+  // detailed field-by-field mechanics; merge-ready-fence.test.mjs covers the
+  // subset the Merge-ready completion fence depends on).
+  assert.ok(containsText(reviewCode, "expected review set は、agent が選択した reviewer だけでは閉じません"));
+  assert.ok(
+    containsText(reviewCode, "consumer が reviewer を required / configured automatic / advisory のいずれとして宣言"),
+  );
+
+  // Acquisition & Validity Contract's record schema and field-level detail
+  for (const field of [
+    '"reviewer"',
+    '"target_sha"',
+    '"status"',
+    '"validity"',
+    '"finding_count"',
+    '"result_locator"',
+    '"started_at"',
+    '"completed_at"',
+    '"failure"',
+  ]) {
+    assert.ok(reviewCode.includes(field), `missing record schema field: ${field}`);
+  }
+  assert.ok(
+    containsText(
+      reviewCode,
+      "record の `target_sha` は、Selection Contract の expected target（SHA / commit range）ではなく、実際に reviewed された SHA / range（observed target）を表します。",
+    ),
+  );
+  assert.ok(containsText(reviewCode, "`validity` は少なくとも `valid` / `invalid` / `unknown` を表現します"));
+
+  // Resolution Contract's procedural bullets (triage categories, message-bus,
+  // technical-dispute routing, P0/P1 dismiss confirmation, drip-fix
+  // prohibition, batch-fix, scope-creep prohibition). The stage-independence
+  // and ancestor-scope invariants stay Kernel-retained (see the first test).
+  assert.ok(
+    containsText(
+      reviewCode,
+      "fix / false-positive / needs-verification / technical-dispute / intent-question へ triage する",
+    ),
+  );
+  assert.ok(containsText(reviewCode, "human を raw finding の message bus にしない"));
+  assert.ok(containsText(reviewCode, "pure technical dispute は technical adjudication で解決する"));
+  assert.ok(containsText(reviewCode, "human escalation は product intent / authority に限る"));
+  assert.ok(
+    containsText(
+      reviewCode,
+      "P0/P1 相当の重大 finding を dismiss する場合は、必要に応じて独立 reviewer の確認を要求する",
+    ),
+  );
+  assert.ok(containsText(reviewCode, "accepted finding は drip fix せず、root-cause を確認した上で batch で fix する"));
+  assert.ok(containsText(reviewCode, "fix 後は全 discovery をやり直さず、targeted closure を基本とする"));
+  assert.ok(containsText(reviewCode, "review を新しい scope の探索に使わない"));
+
+  // Provider-neutral: the moved content must not hard-code provider specifics.
+  assert.doesNotMatch(reviewCode, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
 // #51 Phase 1 (progressive disclosure canary): the artifact-class review finite
 // flow — the phase-specific part of the former Kernel `Review stopping rules`
 // section — is owned by the Foundation-owned review skills, not by the Kernel.
@@ -600,7 +616,7 @@ test("review skills own the artifact-class review finite flow (#51 Phase 1)", as
   assert.ok(
     containsText(
       reviewCode,
-      "targeted closure の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は merge しません。",
+      "targeted closure の finding を、上記 `## Review contracts` の Resolution Contract に従って triage します。unresolved の finding がある間は merge しません。",
     ),
   );
 
@@ -1143,15 +1159,32 @@ test("review skills document procedure without duplicating normative rules", asy
   // asserted where they actually live.
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
+  // #110 C-1: Selection/Execution/Acquisition & Validity/Resolution Contract
+  // procedural detail (the record schema, the drip-fix prohibition, etc.) is
+  // now canonically owned by review-code.md's `## Review contracts` section,
+  // not by policy/core.md. review-code.md legitimately carries this content;
+  // review-doc.md must still defer to it instead of duplicating it.
+  assert.ok(
+    reviewCode.includes('"target_sha": "..."'),
+    "review-code.md must own the Acquisition & Validity record schema (#110 C-1)",
+  );
+  assert.ok(
+    /drip fix/.test(reviewCode),
+    "review-code.md must own the Resolution Contract's drip-fix prohibition (#110 C-1)",
+  );
+  assert.doesNotMatch(
+    reviewDoc,
+    /"target_sha": "\.\.\."/,
+    "review-doc.md must not duplicate the Acquisition & Validity record schema from review-code.md",
+  );
+  assert.doesNotMatch(
+    reviewDoc,
+    /drip fix/,
+    "review-doc.md must reference review-code.md's Resolution Contract instead of restating drip fix",
+  );
+
   for (const skill of [reviewCode, reviewDoc]) {
     assert.ok(skill.includes("policy/core.md"), "skill must reference policy/core.md");
-    assert.doesNotMatch(
-      skill,
-      /"target_sha": "\.\.\."/,
-      "skill must not duplicate the Acquisition & Validity record schema from policy",
-    );
-    // Neither skill restates the drip-fix prohibition; both defer to Resolution Contract.
-    assert.doesNotMatch(skill, /drip fix/, "skill must reference Resolution Contract instead of restating drip fix");
 
     // A distributed skill's many `policy/core.md` references must be resolvable
     // from consumer context, where no `policy/core.md` file ships — only the
@@ -1206,7 +1239,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、`policy/core.md` の Acquisition & Validity Contract が定める durable evidence の要求を、その手段で満たします。",
+      "reviewer mechanism 自身が外部から確認可能な surface へ結果を残さない場合（例: 実装 session 内で動く subagent review）は、本 skill の `## Review contracts`（Acquisition & Validity Contract）が定める durable evidence の要求を、その手段で満たします。",
     ),
   );
   assert.ok(
@@ -1233,24 +1266,23 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "`policy/core.md` の Acquisition & Validity Contract が定める durable evidence の要求を、その手段で満たします。何を persist すれば足りるかは同 Contract が定めます。",
+      "本 skill の `## Review contracts`（Acquisition & Validity Contract）が定める durable evidence の要求を、その手段で満たします。何を persist すれば足りるかは同 Contract が定めます。",
     ),
   );
-  // Both halves of the rule stay stated — but in the Kernel, once, instead of
-  // being re-enumerated in the skill where the copy could drift. The
-  // no-surface fallback must still demand evidence, not just conformance to
-  // the bare record schema (whose `validity` field is only a self-asserted
-  // conclusion a later session can't independently re-derive).
+  // #110 C-1: the sufficiency-bar mechanics (existing-surface counts as
+  // recoverable / no-surface fallback demands independently-judgable info)
+  // moved to the skill's own `## Review contracts` section, where they are
+  // stated once instead of being re-enumerated against the Kernel.
   assert.ok(
     containsText(
-      core,
+      reviewCode,
       "その surface 自体をこの record の recoverable な representation として扱ってよく、別途 record を post し直す必要はありません。",
     ),
   );
   assert.ok(
     containsText(
-      core,
-      "上記の record schema の各 field に加え、Completion と Validity の要求事項を独立に判定できる情報を、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
+      reviewCode,
+      "情報を、そのような場所へ明示的に persist しない限り、session 終了後には recoverable な evidence として扱いません。",
     ),
   );
   assert.ok(
@@ -1364,7 +1396,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewCode,
-      "targeted closure の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は merge しません。",
+      "targeted closure の finding を、上記 `## Review contracts` の Resolution Contract に従って triage します。unresolved の finding がある間は merge しません。",
     ),
   );
   assert.ok(
@@ -1752,7 +1784,13 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "closure verification（手順 7）の finding を Resolution Contract（`policy/core.md`）に従って triage します。unresolved の finding がある間は review procedure を完了としません。",
+      "closure verification（手順 7）の finding を、",
+    ),
+  );
+  assert.ok(
+    containsText(
+      reviewDoc,
+      "`## Review contracts` の Resolution Contract に従って triage します。unresolved の finding がある間は review procedure を完了としません。",
     ),
   );
   assert.ok(containsText(reviewDoc, "accepted な closure finding があれば、手順 6〜7 と同じ procedure"));
@@ -1907,7 +1945,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "Selection Contract（`policy/core.md`）をこの closure review run に適用します。",
+      "Selection Contract\n   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を\n   この closure review run に適用します。",
     ),
   );
   assert.ok(
@@ -1921,7 +1959,7 @@ test("review skills document procedure without duplicating normative rules", asy
   assert.ok(
     containsText(
       reviewDoc,
-      "確定した closure artifact set を、直近の mechanical-check evidence がカバーしていることを確認します。確認できない場合は、確定した closure target に対して mechanical check を再実行してから、Execution Contract（`policy/core.md`）を closure review run に適用します。",
+      "確定した closure artifact set を、直近の mechanical-check evidence がカバーしていることを確認します。確認できない場合は、確定した closure target に対して mechanical check を再実行してから、Execution Contract\n   （`.ai-dev-foundation/skills/review-code.md` の `## Review contracts`）を\n   closure review run に適用します。",
     ),
   );
 


### PR DESCRIPTION
## 概要

Issue #110 の C-1 scope。`policy/core.md` の `### Review contracts`
（Selection Contract / Execution Contract / Acquisition & Validity Contract /
Resolution Contract）のうち、review実行agentのみが必要とする手続き的detailを
`skills/review-code.md` の新設 `## Review contracts` sectionへ移動しました。

## Move inventory

**Kernel（policy/core.md）に残したもの:**
- stage非依存性の intro paragraph（各Contractがdiscovery/closureの両方に
  適用されること、required review数のgate、Resolution完了までmerge/review
  completionへ進まないこと）
- `CI status は review completion と同義ではありません`
- `0 findings は positive evidence を必要とします`
- Completion / Validity の要求事項（bullet list）
- reviewed target の binding invariant（確認できない場合 unknown、一致しない
  場合 invalid）
- run record state と target completion state の区別
- positive completion evidence の target-bound 要件、evidence軸/finding軸
- Resolution Contract の最後の2 bullet（stage非依存性、ancestor target scope）
- Selection/Execution/Acquisition & Validity/Resolution Contractの手続き的
  detailへのone-hop pointer

**skills/review-code.md（新設`## Review contracts`section）へ移したもの:**
- Selection Contract 全体（expected review set の membership 算出、
  required/expected/optional/advisory の区別、consumer宣言優先、carry-over、
  非参加宣言の扱い）
- Execution Contract 全体
- Acquisition & Validity Contract の JSON record schema example、
  `target_sha`/`validity` field 説明、durable evidence persistence の
  sufficiency-bar 手続き、revision/triage identity 確認手続き
- Resolution Contract の前半8 bullet（triage category、message-bus禁止、
  technical-dispute routing、P0/P1 dismiss確認、drip-fix禁止、batch-fix、
  scope-creep禁止）

review-doc.md はこれらのContractを `.ai-dev-foundation/skills/review-code.md`
の `## Review contracts` section経由で参照し、重複定義していません。

**C-2（Merge readiness and merge authority）には触れていません。**
Merge-ready completion fenceが依存するtarget completion state / run record
state / required・expected・optional member の語彙はKernelに残っているため、
Merge readinessセクション自体は無変更です。

## Semantic preservation

- required/expected review obligationの silent discharge防止、Resolution
  完了義務、merge-ready != merge authorityの分離、CI green != review
  completion、0 findingsのpositive evidence要件はすべてKernelに保持。
- review taskは既にSkill routing contract（MUST）でreview-code.md /
  review-doc.mdをloadするため、C-1による追加navigation hopは発生しません
  （one-hop）。
- Kernelとskillの間に新しい二重正本は作っていません（各文はどちらか一方にのみ
  存在）。

## Verification

- `npm test`: 283 tests中282 pass / 1 skip（pre-existing、Windows symlink
  権限起因、本変更と無関係）
- `npm run test:guardrails`: pass
- `npm run check:fixture`: pass（drift なし）
- `git diff --check`: no whitespace errors

## Byte effect（実測）

| artifact | before | after | diff |
| --- | ---: | ---: | ---: |
| `policy/core.md` | 55,853 B | 48,709 B | −7,144 B |
| `skills/review-code.md` | 33,794 B | 45,701 B | +11,907 B |
| `skills/review-doc.md` | 16,733 B | 17,746 B | +1,013 B |
| reference consumer generated `AGENTS.md` | 58,012 B | 50,868 B | −7,144 B |

### Real consumer canary（`reitojike/stage-tracker`, bounded / non-committing）

fresh main `b3669239c0fd747384d4c1751bd2dcbc6ea40ee4` を clone し、candidate
Foundation（本PR）を `tooling/sync.mjs` で一時 clone へ bounded materialize
（stage-tracker repositoryへの commit / push は一切行っていません）。

| artifact | before | after | diff |
| --- | ---: | ---: | ---: |
| generated `AGENTS.md` | 105,245 B | 98,101 B | −7,144 B |
| skill bundle合計 | 50,527 B | 63,447 B | +12,920 B |

`tooling/check.mjs --consumer <canary>` で drift なしを確認。non-review
task が常時読む always-loaded `AGENTS.md` から moved detail
（drip-fix bullet、JSON record schema）が消え、MUST-load routing pointer と
merge authority separation invariantは維持されていることを確認済みです。

このPR本文はIssue #110のAcceptance Criteria確認前にIssueを自動closeさせるkeywordを含みません。merge execution authorityは別checkpointです。
