### PR TITLE
#112: Foundation Change detailをstrong Kernel boundaryでconditional化する

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -22,11 +22,15 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
-policy は、review 実行 agent のみが必要とする場合、または特定の trigger
-発火時（および発火したかどうか不明な場合）にのみ必要となる場合等、
-conditional にのみ必要となる必須事項・禁止事項について、その canonical
-ownership を Foundation-owned な skill へ明示的に委譲してよいです。この
-委譲は次をすべて満たす場合に限ります。
+policy は、次の二つの場合に限り、conditional にのみ必要となる必須事項・
+禁止事項について、その canonical ownership を Foundation-owned な skill へ
+明示的に委譲してよいです。
+
+1. review 実行 agent のみが必要とする場合
+2. 特定の trigger 発火時（および発火したかどうか不明な場合）にのみ
+   必要となる場合
+
+この委譲は次をすべて満たす場合に限ります。
 
 - policy 自身が、委譲先の skill を one-hop pointer として名指しする
 - 委譲後も policy に、その conditional な状況が成立していない Task でも
@@ -710,8 +714,10 @@ detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
 - 専用の ledger / database / schema、GitHub label 体系、bot / collector /
   dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は
   Observation handling の一部にしません。
-- Task closure と Observation（下記）、および Foundation Change の
-  正当化条件（下記）
+
+これに加え、下記の Task closure と Observation の fail-closed hook、
+および Foundation Change の正当化条件も、本 Kernel が保持する minimum
+safety boundary です。
 
 ### Task closure と Observation
 

--- a/policy/core.md
+++ b/policy/core.md
@@ -22,15 +22,20 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
-policy は、review 実行 agent のみが必要とする conditional な必須事項・禁止事項
-について、その canonical ownership を Foundation-owned な skill へ明示的に
-委譲してよいです。この委譲は次をすべて満たす場合に限ります。
+policy は、review 実行 agent のみが必要とする場合、または特定の trigger
+発火時（および発火したかどうか不明な場合）にのみ必要となる場合等、
+conditional にのみ必要となる必須事項・禁止事項について、その canonical
+ownership を Foundation-owned な skill へ明示的に委譲してよいです。この
+委譲は次をすべて満たす場合に限ります。
 
 - policy 自身が、委譲先の skill を one-hop pointer として名指しする
-- 委譲後も policy に、review を実行しない Task でも成立していなければ
-  ならない minimum safety boundary（authority 分離、fail-closed な
-  uncertainty rule 等）が残る
+- 委譲後も policy に、その conditional な状況が成立していない Task でも
+  成立していなければならない minimum safety boundary（authority 分離、
+  fail-closed な uncertainty rule 等）が残る
 - 同じ規範的なルールを policy と skill の両方に重複して記述しない
+- この委譲は個別に列挙した対象にのみ適用し、任意のルールを一般的に skill へ
+  移してよいことを意味しない。委譲のために generalized loader / registry /
+  routing framework / DSL を新設しない
 
 この場合、skill が記述する必須事項・禁止事項は policy の複製ではなく、
 委譲された canonical source です。委譲していない規範的なルールについては、
@@ -682,47 +687,31 @@ Task 実行中に少なくとも次のいずれかを観測した場合、Founda
 4. provider / runtime の実挙動が、Task で依拠した前提と食い違う
 5. 同一 root cause と思われる friction / workaround を以前にも観測している
 
-### Observation classification
+### Observation handling — canonical ownership delegation
 
-Observation trigger が発火したら、症状の重大度ではなく root cause /
-ownership を軸に、次の 4 分類のいずれかへ分類します。
+Observation trigger が発火した場合、または発火したかどうか判断がつかない
+場合は、`.ai-dev-foundation/skills/foundation-change.md` を **MUST load**
+します。判断がつかない場合を「trigger なし」と解釈して silent skip しては
+いけません。
 
-- `consumer-local`: product / domain / consumer 固有で自然に閉じる
-- `provider/runtime`: 外部 provider / runtime の挙動で、Foundation
-  contract 自体の欠陥ではない
-- `Foundation candidate`: shared problem / improvement candidate に
-  なり得るが、Foundation-owned な rule / profile / tooling / artifact
-  自体が誤った挙動を要求・生成・許容していると確認されたわけではない
-  （Foundation-owned だと分かっていても、確認された defect ではない
-  改善余地を含む）
-- `canonical defect candidate`: Foundation-owned な rule / profile /
-  tooling / artifact 自体が誤った挙動を要求・生成・許容していると
-  確認できる場合に限る（正しく機能している manual step を自動化・
-  簡略化できるという改善余地だけでは、この分類に含めない）
+Observation の 4 分類（root cause / ownership を軸にした定義と境界）、
+Observation recording の procedure・field、Change Proposal が表現すべき
+field 定義、および Observation から Change Proposal への昇格 signal の
+detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
+です。本節はこれらの手続き的 detail を複製しません。
 
-`provider/runtime` に分類した Observation でも、Foundation がその挙動を
-誤って恒久前提として固定している場合は、Foundation 側の candidate として
-再評価します。
+本節が、Foundation Change に関与しない Task でも成立していなければ
+ならない minimum safety boundary として保持するのは次のとおりです。
 
-### Observation recording
-
-Observation trigger の発火は、自動的に Foundation Issue を作りません。
-Observation は work item ではありません。
-
-将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
-の canonical Issue へ、少なくとも次を短く記録します。
-
-- Observed / evidence locator
-- Classification
-- Impact
-- Local handling
-- Foundation action: `none` / `observe` / `change proposal candidate`
-- Promotion signal（何が起きれば再評価するか）
-
-consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
-対象にしません。専用の ledger / database / schema、GitHub label 体系、
-bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
-mandatory 化は Observation handling の一部にしません。
+- Observation trigger の発火は、自動的に Foundation Issue を作りません。
+  Observation は work item ではありません。
+- 単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に
+  mandatory 化しません（詳細は Foundation Change の正当化条件を参照）。
+- 専用の ledger / database / schema、GitHub label 体系、bot / collector /
+  dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は
+  Observation handling の一部にしません。
+- Task closure と Observation（下記）、および Foundation Change の
+  正当化条件（下記）
 
 ### Task closure と Observation
 
@@ -745,29 +734,7 @@ mandatory な Foundation change は、原則として次のいずれかで正当
 して条項を足すかどうかの判定にも、そのまま適用します。文言の曖昧さや網羅性の不足を
 指摘する finding は、実運用で misjudgment が観測された場合に限り accept します。
 
-Change Proposal は、少なくとも次を表現できるものとします。
-
-- Problem
-- Evidence
-- Proposed Change
-- Expected Effect
-- Trade-off
-- Scope
-- Success Criterion
-
-### Observation から Change Proposal への昇格
-
-Observation classification は、本節の 3 つの Foundation Change 正当化
-条件を置き換えず、緩和しません。特に次は強い promotion signal になり
-得ます。
-
-- Foundation 自身の material defect が実証された
-- material defect を deterministically 防止できる
-- 同一 root cause が recurring / escaped failure になった
-- correctness のための mandatory manual ritual が定着した
-- consumer-local workaround では canonical semantics の fork が必要に
-  なる
-
-change class や review 強度は、固定の provider 名へ結びつけません。単発の
-friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
-化しません。
+Change Proposal が表現すべき field 定義、および Observation classification
+から本節の 3 条件への昇格を促す detailed promotion signal の canonical
+source は `.ai-dev-foundation/skills/foundation-change.md` です。change
+class や review 強度は、固定の provider 名へ結びつけません。

--- a/policy/core.md
+++ b/policy/core.md
@@ -696,13 +696,17 @@ Task 実行中に少なくとも次のいずれかを観測した場合、Founda
 Observation trigger が発火した場合、または発火したかどうか判断がつかない
 場合は、`.ai-dev-foundation/skills/foundation-change.md` を **MUST load**
 します。判断がつかない場合を「trigger なし」と解釈して silent skip しては
-いけません。
+いけません。**この path は consumer context のものです。Foundation
+リポジトリ自身の Task では、同じ canonical source である
+`skills/foundation-change.md` を同じ条件で MUST load します。**
 
 Observation の 4 分類（root cause / ownership を軸にした定義と境界）、
 Observation recording の procedure・field、Change Proposal が表現すべき
 field 定義、および Observation から Change Proposal への昇格 signal の
-detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
-です。本節はこれらの手続き的 detail を複製しません。
+detail の canonical source は、consumer context では
+`.ai-dev-foundation/skills/foundation-change.md`、Foundation リポジトリ
+自身の Task では `skills/foundation-change.md` です。本節はこれらの
+手続き的 detail を複製しません。
 
 本節が、Foundation Change に関与しない Task でも成立していなければ
 ならない minimum safety boundary として保持するのは次のとおりです。

--- a/policy/core.md
+++ b/policy/core.md
@@ -746,5 +746,6 @@ mandatory な Foundation change は、原則として次のいずれかで正当
 
 Change Proposal が表現すべき field 定義、および Observation classification
 から本節の 3 条件への昇格を促す detailed promotion signal の canonical
-source は `.ai-dev-foundation/skills/foundation-change.md` です。change
-class や review 強度は、固定の provider 名へ結びつけません。
+source は、consumer context では `.ai-dev-foundation/skills/foundation-change.md`、
+Foundation リポジトリ自身の Task では `skills/foundation-change.md` です。
+change class や review 強度は、固定の provider 名へ結びつけません。

--- a/skills/foundation-change.md
+++ b/skills/foundation-change.md
@@ -54,8 +54,11 @@ ownership を軸に、次の 4 分類のいずれかへ分類します。
 
 ## Observation recording
 
-Observation trigger の発火は、自動的に Foundation Issue を作りません。
-Observation は work item ではありません。
+Observation が自動的に Foundation Issue や work item にならないこと、および
+ledger / database / schema、GitHub label 体系、bot / collector / dashboard /
+statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしない
+ことは `policy/core.md` の minimum safety boundary です。本 skill では
+複製しません。
 
 将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
 の canonical Issue へ、少なくとも次を短く記録します。
@@ -68,13 +71,12 @@ Observation は work item ではありません。
 - Promotion signal（何が起きれば再評価するか）
 
 consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
-対象にしません。専用の ledger / database / schema、GitHub label 体系、
-bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
-mandatory 化は Observation handling の一部にしません。
+対象にしません。
 
-Task closure との関係は `policy/core.md` の Task closure と Observation に
-従います。記録義務の対象にしない軽微な事象について省略できるのは記録だけで
-あり、classification の完了は省略しません。
+Task closure との関係、および記録義務の対象にしない軽微な事象でも
+classification の完了は省略しないという fail-closed hook は
+`policy/core.md` の Task closure と Observation に従います。本 skill では
+複製しません。
 
 ## Change Proposal
 
@@ -104,6 +106,7 @@ signal になり得ます。
 - consumer-local workaround では canonical semantics の fork が必要に
   なる
 
-change class や review 強度は、固定の provider 名へ結びつけません。単発の
-friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
-化しません。
+change class や review 強度を固定の provider 名へ結びつけないこと、および
+単発の friction、style、prompt nicety、効率改善のみを理由に自動的に
+mandatory 化しないことは `policy/core.md` の minimum safety boundary です。
+本 skill では複製しません。

--- a/skills/foundation-change.md
+++ b/skills/foundation-change.md
@@ -1,0 +1,109 @@
+# foundation-change skill
+
+このファイルは `policy/core.md` の Foundation Change Protocol を使った
+classification / recording / proposal 手順です。`policy/core.md` が保持する
+minimum safety boundary（Observation trigger 5 条件、Observation は自動的に
+Foundation Issue や work item にならないこと、Task closure と Observation の
+fail-closed hook、Foundation Change の正当化 3 条件、単発の friction / style /
+prompt nicety / 効率改善のみで mandatory 化しないこと、ledger / dashboard /
+自動 Issue 生成等の禁止）はここで再定義せず、`policy/core.md` を参照します。
+本 skill と policy が矛盾する場合は policy が優先します。
+
+Observation classification の 4 分類、Observation recording の procedure・
+field、Change Proposal が表現すべき field 定義、および Observation から
+Change Proposal への昇格 signal の detail の canonical source は本 skill
+であり、`policy/core.md` には置きません。
+
+## いつ load するか
+
+`policy/core.md` の Foundation Change Protocol に従い、Task 実行中に
+Observation trigger が発火した場合、または発火したかどうか判断がつかない
+場合は本 skill を **MUST load** します。判断がつかない場合を「trigger
+なし」と解釈して silent skip してはいけません。
+
+この skill の canonical source は Foundation リポジトリの `policy/core.md`
+および `skills/foundation-change.md` です。consumer には
+`.ai-dev-foundation/skills/foundation-change.md` として本ファイルが配布され、
+`policy/core.md` の規範的なルールは generated `AGENTS.md` の `## Foundation
+policy` section として配布されます。以降 `policy/core.md` への参照は、
+consumer context ではこの `AGENTS.md` の `## Foundation policy` section を
+指します。consumer リポジトリに `policy/core.md` という path が存在することは
+前提にしません。
+
+## Observation classification
+
+Observation trigger が発火したら、症状の重大度ではなく root cause /
+ownership を軸に、次の 4 分類のいずれかへ分類します。
+
+- `consumer-local`: product / domain / consumer 固有で自然に閉じる
+- `provider/runtime`: 外部 provider / runtime の挙動で、Foundation
+  contract 自体の欠陥ではない
+- `Foundation candidate`: shared problem / improvement candidate に
+  なり得るが、Foundation-owned な rule / profile / tooling / artifact
+  自体が誤った挙動を要求・生成・許容していると確認されたわけではない
+  （Foundation-owned だと分かっていても、確認された defect ではない
+  改善余地を含む）
+- `canonical defect candidate`: Foundation-owned な rule / profile /
+  tooling / artifact 自体が誤った挙動を要求・生成・許容していると
+  確認できる場合に限る（正しく機能している manual step を自動化・
+  簡略化できるという改善余地だけでは、この分類に含めない）
+
+`provider/runtime` に分類した Observation でも、Foundation がその挙動を
+誤って恒久前提として固定している場合は、Foundation 側の candidate として
+再評価します。
+
+## Observation recording
+
+Observation trigger の発火は、自動的に Foundation Issue を作りません。
+Observation は work item ではありません。
+
+将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
+の canonical Issue へ、少なくとも次を短く記録します。
+
+- Observed / evidence locator
+- Classification
+- Impact
+- Local handling
+- Foundation action: `none` / `observe` / `change proposal candidate`
+- Promotion signal（何が起きれば再評価するか）
+
+consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
+対象にしません。専用の ledger / database / schema、GitHub label 体系、
+bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
+mandatory 化は Observation handling の一部にしません。
+
+Task closure との関係は `policy/core.md` の Task closure と Observation に
+従います。記録義務の対象にしない軽微な事象について省略できるのは記録だけで
+あり、classification の完了は省略しません。
+
+## Change Proposal
+
+Change Proposal は、少なくとも次を表現できるものとします。
+
+- Problem
+- Evidence
+- Proposed Change
+- Expected Effect
+- Trade-off
+- Scope
+- Success Criterion
+
+Change Proposal の accept 可否は `policy/core.md` の Foundation Change の
+正当化条件（3 条件）に従います。本 skill はこの 3 条件を複製しません。
+
+## Observation から Change Proposal への昇格
+
+Observation classification は、`policy/core.md` の 3 つの Foundation
+Change 正当化条件を置き換えず、緩和しません。特に次は強い promotion
+signal になり得ます。
+
+- Foundation 自身の material defect が実証された
+- material defect を deterministically 防止できる
+- 同一 root cause が recurring / escaped failure になった
+- correctness のための mandatory manual ritual が定着した
+- consumer-local workaround では canonical semantics の fork が必要に
+  なる
+
+change class や review 強度は、固定の provider 名へ結びつけません。単発の
+friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
+化しません。

--- a/skills/foundation-change.md
+++ b/skills/foundation-change.md
@@ -6,8 +6,8 @@ minimum safety boundary（Observation trigger 5 条件、Observation は自動�
 Foundation Issue や work item にならないこと、Task closure と Observation の
 fail-closed hook、Foundation Change の正当化 3 条件、単発の friction / style /
 prompt nicety / 効率改善のみで mandatory 化しないこと、ledger / dashboard /
-自動 Issue 生成等の禁止）はここで再定義せず、`policy/core.md` を参照します。
-本 skill と policy が矛盾する場合は policy が優先します。
+自動 Issue 生成等の mandatory 化の禁止）はここで再定義せず、`policy/core.md`
+を参照します。本 skill と policy が矛盾する場合は policy が優先します。
 
 Observation classification の 4 分類、Observation recording の procedure・
 field、Change Proposal が表現すべき field 定義、および Observation から
@@ -55,9 +55,8 @@ ownership を軸に、次の 4 分類のいずれかへ分類します。
 ## Observation recording
 
 Observation が自動的に Foundation Issue や work item にならないこと、および
-ledger / database / schema、GitHub label 体系、bot / collector / dashboard /
-statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしない
-ことは `policy/core.md` の minimum safety boundary です。本 skill では
+専用の ledger / dashboard 等の mandatory 化を Observation handling の一部に
+しないことは `policy/core.md` の minimum safety boundary です。本 skill では
 複製しません。
 
 将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
@@ -54,8 +54,11 @@ ownership を軸に、次の 4 分類のいずれかへ分類します。
 
 ## Observation recording
 
-Observation trigger の発火は、自動的に Foundation Issue を作りません。
-Observation は work item ではありません。
+Observation が自動的に Foundation Issue や work item にならないこと、および
+ledger / database / schema、GitHub label 体系、bot / collector / dashboard /
+statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしない
+ことは `policy/core.md` の minimum safety boundary です。本 skill では
+複製しません。
 
 将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
 の canonical Issue へ、少なくとも次を短く記録します。
@@ -68,13 +71,12 @@ Observation は work item ではありません。
 - Promotion signal（何が起きれば再評価するか）
 
 consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
-対象にしません。専用の ledger / database / schema、GitHub label 体系、
-bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
-mandatory 化は Observation handling の一部にしません。
+対象にしません。
 
-Task closure との関係は `policy/core.md` の Task closure と Observation に
-従います。記録義務の対象にしない軽微な事象について省略できるのは記録だけで
-あり、classification の完了は省略しません。
+Task closure との関係、および記録義務の対象にしない軽微な事象でも
+classification の完了は省略しないという fail-closed hook は
+`policy/core.md` の Task closure と Observation に従います。本 skill では
+複製しません。
 
 ## Change Proposal
 
@@ -104,6 +106,7 @@ signal になり得ます。
 - consumer-local workaround では canonical semantics の fork が必要に
   なる
 
-change class や review 強度は、固定の provider 名へ結びつけません。単発の
-friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
-化しません。
+change class や review 強度を固定の provider 名へ結びつけないこと、および
+単発の friction、style、prompt nicety、効率改善のみを理由に自動的に
+mandatory 化しないことは `policy/core.md` の minimum safety boundary です。
+本 skill では複製しません。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
@@ -1,0 +1,109 @@
+# foundation-change skill
+
+このファイルは `policy/core.md` の Foundation Change Protocol を使った
+classification / recording / proposal 手順です。`policy/core.md` が保持する
+minimum safety boundary（Observation trigger 5 条件、Observation は自動的に
+Foundation Issue や work item にならないこと、Task closure と Observation の
+fail-closed hook、Foundation Change の正当化 3 条件、単発の friction / style /
+prompt nicety / 効率改善のみで mandatory 化しないこと、ledger / dashboard /
+自動 Issue 生成等の禁止）はここで再定義せず、`policy/core.md` を参照します。
+本 skill と policy が矛盾する場合は policy が優先します。
+
+Observation classification の 4 分類、Observation recording の procedure・
+field、Change Proposal が表現すべき field 定義、および Observation から
+Change Proposal への昇格 signal の detail の canonical source は本 skill
+であり、`policy/core.md` には置きません。
+
+## いつ load するか
+
+`policy/core.md` の Foundation Change Protocol に従い、Task 実行中に
+Observation trigger が発火した場合、または発火したかどうか判断がつかない
+場合は本 skill を **MUST load** します。判断がつかない場合を「trigger
+なし」と解釈して silent skip してはいけません。
+
+この skill の canonical source は Foundation リポジトリの `policy/core.md`
+および `skills/foundation-change.md` です。consumer には
+`.ai-dev-foundation/skills/foundation-change.md` として本ファイルが配布され、
+`policy/core.md` の規範的なルールは generated `AGENTS.md` の `## Foundation
+policy` section として配布されます。以降 `policy/core.md` への参照は、
+consumer context ではこの `AGENTS.md` の `## Foundation policy` section を
+指します。consumer リポジトリに `policy/core.md` という path が存在することは
+前提にしません。
+
+## Observation classification
+
+Observation trigger が発火したら、症状の重大度ではなく root cause /
+ownership を軸に、次の 4 分類のいずれかへ分類します。
+
+- `consumer-local`: product / domain / consumer 固有で自然に閉じる
+- `provider/runtime`: 外部 provider / runtime の挙動で、Foundation
+  contract 自体の欠陥ではない
+- `Foundation candidate`: shared problem / improvement candidate に
+  なり得るが、Foundation-owned な rule / profile / tooling / artifact
+  自体が誤った挙動を要求・生成・許容していると確認されたわけではない
+  （Foundation-owned だと分かっていても、確認された defect ではない
+  改善余地を含む）
+- `canonical defect candidate`: Foundation-owned な rule / profile /
+  tooling / artifact 自体が誤った挙動を要求・生成・許容していると
+  確認できる場合に限る（正しく機能している manual step を自動化・
+  簡略化できるという改善余地だけでは、この分類に含めない）
+
+`provider/runtime` に分類した Observation でも、Foundation がその挙動を
+誤って恒久前提として固定している場合は、Foundation 側の candidate として
+再評価します。
+
+## Observation recording
+
+Observation trigger の発火は、自動的に Foundation Issue を作りません。
+Observation は work item ではありません。
+
+将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
+の canonical Issue へ、少なくとも次を短く記録します。
+
+- Observed / evidence locator
+- Classification
+- Impact
+- Local handling
+- Foundation action: `none` / `observe` / `change proposal candidate`
+- Promotion signal（何が起きれば再評価するか）
+
+consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
+対象にしません。専用の ledger / database / schema、GitHub label 体系、
+bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
+mandatory 化は Observation handling の一部にしません。
+
+Task closure との関係は `policy/core.md` の Task closure と Observation に
+従います。記録義務の対象にしない軽微な事象について省略できるのは記録だけで
+あり、classification の完了は省略しません。
+
+## Change Proposal
+
+Change Proposal は、少なくとも次を表現できるものとします。
+
+- Problem
+- Evidence
+- Proposed Change
+- Expected Effect
+- Trade-off
+- Scope
+- Success Criterion
+
+Change Proposal の accept 可否は `policy/core.md` の Foundation Change の
+正当化条件（3 条件）に従います。本 skill はこの 3 条件を複製しません。
+
+## Observation から Change Proposal への昇格
+
+Observation classification は、`policy/core.md` の 3 つの Foundation
+Change 正当化条件を置き換えず、緩和しません。特に次は強い promotion
+signal になり得ます。
+
+- Foundation 自身の material defect が実証された
+- material defect を deterministically 防止できる
+- 同一 root cause が recurring / escaped failure になった
+- correctness のための mandatory manual ritual が定着した
+- consumer-local workaround では canonical semantics の fork が必要に
+  なる
+
+change class や review 強度は、固定の provider 名へ結びつけません。単発の
+friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
+化しません。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/foundation-change.md
@@ -6,8 +6,8 @@ minimum safety boundary（Observation trigger 5 条件、Observation は自動�
 Foundation Issue や work item にならないこと、Task closure と Observation の
 fail-closed hook、Foundation Change の正当化 3 条件、単発の friction / style /
 prompt nicety / 効率改善のみで mandatory 化しないこと、ledger / dashboard /
-自動 Issue 生成等の禁止）はここで再定義せず、`policy/core.md` を参照します。
-本 skill と policy が矛盾する場合は policy が優先します。
+自動 Issue 生成等の mandatory 化の禁止）はここで再定義せず、`policy/core.md`
+を参照します。本 skill と policy が矛盾する場合は policy が優先します。
 
 Observation classification の 4 分類、Observation recording の procedure・
 field、Change Proposal が表現すべき field 定義、および Observation から
@@ -55,9 +55,8 @@ ownership を軸に、次の 4 分類のいずれかへ分類します。
 ## Observation recording
 
 Observation が自動的に Foundation Issue や work item にならないこと、および
-ledger / database / schema、GitHub label 体系、bot / collector / dashboard /
-statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしない
-ことは `policy/core.md` の minimum safety boundary です。本 skill では
+専用の ledger / dashboard 等の mandatory 化を Observation handling の一部に
+しないことは `policy/core.md` の minimum safety boundary です。本 skill では
 複製しません。
 
 将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -30,15 +30,20 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
-policy は、review 実行 agent のみが必要とする conditional な必須事項・禁止事項
-について、その canonical ownership を Foundation-owned な skill へ明示的に
-委譲してよいです。この委譲は次をすべて満たす場合に限ります。
+policy は、review 実行 agent のみが必要とする場合、または特定の trigger
+発火時（および発火したかどうか不明な場合）にのみ必要となる場合等、
+conditional にのみ必要となる必須事項・禁止事項について、その canonical
+ownership を Foundation-owned な skill へ明示的に委譲してよいです。この
+委譲は次をすべて満たす場合に限ります。
 
 - policy 自身が、委譲先の skill を one-hop pointer として名指しする
-- 委譲後も policy に、review を実行しない Task でも成立していなければ
-  ならない minimum safety boundary（authority 分離、fail-closed な
-  uncertainty rule 等）が残る
+- 委譲後も policy に、その conditional な状況が成立していない Task でも
+  成立していなければならない minimum safety boundary（authority 分離、
+  fail-closed な uncertainty rule 等）が残る
 - 同じ規範的なルールを policy と skill の両方に重複して記述しない
+- この委譲は個別に列挙した対象にのみ適用し、任意のルールを一般的に skill へ
+  移してよいことを意味しない。委譲のために generalized loader / registry /
+  routing framework / DSL を新設しない
 
 この場合、skill が記述する必須事項・禁止事項は policy の複製ではなく、
 委譲された canonical source です。委譲していない規範的なルールについては、
@@ -690,47 +695,31 @@ Task 実行中に少なくとも次のいずれかを観測した場合、Founda
 4. provider / runtime の実挙動が、Task で依拠した前提と食い違う
 5. 同一 root cause と思われる friction / workaround を以前にも観測している
 
-### Observation classification
+### Observation handling — canonical ownership delegation
 
-Observation trigger が発火したら、症状の重大度ではなく root cause /
-ownership を軸に、次の 4 分類のいずれかへ分類します。
+Observation trigger が発火した場合、または発火したかどうか判断がつかない
+場合は、`.ai-dev-foundation/skills/foundation-change.md` を **MUST load**
+します。判断がつかない場合を「trigger なし」と解釈して silent skip しては
+いけません。
 
-- `consumer-local`: product / domain / consumer 固有で自然に閉じる
-- `provider/runtime`: 外部 provider / runtime の挙動で、Foundation
-  contract 自体の欠陥ではない
-- `Foundation candidate`: shared problem / improvement candidate に
-  なり得るが、Foundation-owned な rule / profile / tooling / artifact
-  自体が誤った挙動を要求・生成・許容していると確認されたわけではない
-  （Foundation-owned だと分かっていても、確認された defect ではない
-  改善余地を含む）
-- `canonical defect candidate`: Foundation-owned な rule / profile /
-  tooling / artifact 自体が誤った挙動を要求・生成・許容していると
-  確認できる場合に限る（正しく機能している manual step を自動化・
-  簡略化できるという改善余地だけでは、この分類に含めない）
+Observation の 4 分類（root cause / ownership を軸にした定義と境界）、
+Observation recording の procedure・field、Change Proposal が表現すべき
+field 定義、および Observation から Change Proposal への昇格 signal の
+detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
+です。本節はこれらの手続き的 detail を複製しません。
 
-`provider/runtime` に分類した Observation でも、Foundation がその挙動を
-誤って恒久前提として固定している場合は、Foundation 側の candidate として
-再評価します。
+本節が、Foundation Change に関与しない Task でも成立していなければ
+ならない minimum safety boundary として保持するのは次のとおりです。
 
-### Observation recording
-
-Observation trigger の発火は、自動的に Foundation Issue を作りません。
-Observation は work item ではありません。
-
-将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task
-の canonical Issue へ、少なくとも次を短く記録します。
-
-- Observed / evidence locator
-- Classification
-- Impact
-- Local handling
-- Foundation action: `none` / `observe` / `change proposal candidate`
-- Promotion signal（何が起きれば再評価するか）
-
-consumer-local で完結し、将来参照価値もない軽微な事象は、この記録義務の
-対象にしません。専用の ledger / database / schema、GitHub label 体系、
-bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの
-mandatory 化は Observation handling の一部にしません。
+- Observation trigger の発火は、自動的に Foundation Issue を作りません。
+  Observation は work item ではありません。
+- 単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に
+  mandatory 化しません（詳細は Foundation Change の正当化条件を参照）。
+- 専用の ledger / database / schema、GitHub label 体系、bot / collector /
+  dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は
+  Observation handling の一部にしません。
+- Task closure と Observation（下記）、および Foundation Change の
+  正当化条件（下記）
 
 ### Task closure と Observation
 
@@ -753,32 +742,10 @@ mandatory な Foundation change は、原則として次のいずれかで正当
 して条項を足すかどうかの判定にも、そのまま適用します。文言の曖昧さや網羅性の不足を
 指摘する finding は、実運用で misjudgment が観測された場合に限り accept します。
 
-Change Proposal は、少なくとも次を表現できるものとします。
-
-- Problem
-- Evidence
-- Proposed Change
-- Expected Effect
-- Trade-off
-- Scope
-- Success Criterion
-
-### Observation から Change Proposal への昇格
-
-Observation classification は、本節の 3 つの Foundation Change 正当化
-条件を置き換えず、緩和しません。特に次は強い promotion signal になり
-得ます。
-
-- Foundation 自身の material defect が実証された
-- material defect を deterministically 防止できる
-- 同一 root cause が recurring / escaped failure になった
-- correctness のための mandatory manual ritual が定着した
-- consumer-local workaround では canonical semantics の fork が必要に
-  なる
-
-change class や review 強度は、固定の provider 名へ結びつけません。単発の
-friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory
-化しません。
+Change Proposal が表現すべき field 定義、および Observation classification
+から本節の 3 条件への昇格を促す detailed promotion signal の canonical
+source は `.ai-dev-foundation/skills/foundation-change.md` です。change
+class や review 強度は、固定の provider 名へ結びつけません。
 
 ## Technology profile: Next.js + Supabase
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -704,13 +704,17 @@ Task 実行中に少なくとも次のいずれかを観測した場合、Founda
 Observation trigger が発火した場合、または発火したかどうか判断がつかない
 場合は、`.ai-dev-foundation/skills/foundation-change.md` を **MUST load**
 します。判断がつかない場合を「trigger なし」と解釈して silent skip しては
-いけません。
+いけません。**この path は consumer context のものです。Foundation
+リポジトリ自身の Task では、同じ canonical source である
+`skills/foundation-change.md` を同じ条件で MUST load します。**
 
 Observation の 4 分類（root cause / ownership を軸にした定義と境界）、
 Observation recording の procedure・field、Change Proposal が表現すべき
 field 定義、および Observation から Change Proposal への昇格 signal の
-detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
-です。本節はこれらの手続き的 detail を複製しません。
+detail の canonical source は、consumer context では
+`.ai-dev-foundation/skills/foundation-change.md`、Foundation リポジトリ
+自身の Task では `skills/foundation-change.md` です。本節はこれらの
+手続き的 detail を複製しません。
 
 本節が、Foundation Change に関与しない Task でも成立していなければ
 ならない minimum safety boundary として保持するのは次のとおりです。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -754,8 +754,9 @@ mandatory な Foundation change は、原則として次のいずれかで正当
 
 Change Proposal が表現すべき field 定義、および Observation classification
 から本節の 3 条件への昇格を促す detailed promotion signal の canonical
-source は `.ai-dev-foundation/skills/foundation-change.md` です。change
-class や review 強度は、固定の provider 名へ結びつけません。
+source は、consumer context では `.ai-dev-foundation/skills/foundation-change.md`、
+Foundation リポジトリ自身の Task では `skills/foundation-change.md` です。
+change class や review 強度は、固定の provider 名へ結びつけません。
 
 ## Technology profile: Next.js + Supabase
 

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -30,11 +30,15 @@
 同じ規範的なルールを Skill、Profile、generated adapter の source に再記述せず、
 所有するルールを参照してください。
 
-policy は、review 実行 agent のみが必要とする場合、または特定の trigger
-発火時（および発火したかどうか不明な場合）にのみ必要となる場合等、
-conditional にのみ必要となる必須事項・禁止事項について、その canonical
-ownership を Foundation-owned な skill へ明示的に委譲してよいです。この
-委譲は次をすべて満たす場合に限ります。
+policy は、次の二つの場合に限り、conditional にのみ必要となる必須事項・
+禁止事項について、その canonical ownership を Foundation-owned な skill へ
+明示的に委譲してよいです。
+
+1. review 実行 agent のみが必要とする場合
+2. 特定の trigger 発火時（および発火したかどうか不明な場合）にのみ
+   必要となる場合
+
+この委譲は次をすべて満たす場合に限ります。
 
 - policy 自身が、委譲先の skill を one-hop pointer として名指しする
 - 委譲後も policy に、その conditional な状況が成立していない Task でも
@@ -718,8 +722,10 @@ detail の canonical source は `.ai-dev-foundation/skills/foundation-change.md`
 - 専用の ledger / database / schema、GitHub label 体系、bot / collector /
   dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は
   Observation handling の一部にしません。
-- Task closure と Observation（下記）、および Foundation Change の
-  正当化条件（下記）
+
+これに加え、下記の Task closure と Observation の fail-closed hook、
+および Foundation Change の正当化条件も、本 Kernel が保持する minimum
+safety boundary です。
 
 ### Task closure と Observation
 

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -183,6 +183,23 @@ test("core policy keeps the minimum Foundation Change Kernel safety boundary (#2
     containsText(core, "判断がつかない場合を「trigger なし」と解釈して silent skip してはいけません。"),
   );
 
+  // #113 Codex P2: the MUST-load pointer named only the consumer-distributed
+  // path, so a Task running inside the Foundation repository itself could
+  // not resolve it to the canonical skills/foundation-change.md. Both
+  // contexts must be named explicitly, without a generalized resolver.
+  assert.ok(
+    containsText(
+      core,
+      "この path は consumer context のものです。Foundation リポジトリ自身の Task では、同じ canonical source である `skills/foundation-change.md` を同じ条件で MUST load します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      core,
+      "consumer context では `.ai-dev-foundation/skills/foundation-change.md`、Foundation リポジトリ自身の Task では `skills/foundation-change.md` です。",
+    ),
+  );
+
   // Observation is not a work item and does not auto-create a Foundation
   // Issue; it is recorded on the originating consumer Task's canonical Issue.
   assert.ok(

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -30,6 +30,9 @@ test("core policy defines the Foundation Change Protocol", async () => {
     assert.ok(core.includes(reason), `missing Foundation Change justification: ${reason}`);
   }
 
+  // #112: Change Proposal field definitions are canonically owned by
+  // skills/foundation-change.md, not restated in core.md.
+  const foundationChange = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
   for (const field of [
     "Problem",
     "Evidence",
@@ -39,13 +42,13 @@ test("core policy defines the Foundation Change Protocol", async () => {
     "Scope",
     "Success Criterion",
   ]) {
-    assert.ok(core.includes(field), `Change Proposal must express: ${field}`);
+    assert.ok(foundationChange.includes(field), `Change Proposal must express: ${field}`);
   }
 
   assert.ok(
     containsText(
       core,
-      "単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory 化しません。",
+      "単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に mandatory 化しません",
     ),
   );
 
@@ -135,14 +138,20 @@ test("core policy separates merge-readiness from merge execution authority", asy
   );
 });
 
-test("core policy defines a minimal Observation handling entry point (#20)", async () => {
+test("core policy keeps the minimum Foundation Change Kernel safety boundary (#20, #112)", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
   assert.ok(core.includes("### Observation trigger"));
-  assert.ok(core.includes("### Observation classification"));
-  assert.ok(core.includes("### Observation recording"));
+  assert.ok(core.includes("### Observation handling — canonical ownership delegation"));
   assert.ok(core.includes("### Task closure と Observation"));
-  assert.ok(core.includes("### Observation から Change Proposal への昇格"));
+  assert.ok(core.includes("### Foundation Change の正当化条件"));
+
+  // #112: classification/recording/promotion procedural detail is no longer
+  // duplicated as its own heading in the Kernel; it is delegated to
+  // skills/foundation-change.md.
+  assert.ok(!core.includes("### Observation classification"));
+  assert.ok(!core.includes("### Observation recording"));
+  assert.ok(!core.includes("### Observation から Change Proposal への昇格"));
 
   // Observation trigger stays event-driven: five concrete conditions, not a
   // blanket per-Task retrospective requirement.
@@ -162,35 +171,16 @@ test("core policy defines a minimal Observation handling entry point (#20)", asy
     ),
   );
 
-  // Minimal four-way classification, judged by root cause/ownership rather
-  // than severity.
-  for (const label of [
-    "`consumer-local`",
-    "`provider/runtime`",
-    "`Foundation candidate`",
-    "`canonical defect candidate`",
-  ]) {
-    assert.ok(core.includes(label), `missing Observation classification: ${label}`);
-  }
-  assert.ok(containsText(core, "症状の重大度ではなく root cause / ownership を軸に"));
-
-  // `Foundation candidate` is not exclusive
-  // to unconfirmed ownership — a Foundation-owned shared improvement
-  // candidate that is not a confirmed defect belongs here too.
-  // `canonical defect candidate` is limited strictly to confirmed defective
-  // behavior; a correctly-functioning manual step that could be automated
-  // does not qualify (Issue #20's original semantic contract).
+  // #112: trigger 発火時、または発火したかどうか不明な場合は
+  // skills/foundation-change.md を MUST load する fail-closed one-hop pointer.
   assert.ok(
     containsText(
       core,
-      "Foundation-owned だと分かっていても、確認された defect ではない改善余地を含む",
+      "Observation trigger が発火した場合、または発火したかどうか判断がつかない場合は、`.ai-dev-foundation/skills/foundation-change.md` を **MUST load** します。",
     ),
   );
   assert.ok(
-    containsText(
-      core,
-      "正しく機能している manual step を自動化・簡略化できるという改善余地だけでは、この分類に含めない",
-    ),
+    containsText(core, "判断がつかない場合を「trigger なし」と解釈して silent skip してはいけません。"),
   );
 
   // Observation is not a work item and does not auto-create a Foundation
@@ -200,54 +190,18 @@ test("core policy defines a minimal Observation handling entry point (#20)", asy
   );
   assert.ok(containsText(core, "Observation は work item ではありません。"));
 
-  // Recording is a mandatory obligation (not merely a recordable capability)
-  // when the future-reuse-value condition is met: "記録できることを要求します"
-  // reads as capability-only and lets required evidence be omitted at Task
-  // closure.
-  assert.ok(
-    containsText(
-      core,
-      "将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task の canonical Issue へ、少なくとも次を短く記録します。",
-    ),
-  );
-  for (const field of [
-    "Observed / evidence locator",
-    "Classification",
-    "Impact",
-    "Local handling",
-    "Foundation action",
-    "Promotion signal",
-  ]) {
-    assert.ok(core.includes(field), `Observation record must express: ${field}`);
-  }
-
   // Out of Scope for #20: no ledger/bot/dashboard/auto-issue/periodic-audit
-  // machinery, and no new tooling files were added to implement it.
+  // machinery stays a Kernel-retained anti-overbuilding invariant even after
+  // the recording procedure itself moved to the skill (#112).
   assert.ok(
     containsText(
       core,
       "専用の ledger / database / schema、GitHub label 体系、bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は Observation handling の一部にしません。",
     ),
   );
-  // An exact directory-equality check, a filename-token pattern, and a dynamic
-  // merge-base diff were each tried and each had a real failure mode (fails
-  // on unrelated future tooling additions; false-positives/negatives on
-  // filenames; or, for the merge-base diff, silently becomes a *permanent*
-  // "no one may ever add a tooling file" gate on this test file long after
-  // this PR merges, since `git merge-base HEAD main` re-resolves on every
-  // future branch that happens to reuse this code). Whether this specific
-  // PR added new tooling files is a one-time historical fact about this
-  // PR's landing, not an evergreen property this file can assert on every
-  // future checkout — so it is not encoded as an automated regression check
-  // here. It was instead verified once, out of band, via
-  // `git diff --stat <PR base>..HEAD -- tooling` returning no changes, and
-  // is reported as evidence in the PR itself. The canonical, permanent
-  // contract asserted below is the policy text prohibiting this machinery.
 
   // Task closure collects only triggers that already fired; it is not a new
-  // improvement-discovery step. It also does not force recording of
-  // observations the recording contract exempts: the closure gate must not
-  // conflict with the recording exemption.
+  // improvement-discovery step.
   assert.ok(
     containsText(
       core,
@@ -273,12 +227,95 @@ test("core policy defines a minimal Observation handling entry point (#20)", asy
     ),
   );
 
+  // The pre-existing justification conditions are general Foundation Change
+  // Protocol content, not Task-closure-specific, and must not nest under the
+  // "### Task closure と Observation" heading.
+  const taskClosureHeadingIndex = core.indexOf("### Task closure と Observation");
+  const justificationHeadingIndex = core.indexOf("### Foundation Change の正当化条件");
+  const justificationReasonIndex = core.indexOf("既存の mandatory / manual step を置き換える");
+  assert.ok(taskClosureHeadingIndex !== -1 && justificationHeadingIndex !== -1);
+  assert.ok(
+    taskClosureHeadingIndex < justificationHeadingIndex &&
+      justificationHeadingIndex < justificationReasonIndex,
+    "the 3 justification conditions must sit under their own heading, after Task closure, not nested inside it",
+  );
+
+  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+test("skills/foundation-change.md owns Observation classification/recording/promotion detail (#112)", async () => {
+  const foundationChange = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
+
+  assert.ok(foundationChange.includes("## Observation classification"));
+  assert.ok(foundationChange.includes("## Observation recording"));
+  assert.ok(foundationChange.includes("## Change Proposal"));
+  assert.ok(foundationChange.includes("## Observation から Change Proposal への昇格"));
+
+  // Minimal four-way classification, judged by root cause/ownership rather
+  // than severity.
+  for (const label of [
+    "`consumer-local`",
+    "`provider/runtime`",
+    "`Foundation candidate`",
+    "`canonical defect candidate`",
+  ]) {
+    assert.ok(foundationChange.includes(label), `missing Observation classification: ${label}`);
+  }
+  assert.ok(containsText(foundationChange, "症状の重大度ではなく root cause / ownership を軸に"));
+
+  // `Foundation candidate` is not exclusive
+  // to unconfirmed ownership — a Foundation-owned shared improvement
+  // candidate that is not a confirmed defect belongs here too.
+  // `canonical defect candidate` is limited strictly to confirmed defective
+  // behavior; a correctly-functioning manual step that could be automated
+  // does not qualify (Issue #20's original semantic contract).
+  assert.ok(
+    containsText(
+      foundationChange,
+      "Foundation-owned だと分かっていても、確認された defect ではない改善余地を含む",
+    ),
+  );
+  assert.ok(
+    containsText(
+      foundationChange,
+      "正しく機能している manual step を自動化・簡略化できるという改善余地だけでは、この分類に含めない",
+    ),
+  );
+
+  // Recording is a mandatory obligation (not merely a recordable capability)
+  // when the future-reuse-value condition is met: "記録できることを要求します"
+  // reads as capability-only and lets required evidence be omitted at Task
+  // closure.
+  assert.ok(
+    containsText(
+      foundationChange,
+      "将来の Foundation 判断へ再利用する価値がある場合、発生した consumer Task の canonical Issue へ、少なくとも次を短く記録します。",
+    ),
+  );
+  for (const field of [
+    "Observed / evidence locator",
+    "Classification",
+    "Impact",
+    "Local handling",
+    "Foundation action",
+    "Promotion signal",
+  ]) {
+    assert.ok(foundationChange.includes(field), `Observation record must express: ${field}`);
+  }
+
+  assert.ok(
+    containsText(
+      foundationChange,
+      "専用の ledger / database / schema、GitHub label 体系、bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は Observation handling の一部にしません。",
+    ),
+  );
+
   // Observation classification supplements, and does not replace or relax,
   // the existing three Foundation Change justification conditions.
   assert.ok(
     containsText(
-      core,
-      "Observation classification は、本節の 3 つの Foundation Change 正当化条件を置き換えず、緩和しません。",
+      foundationChange,
+      "Observation classification は、`policy/core.md` の 3 つの Foundation Change 正当化条件を置き換えず、緩和しません。",
     ),
   );
   for (const signal of [
@@ -288,36 +325,26 @@ test("core policy defines a minimal Observation handling entry point (#20)", asy
     "correctness のための mandatory manual ritual が定着した",
     "consumer-local workaround では canonical semantics の fork が必要に",
   ]) {
-    assert.ok(core.includes(signal), `missing Observation promotion signal: ${signal}`);
+    assert.ok(foundationChange.includes(signal), `missing Observation promotion signal: ${signal}`);
   }
 
-  // The pre-existing justification conditions and Change Proposal fields are general Foundation
-  // Change Protocol content, not Task-closure-specific, and must not nest under the
-  // "### Task closure と Observation" heading (which "### Observation から
-  // Change Proposal への昇格" still refers back to as "本節の 3 つの...
-  // 正当化条件").
-  const taskClosureHeadingIndex = core.indexOf("### Task closure と Observation");
-  const justificationHeadingIndex = core.indexOf("### Foundation Change の正当化条件");
-  const justificationReasonIndex = core.indexOf("既存の mandatory / manual step を置き換える");
-  const promotionHeadingIndex = core.indexOf("### Observation から Change Proposal への昇格");
-  assert.ok(taskClosureHeadingIndex !== -1 && justificationHeadingIndex !== -1);
-  assert.ok(
-    taskClosureHeadingIndex < justificationHeadingIndex &&
-      justificationHeadingIndex < justificationReasonIndex &&
-      justificationReasonIndex < promotionHeadingIndex,
-    "the 3 justification conditions must sit under their own heading, between Task closure and Observation promotion, not nested inside either",
-  );
-
-  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+  assert.doesNotMatch(foundationChange, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
 });
 
 test("generated consumer AGENTS.md reflects the Observation handling contract", async () => {
   const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
 
   assert.ok(agents.includes("### Observation trigger"));
-  assert.ok(agents.includes("### Observation classification"));
-  assert.ok(agents.includes("### Observation recording"));
+  assert.ok(agents.includes("### Observation handling — canonical ownership delegation"));
   assert.ok(agents.includes("### Task closure と Observation"));
   assert.ok(agents.includes("### Foundation Change の正当化条件"));
-  assert.ok(agents.includes("### Observation から Change Proposal への昇格"));
+});
+
+test("materialized consumer skill bundle includes foundation-change.md (#112)", async () => {
+  const materialized = await readFile(
+    path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "skills", "foundation-change.md"),
+    "utf8",
+  );
+  const source = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
+  assert.equal(materialized, source);
 });

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -348,3 +348,77 @@ test("materialized consumer skill bundle includes foundation-change.md (#112)", 
   const source = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
   assert.equal(materialized, source);
 });
+
+// #112: the moved procedural headings must actually leave the generated
+// consumer artifact, not just gain new Kernel headings alongside stale
+// leftovers from a broken sync.
+test("generated consumer AGENTS.md does not carry the moved Observation procedural detail (#112)", async () => {
+  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+
+  assert.ok(!agents.includes("### Observation classification"));
+  assert.ok(!agents.includes("### Observation recording"));
+  assert.ok(!agents.includes("### Observation から Change Proposal への昇格"));
+});
+
+// #112: the widened "## 責務の分離" delegation clause must stay a closed,
+// bounded enumeration of exactly the two named cases (review-execution-only,
+// and trigger-fired-or-uncertain), not an open-ended class an agent could
+// read as license to delegate arbitrary rules to arbitrary skills.
+test("core policy's widened canonical ownership delegation clause stays a closed, bounded enumeration (#112)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  assert.ok(
+    containsText(
+      core,
+      "policy は、次の二つの場合に限り、conditional にのみ必要となる必須事項・禁止事項について、その canonical ownership を Foundation-owned な skill へ明示的に委譲してよいです。",
+    ),
+  );
+  assert.ok(containsText(core, "review 実行 agent のみが必要とする場合"));
+  assert.ok(
+    containsText(core, "特定の trigger 発火時（および発火したかどうか不明な場合）にのみ必要となる場合"),
+  );
+
+  for (const condition of [
+    "policy 自身が、委譲先の skill を one-hop pointer として名指しする",
+    "同じ規範的なルールを policy と skill の両方に重複して記述しない",
+    "この委譲は個別に列挙した対象にのみ適用し、任意のルールを一般的に skill へ移してよいことを意味しない",
+    "generalized loader / registry / routing framework / DSL を新設しない",
+  ]) {
+    assert.ok(containsText(core, condition), `missing delegation condition: ${condition}`);
+  }
+
+  // The enumeration must not carry a trailing "等" (etc.) or other
+  // open-ended qualifier right after the two named cases — that would
+  // contradict "個別に列挙した対象にのみ適用".
+  const delegationIntroIndex = core.indexOf("policy は、次の二つの場合に限り");
+  assert.ok(delegationIntroIndex !== -1);
+  const delegationClauseSlice = core.slice(delegationIntroIndex, delegationIntroIndex + 400);
+  assert.doesNotMatch(
+    delegationClauseSlice,
+    /場合等/,
+    "the two-case enumeration must be closed, not suffixed with an open-ended 等",
+  );
+});
+
+// #112 Safety scenario 6: Review Protocol tasks must be able to satisfy the
+// Foundation Change justification conditions from the Kernel alone. They
+// must not need to load skills/foundation-change.md, and must not duplicate
+// or depend on its content.
+test("review skills do not need to load or duplicate skills/foundation-change.md (#112 safety scenario 6)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+
+  for (const [name, skill] of [
+    ["review-code.md", reviewCode],
+    ["review-doc.md", reviewDoc],
+  ]) {
+    assert.ok(
+      !skill.includes("foundation-change"),
+      `${name} must not reference skills/foundation-change.md; the Review lane gets the justification conditions from the Kernel alone`,
+    );
+    assert.ok(
+      !skill.includes("Foundation Change の正当化条件"),
+      `${name} must not duplicate the Foundation Change justification conditions`,
+    );
+  }
+});

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -351,10 +351,15 @@ test("skills/foundation-change.md owns Observation classification/recording/prom
   // minimum safety boundary sentence; the skill must reference it, not
   // restate it verbatim (that would violate the delegation's own
   // no-duplication condition in policy/core.md's 責務の分離).
+  //
+  // #113 Codex P2 follow-up: the reference text must not drop "mandatory
+  // 化" — core.md only forbids *making ledger/dashboard mandatory*, not
+  // ever using one; a paraphrase that omits "mandatory 化" reads as an
+  // absolute ban and is stricter than the Kernel actually requires.
   assert.ok(
     containsText(
       foundationChange,
-      "ledger / database / schema、GitHub label 体系、bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしないことは `policy/core.md` の minimum safety boundary です。本 skill では複製しません。",
+      "専用の ledger / dashboard 等の mandatory 化を Observation handling の一部にしないことは `policy/core.md` の minimum safety boundary です。本 skill では複製しません。",
     ),
   );
 

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -200,6 +200,33 @@ test("core policy keeps the minimum Foundation Change Kernel safety boundary (#2
     ),
   );
 
+  // #113 Codex P2 follow-up: a second consumer-only canonical-source
+  // reference survived in the Foundation Change justification section
+  // (Change Proposal field / promotion signal detail) after the first
+  // MUST-load pointer fix. It must also branch by context.
+  assert.ok(
+    containsText(
+      core,
+      "canonical source は、consumer context では `.ai-dev-foundation/skills/foundation-change.md`、Foundation リポジトリ自身の Task では `skills/foundation-change.md` です。",
+    ),
+  );
+
+  // Repo-wide regression guard: every reference to the consumer-distributed
+  // `.ai-dev-foundation/skills/foundation-change.md` path in core.md must be
+  // paired with the Foundation-repository-self path `skills/foundation-change.md`
+  // nearby, so a future addition of a new consumer-only reference doesn't
+  // silently reintroduce the same unreachable-pointer defect.
+  const consumerOnlyPointerCount = (core.match(/`\.ai-dev-foundation\/skills\/foundation-change\.md`/g) ?? [])
+    .length;
+  // This pattern only matches a bare `skills/foundation-change.md` (backtick
+  // immediately before "skills/"), so it does not also match inside the
+  // consumer path above (which has a backtick before ".ai-dev-foundation/").
+  const selfContextPointerCount = (core.match(/`skills\/foundation-change\.md`/g) ?? []).length;
+  assert.ok(
+    selfContextPointerCount >= consumerOnlyPointerCount,
+    `every consumer-context foundation-change.md pointer in core.md must be paired with a Foundation-self-context pointer (consumer-only refs: ${consumerOnlyPointerCount}, self-context refs: ${selfContextPointerCount})`,
+  );
+
   // Observation is not a work item and does not auto-create a Foundation
   // Issue; it is recorded on the originating consumer Task's canonical Issue.
   assert.ok(

--- a/test/foundation-change-and-merge-authority.test.mjs
+++ b/test/foundation-change-and-merge-authority.test.mjs
@@ -320,10 +320,14 @@ test("skills/foundation-change.md owns Observation classification/recording/prom
     assert.ok(foundationChange.includes(field), `Observation record must express: ${field}`);
   }
 
+  // #113 Claude review: the ledger/dashboard prohibition is a Kernel
+  // minimum safety boundary sentence; the skill must reference it, not
+  // restate it verbatim (that would violate the delegation's own
+  // no-duplication condition in policy/core.md's 責務の分離).
   assert.ok(
     containsText(
       foundationChange,
-      "専用の ledger / database / schema、GitHub label 体系、bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しの mandatory 化は Observation handling の一部にしません。",
+      "ledger / database / schema、GitHub label 体系、bot / collector / dashboard / statistics、自動 Issue 生成、定期棚卸しを Observation handling の一部にしないことは `policy/core.md` の minimum safety boundary です。本 skill では複製しません。",
     ),
   );
 
@@ -436,6 +440,35 @@ test("review skills do not need to load or duplicate skills/foundation-change.md
     assert.ok(
       !skill.includes("Foundation Change の正当化条件"),
       `${name} must not duplicate the Foundation Change justification conditions`,
+    );
+  }
+});
+
+// #113 Claude review: skills/foundation-change.md's own delegation rule
+// (policy/core.md's 責務の分離, "同じ規範的なルールを policy と skill の
+// 両方に重複して記述しない") must not be violated by the skill it applies
+// to. Lock the specific Kernel minimum-safety-boundary sentences that were
+// found verbatim-duplicated in skills/foundation-change.md, so a future
+// edit can't silently reintroduce the duplication.
+test("skills/foundation-change.md does not verbatim-duplicate Kernel minimum safety boundary sentences (#113)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const foundationChange = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
+
+  for (const kernelSentence of [
+    "Observation trigger の発火は、自動的に Foundation Issue を作りません。",
+    "Observation は work item ではありません。",
+    "専用の ledger / database / schema、GitHub label 体系、bot / collector /",
+    "記録義務の対象にしない軽微な事象について省略できるのは記録だけであり、classification の完了は省略しません。",
+    "単発の friction、style、prompt nicety、効率改善のみを理由に、自動的に",
+    "change class や review 強度は、固定の provider 名へ結びつけません。",
+  ]) {
+    assert.ok(
+      containsText(core, kernelSentence),
+      `sanity check: sentence must actually be in core.md: ${kernelSentence}`,
+    );
+    assert.ok(
+      !containsText(foundationChange, kernelSentence),
+      `skills/foundation-change.md must not verbatim-duplicate this Kernel sentence, only reference policy/core.md: ${kernelSentence}`,
     );
   }
 });


### PR DESCRIPTION
## Summary

`policy/core.md` の `## Foundation Change Protocol` のうち、Observation
classification（4分類）・recording procedure/field・Change Proposal field
定義・promotion signal detail を、新設 `skills/foundation-change.md` へ
canonical ownership として委譲する。

Kernel には次の minimum safety boundary を残す。

- Observation trigger 5条件（全文）
- trigger発火時 / 発火不明時に `skills/foundation-change.md` を MUST load
  する one-hop pointer（fail-closed uncertainty rule）
- Observation は自動的に Foundation Issue / work item にならない
- Task closure 前の未分類 Observation の fail-closed classification hook
- Foundation Change 正当化3条件（全文）
- ledger / dashboard / 自動 Issue 生成等の禁止

`責務の分離` の canonical ownership delegation 条件を、review 実行 agent
のみから、trigger 発火時 / 不明時にのみ必要となる conditional な必須事項・
禁止事項にも bounded 適用できるよう最小限拡張した。新しい generalized
loader / registry / routing framework / DSL は導入していない。

Parent: #109 / Architecture: #107

## Test plan

- [x] `npm test`（284 pass / 1 skipped、guardrails green）
- [x] `npm run sync:fixture` / `npm run check:fixture`（reference consumer 再生成・drift なし）
- [x] `git diff --check`
- [ ] normal Review Protocol（本 PR で実施）
- [ ] real-consumer canary（stage-tracker、bounded・non-committing）

🤖 Generated with [Claude Code](https://claude.com/claude-code)