### PR TITLE
#114: Task closure detailをstrong Kernel boundaryでconditional化する

### DIFF
--- a/policy/core.md
+++ b/policy/core.md
@@ -213,45 +213,36 @@ Review が完了していても、Issue Task Contract 上の Acceptance Criteria
 よいことにはなりません。canonical Issue を completed として close する判断は、この
 節に従います。
 
-canonical Issue を completed として close する前に、少なくとも次を行います。
+canonical Issue を completed として close しようとする場合、または close 手順の
+適用要否が判断つかない場合は、`.ai-dev-foundation/skills/task-closure.md` を
+**MUST load** します。判断がつかない場合を「適用不要」と解釈して silent skip しては
+いけません。**この path は consumer context のものです。Foundation リポジトリ自身の
+Task では、同じ canonical source である `skills/task-closure.md` を同じ条件で MUST
+load します。**
 
-1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
-   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
-   （canonical Task Contract）と、merge 済み current main または applicable branch
-   の状態を再取得します。
-2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
-   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
-   完了したように見える」という印象だけでは充足の根拠にしません。
-3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
-   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
-   evidence の一部として扱います。
-4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない Acceptance
-   Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。
-   Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance
-   Criteria を捏造しません。
-5. **completion comment** — final SHA、verification 結果、review evidence
-   （Review Protocol の Acquisition & Validity Contract に従う record / result
-   locator を含む）、および未解決事項を、Issue 上の completion comment として
-   記録します。
+5-step closure procedure（canonical context の再取得手順、Acceptance Criteria
+evidence 照合手順、checkbox 更新手順、未達・判断不能時の procedure detail、
+completion comment の field / record locator detail）、推奨する sequence、close
+authority が無い場合の completion-comment / handoff procedure detail、および
+closure-specific no-new-machinery detail の canonical source は、consumer context
+では `.ai-dev-foundation/skills/task-closure.md`、Foundation リポジトリ自身の Task
+では `skills/task-closure.md` です。本節はこれらの手続き的 detail を複製しません。
 
-推奨する sequence は次のとおりです。
+本節が、closure 判断に至っていない Task でも成立していなければならない minimum
+safety boundary として保持するのは次のとおりです。
 
-`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
-completion comment -> Issue close`
-
-Issue close の execution authority は、Merge readiness and merge authority と同じ
-分離に従います。current Task、Execution Envelope、または explicit な authority が
-close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
-が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
-編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
-（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、
-authority escalation / handoff します。
-
-auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
-Issue が自動 close される運用を、標準運用にしません。
-
-この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
-workflow engine、または新しい orchestrator を要求しません。
+- evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、
+  その項目を勝手に check せず、Issue も close しません。Issue に Acceptance
+  Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造
+  しません。
+- Issue close の execution authority は、Merge readiness and merge authority と
+  同じ分離に従います。current Task、Execution Envelope、または explicit な
+  authority が close の実行を許可している場合に限り、agent は Issue を close して
+  よいです。authority が明示されていない場合、または別 authority の承認が必要な
+  場合、agent は Issue 本文の編集や close を実行せず、evidence-supported な
+  completion state を記録した上で停止し、authority escalation / handoff します。
+- auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria
+  確認前に Issue が自動 close される運用を、標準運用にしません。
 
 ## Review Protocol
 

--- a/skills/task-closure.md
+++ b/skills/task-closure.md
@@ -1,0 +1,80 @@
+# task-closure skill
+
+このファイルは `policy/core.md` の Issue closure and Acceptance Criteria
+completion protocol を使った Task closure 手順です。`policy/core.md` が保持する
+minimum safety boundary（Task Contract completion と merge-readiness の分離、
+evidence 不足・未達・判断不能な Acceptance Criteria がある場合の no-check /
+no-close、Acceptance Criteria が存在しない Issue へ close のために新たな
+Acceptance Criteria を捏造しないこと、Issue close execution authority の分離、
+auto-close keyword による標準 close の禁止）はここで再定義せず、`policy/core.md`
+を参照します。本 skill と policy が矛盾する場合は policy が優先します。
+
+5-step closure procedure の detail、推奨する sequence、close authority が無い
+場合の completion-comment / handoff procedure detail、および closure-specific
+no-new-machinery detail の canonical source は本 skill であり、`policy/core.md`
+には置きません。
+
+## いつ load するか
+
+`policy/core.md` の Issue closure and Acceptance Criteria completion protocol に
+従い、canonical Issue を completed として close しようとする場合、または close
+手順の適用要否が判断つかない場合は本 skill を **MUST load** します。判断がつかない
+場合を「適用不要」と解釈して silent skip してはいけません。
+
+この skill の canonical source は Foundation リポジトリの `policy/core.md` および
+`skills/task-closure.md` です。consumer には
+`.ai-dev-foundation/skills/task-closure.md` として本ファイルが配布され、
+`policy/core.md` の規範的なルールは generated `AGENTS.md` の `## Foundation
+policy` section として配布されます。以降 `policy/core.md` への参照は、consumer
+context ではこの `AGENTS.md` の `## Foundation policy` section を指します。
+consumer リポジトリに `policy/core.md` という path が存在することは前提にしません。
+
+## Closure procedure
+
+canonical Issue を completed として close する前に、少なくとも次を行います。
+
+1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
+   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
+   （canonical Task Contract）と、merge 済み current main または applicable branch
+   の状態を再取得します。
+2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
+   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
+   完了したように見える」という印象だけでは充足の根拠にしません。
+3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
+   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
+   evidence の一部として扱います。
+4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない
+   Acceptance Criteria が 1 件でも残る場合に check/close しないこと、および
+   Acceptance Criteria が存在しない Issue へ close のために新たな Acceptance
+   Criteria を捏造しないことは `policy/core.md` の minimum safety boundary です。
+   本 skill では複製しません。判断できない理由が明確な場合は、その理由を手順 5 の
+   completion comment に記録します。
+5. **completion comment** — final SHA、verification 結果、review evidence
+   （Review Protocol の Acquisition & Validity Contract に従う record / result
+   locator を含む）、および未解決事項を、Issue 上の completion comment として
+   記録します。
+
+推奨する sequence は次のとおりです。
+
+`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
+completion comment -> Issue close`
+
+## Close authority が無い場合
+
+Issue close の execution authority separation、および authority が無い場合に
+close を実行しないことは `policy/core.md` の minimum safety boundary です。本
+skill では複製しません。
+
+authority が明示されていない場合、または別 authority の承認が必要な場合、agent は
+Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で
+満たされているか（または未達か）を、手順 5 の completion comment として明示的に
+残した上で停止し、authority escalation / handoff します。
+
+## No new machinery
+
+この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
+workflow engine、または新しい orchestrator を要求しません。
+
+auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前
+に Issue が自動 close される運用を標準運用にしないことは `policy/core.md` の
+minimum safety boundary です。本 skill では複製しません。

--- a/test/fixtures/consumer/.ai-dev-foundation/skills/task-closure.md
+++ b/test/fixtures/consumer/.ai-dev-foundation/skills/task-closure.md
@@ -1,0 +1,80 @@
+# task-closure skill
+
+このファイルは `policy/core.md` の Issue closure and Acceptance Criteria
+completion protocol を使った Task closure 手順です。`policy/core.md` が保持する
+minimum safety boundary（Task Contract completion と merge-readiness の分離、
+evidence 不足・未達・判断不能な Acceptance Criteria がある場合の no-check /
+no-close、Acceptance Criteria が存在しない Issue へ close のために新たな
+Acceptance Criteria を捏造しないこと、Issue close execution authority の分離、
+auto-close keyword による標準 close の禁止）はここで再定義せず、`policy/core.md`
+を参照します。本 skill と policy が矛盾する場合は policy が優先します。
+
+5-step closure procedure の detail、推奨する sequence、close authority が無い
+場合の completion-comment / handoff procedure detail、および closure-specific
+no-new-machinery detail の canonical source は本 skill であり、`policy/core.md`
+には置きません。
+
+## いつ load するか
+
+`policy/core.md` の Issue closure and Acceptance Criteria completion protocol に
+従い、canonical Issue を completed として close しようとする場合、または close
+手順の適用要否が判断つかない場合は本 skill を **MUST load** します。判断がつかない
+場合を「適用不要」と解釈して silent skip してはいけません。
+
+この skill の canonical source は Foundation リポジトリの `policy/core.md` および
+`skills/task-closure.md` です。consumer には
+`.ai-dev-foundation/skills/task-closure.md` として本ファイルが配布され、
+`policy/core.md` の規範的なルールは generated `AGENTS.md` の `## Foundation
+policy` section として配布されます。以降 `policy/core.md` への参照は、consumer
+context ではこの `AGENTS.md` の `## Foundation policy` section を指します。
+consumer リポジトリに `policy/core.md` という path が存在することは前提にしません。
+
+## Closure procedure
+
+canonical Issue を completed として close する前に、少なくとも次を行います。
+
+1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
+   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
+   （canonical Task Contract）と、merge 済み current main または applicable branch
+   の状態を再取得します。
+2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
+   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
+   完了したように見える」という印象だけでは充足の根拠にしません。
+3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
+   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
+   evidence の一部として扱います。
+4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない
+   Acceptance Criteria が 1 件でも残る場合に check/close しないこと、および
+   Acceptance Criteria が存在しない Issue へ close のために新たな Acceptance
+   Criteria を捏造しないことは `policy/core.md` の minimum safety boundary です。
+   本 skill では複製しません。判断できない理由が明確な場合は、その理由を手順 5 の
+   completion comment に記録します。
+5. **completion comment** — final SHA、verification 結果、review evidence
+   （Review Protocol の Acquisition & Validity Contract に従う record / result
+   locator を含む）、および未解決事項を、Issue 上の completion comment として
+   記録します。
+
+推奨する sequence は次のとおりです。
+
+`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
+completion comment -> Issue close`
+
+## Close authority が無い場合
+
+Issue close の execution authority separation、および authority が無い場合に
+close を実行しないことは `policy/core.md` の minimum safety boundary です。本
+skill では複製しません。
+
+authority が明示されていない場合、または別 authority の承認が必要な場合、agent は
+Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で
+満たされているか（または未達か）を、手順 5 の completion comment として明示的に
+残した上で停止し、authority escalation / handoff します。
+
+## No new machinery
+
+この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
+workflow engine、または新しい orchestrator を要求しません。
+
+auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前
+に Issue が自動 close される運用を標準運用にしないことは `policy/core.md` の
+minimum safety boundary です。本 skill では複製しません。

--- a/test/fixtures/consumer/AGENTS.md
+++ b/test/fixtures/consumer/AGENTS.md
@@ -221,45 +221,36 @@ Review が完了していても、Issue Task Contract 上の Acceptance Criteria
 よいことにはなりません。canonical Issue を completed として close する判断は、この
 節に従います。
 
-canonical Issue を completed として close する前に、少なくとも次を行います。
+canonical Issue を completed として close しようとする場合、または close 手順の
+適用要否が判断つかない場合は、`.ai-dev-foundation/skills/task-closure.md` を
+**MUST load** します。判断がつかない場合を「適用不要」と解釈して silent skip しては
+いけません。**この path は consumer context のものです。Foundation リポジトリ自身の
+Task では、同じ canonical source である `skills/task-closure.md` を同じ条件で MUST
+load します。**
 
-1. **canonical context の再取得** — close しようとする session 自身の記憶や過去の
-   長文 handoff をそのまま正としてはいけません。close 直前に、current Issue 本文
-   （canonical Task Contract）と、merge 済み current main または applicable branch
-   の状態を再取得します。
-2. **Acceptance Criteria evidence 照合** — Acceptance Criteria を 1 項目ずつ、
-   実装・test・PR・review・merge 後の状態等の evidence と個別に照合します。「実装が
-   完了したように見える」という印象だけでは充足の根拠にしません。
-3. **checkbox 更新** — evidence で明確に充足を確認できた項目だけ checkbox を更新
-   します。checkbox 更新は見た目上の cleanup ではなく、Task Contract completion
-   evidence の一部として扱います。
-4. **未達・判断不能な項目の扱い** — evidence 不足または未達で判断できない Acceptance
-   Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。
-   Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance
-   Criteria を捏造しません。
-5. **completion comment** — final SHA、verification 結果、review evidence
-   （Review Protocol の Acquisition & Validity Contract に従う record / result
-   locator を含む）、および未解決事項を、Issue 上の completion comment として
-   記録します。
+5-step closure procedure（canonical context の再取得手順、Acceptance Criteria
+evidence 照合手順、checkbox 更新手順、未達・判断不能時の procedure detail、
+completion comment の field / record locator detail）、推奨する sequence、close
+authority が無い場合の completion-comment / handoff procedure detail、および
+closure-specific no-new-machinery detail の canonical source は、consumer context
+では `.ai-dev-foundation/skills/task-closure.md`、Foundation リポジトリ自身の Task
+では `skills/task-closure.md` です。本節はこれらの手続き的 detail を複製しません。
 
-推奨する sequence は次のとおりです。
+本節が、closure 判断に至っていない Task でも成立していなければならない minimum
+safety boundary として保持するのは次のとおりです。
 
-`merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 ->
-completion comment -> Issue close`
-
-Issue close の execution authority は、Merge readiness and merge authority と同じ
-分離に従います。current Task、Execution Envelope、または explicit な authority が
-close の実行を許可している場合に限り、agent は Issue を close してよいです。authority
-が明示されていない場合、または別 authority の承認が必要な場合、agent は Issue 本文の
-編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか
-（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、
-authority escalation / handoff します。
-
-auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に
-Issue が自動 close される運用を、標準運用にしません。
-
-この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management
-workflow engine、または新しい orchestrator を要求しません。
+- evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、
+  その項目を勝手に check せず、Issue も close しません。Issue に Acceptance
+  Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造
+  しません。
+- Issue close の execution authority は、Merge readiness and merge authority と
+  同じ分離に従います。current Task、Execution Envelope、または explicit な
+  authority が close の実行を許可している場合に限り、agent は Issue を close して
+  よいです。authority が明示されていない場合、または別 authority の承認が必要な
+  場合、agent は Issue 本文の編集や close を実行せず、evidence-supported な
+  completion state を記録した上で停止し、authority escalation / handoff します。
+- auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria
+  確認前に Issue が自動 close される運用を、標準運用にしません。
 
 ## Review Protocol
 

--- a/test/issue-closure-completion.test.mjs
+++ b/test/issue-closure-completion.test.mjs
@@ -20,7 +20,10 @@ function containsText(haystack, needle) {
 // consumer AGENTS.md, since composeAgents() embeds core.md verbatim and this
 // boundary must not silently drift between the two.
 function assertIssueClosureKernelBoundary(text, label) {
-  assert.ok(text.includes("### Issue closure and Acceptance Criteria completion"), `${label}: missing heading`);
+  assert.ok(
+    text.includes("### Issue closure and Acceptance Criteria completion"),
+    `${label}: missing heading`,
+  );
 
   // This must stay a distinct contract from Review Protocol's merge-readiness:
   // review completion does not stand in for Acceptance Criteria confirmation.
@@ -55,7 +58,10 @@ function assertIssueClosureKernelBoundary(text, label) {
     `${label}: missing act-shaped MUST-load trigger`,
   );
   assert.ok(
-    containsText(text, "判断がつかない場合を「適用不要」と解釈して silent skip してはいけません。"),
+    containsText(
+      text,
+      "判断がつかない場合を「適用不要」と解釈して silent skip してはいけません。",
+    ),
     `${label}: missing fail-closed uncertainty rule`,
   );
   assert.ok(
@@ -113,7 +119,7 @@ function assertIssueClosureKernelBoundary(text, label) {
   assert.ok(
     containsText(
       text,
-      "auto-close keyword（例: PR 本文の \"Closes #N\"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。",
+      'auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。',
     ),
     `${label}: missing auto-close-not-standard statement`,
   );
@@ -125,11 +131,17 @@ test("core policy keeps the minimum Issue closure Kernel safety boundary (#32, #
   assertIssueClosureKernelBoundary(core, "policy/core.md");
 
   // Stays provider-neutral, like the rest of the Kernel.
-  assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+  assert.doesNotMatch(
+    core,
+    /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i,
+  );
 });
 
 test("generated consumer AGENTS.md reflects the Issue closure Kernel safety boundary", async () => {
-  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+  const agents = await readFile(
+    path.join(root, "test", "fixtures", "consumer", "AGENTS.md"),
+    "utf8",
+  );
 
   assertIssueClosureKernelBoundary(agents, "test/fixtures/consumer/AGENTS.md");
 });
@@ -164,7 +176,10 @@ test("core policy delegates the 5-step closure procedure detail to skills/task-c
 });
 
 test("skills/task-closure.md owns the 5-step closure procedure detail (#114)", async () => {
-  const taskClosure = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+  const taskClosure = await readFile(
+    path.join(root, "skills", "task-closure.md"),
+    "utf8",
+  );
 
   assert.ok(taskClosure.includes("## Closure procedure"));
   assert.ok(taskClosure.includes("## Close authority が無い場合"));
@@ -179,7 +194,10 @@ test("skills/task-closure.md owns the 5-step closure procedure detail (#114)", a
   );
   assert.ok(containsText(taskClosure, "Acceptance Criteria evidence 照合"));
   assert.ok(
-    containsText(taskClosure, "「実装が完了したように見える」という印象だけでは充足の根拠にしません。"),
+    containsText(
+      taskClosure,
+      "「実装が完了したように見える」という印象だけでは充足の根拠にしません。",
+    ),
   );
   assert.ok(containsText(taskClosure, "checkbox 更新"));
   assert.ok(
@@ -215,7 +233,10 @@ test("skills/task-closure.md owns the 5-step closure procedure detail (#114)", a
     ),
   );
 
-  assert.doesNotMatch(taskClosure, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+  assert.doesNotMatch(
+    taskClosure,
+    /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i,
+  );
 });
 
 // #114 (#112 lesson): the Kernel MUST-load pointer must name both the
@@ -224,9 +245,16 @@ test("skills/task-closure.md owns the 5-step closure procedure detail (#114)", a
 test("core policy's task-closure pointer resolves in both consumer and Foundation-self context (#114)", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
-  const consumerOnlyPointerCount = (core.match(/`\.ai-dev-foundation\/skills\/task-closure\.md`/g) ?? []).length;
-  const selfContextPointerCount = (core.match(/`skills\/task-closure\.md`/g) ?? []).length;
-  assert.ok(consumerOnlyPointerCount > 0, "sanity check: consumer-context pointer must exist");
+  const consumerOnlyPointerCount = (
+    core.match(/`\.ai-dev-foundation\/skills\/task-closure\.md`/g) ?? []
+  ).length;
+  const selfContextPointerCount = (
+    core.match(/`skills\/task-closure\.md`/g) ?? []
+  ).length;
+  assert.ok(
+    consumerOnlyPointerCount > 0,
+    "sanity check: consumer-context pointer must exist",
+  );
   assert.ok(
     selfContextPointerCount >= consumerOnlyPointerCount,
     `every consumer-context task-closure.md pointer in core.md must be paired with a Foundation-self-context pointer (consumer-only refs: ${consumerOnlyPointerCount}, self-context refs: ${selfContextPointerCount})`,
@@ -239,7 +267,10 @@ test("core policy's task-closure pointer resolves in both consumer and Foundatio
 // sentences it references.
 test("policy/core.md and skills/task-closure.md do not verbatim-duplicate each other's canonical content (#114)", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
-  const taskClosure = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+  const taskClosure = await readFile(
+    path.join(root, "skills", "task-closure.md"),
+    "utf8",
+  );
 
   for (const skillOwnedDetail of [
     "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
@@ -259,9 +290,12 @@ test("policy/core.md and skills/task-closure.md do not verbatim-duplicate each o
     "evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。",
     "Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造しません。",
     "Issue close の execution authority は、Merge readiness and merge authority と同じ分離に従います。",
-    "auto-close keyword（例: PR 本文の \"Closes #N\"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。",
+    'auto-close keyword（例: PR 本文の "Closes #N"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。',
   ]) {
-    assert.ok(containsText(core, kernelSentence), `sanity check: sentence must actually be in core.md: ${kernelSentence}`);
+    assert.ok(
+      containsText(core, kernelSentence),
+      `sanity check: sentence must actually be in core.md: ${kernelSentence}`,
+    );
     assert.ok(
       !containsText(taskClosure, kernelSentence),
       `skills/task-closure.md must not verbatim-duplicate this Kernel sentence, only reference policy/core.md: ${kernelSentence}`,
@@ -271,10 +305,21 @@ test("policy/core.md and skills/task-closure.md do not verbatim-duplicate each o
 
 test("materialized consumer skill bundle includes task-closure.md (#114)", async () => {
   const materialized = await readFile(
-    path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "skills", "task-closure.md"),
+    path.join(
+      root,
+      "test",
+      "fixtures",
+      "consumer",
+      ".ai-dev-foundation",
+      "skills",
+      "task-closure.md",
+    ),
     "utf8",
   );
-  const source = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+  const source = await readFile(
+    path.join(root, "skills", "task-closure.md"),
+    "utf8",
+  );
   assert.equal(materialized, source);
 });
 
@@ -282,7 +327,10 @@ test("materialized consumer skill bundle includes task-closure.md (#114)", async
 // consumer artifact, not just gain new Kernel headings alongside stale
 // leftovers from a broken sync.
 test("generated consumer AGENTS.md does not carry the moved closure procedural detail (#114)", async () => {
-  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+  const agents = await readFile(
+    path.join(root, "test", "fixtures", "consumer", "AGENTS.md"),
+    "utf8",
+  );
 
   assert.ok(
     !containsText(
@@ -308,9 +356,18 @@ test("generated consumer AGENTS.md does not carry the moved closure procedural d
 // task-closure.md or duplicate its content — mirrors the #112 safety
 // scenario 6 pattern for the Review lane.
 test("review skills do not need to load or duplicate skills/task-closure.md (#114 safety scenario 1)", async () => {
-  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
-  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
-  const foundationChange = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
+  const reviewCode = await readFile(
+    path.join(root, "skills", "review-code.md"),
+    "utf8",
+  );
+  const reviewDoc = await readFile(
+    path.join(root, "skills", "review-doc.md"),
+    "utf8",
+  );
+  const foundationChange = await readFile(
+    path.join(root, "skills", "foundation-change.md"),
+    "utf8",
+  );
 
   for (const [name, skill] of [
     ["review-code.md", reviewCode],

--- a/test/issue-closure-completion.test.mjs
+++ b/test/issue-closure-completion.test.mjs
@@ -14,11 +14,12 @@ function containsText(haystack, needle) {
   return stripWhitespace(haystack).includes(stripWhitespace(needle));
 }
 
-// Shared assertion set for the Issue closure and Acceptance Criteria completion
-// protocol (#32). Run against both the canonical policy/core.md and the
-// generated consumer AGENTS.md, since composeAgents() embeds core.md verbatim
-// and this protocol's content must not silently drift between the two.
-function assertIssueClosureCompletionProtocol(text, label) {
+// Shared assertion set for the minimum Kernel safety boundary of the Issue
+// closure and Acceptance Criteria completion protocol (#32, narrowed by
+// #114). Run against both the canonical policy/core.md and the generated
+// consumer AGENTS.md, since composeAgents() embeds core.md verbatim and this
+// boundary must not silently drift between the two.
+function assertIssueClosureKernelBoundary(text, label) {
   assert.ok(text.includes("### Issue closure and Acceptance Criteria completion"), `${label}: missing heading`);
 
   // This must stay a distinct contract from Review Protocol's merge-readiness:
@@ -45,35 +46,34 @@ function assertIssueClosureCompletionProtocol(text, label) {
     `${label}: missing review-completion-does-not-skip-AC statement`,
   );
 
-  // The 5 required pre-close steps.
-  assert.ok(containsText(text, "canonical context の再取得"), `${label}: missing step 1 label`);
+  // #114: act-shaped closure trigger + dual-context MUST-load one-hop pointer.
   assert.ok(
     containsText(
       text,
-      "close しようとする session 自身の記憶や過去の長文 handoff をそのまま正としてはいけません。",
+      "canonical Issue を completed として close しようとする場合、または close 手順の適用要否が判断つかない場合は、`.ai-dev-foundation/skills/task-closure.md` を **MUST load** します。",
     ),
-    `${label}: missing step 1 detail`,
+    `${label}: missing act-shaped MUST-load trigger`,
   );
-  assert.ok(containsText(text, "Acceptance Criteria evidence 照合"), `${label}: missing step 2 label`);
   assert.ok(
-    containsText(text, "「実装が完了したように見える」という印象だけでは充足の根拠にしません。"),
-    `${label}: missing step 2 detail`,
+    containsText(text, "判断がつかない場合を「適用不要」と解釈して silent skip してはいけません。"),
+    `${label}: missing fail-closed uncertainty rule`,
   );
-  assert.ok(containsText(text, "checkbox 更新"), `${label}: missing step 3 label`);
   assert.ok(
     containsText(
       text,
-      "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+      "この path は consumer context のものです。Foundation リポジトリ自身の Task では、同じ canonical source である `skills/task-closure.md` を同じ条件で MUST load します。",
     ),
-    `${label}: missing step 3 detail`,
+    `${label}: missing Foundation-self path pointer`,
   );
-  assert.ok(containsText(text, "未達・判断不能な項目の扱い"), `${label}: missing step 4 label`);
+
+  // Fail-closed AC boundary: unmet/unknown Acceptance Criteria block close,
+  // and Acceptance Criteria are never fabricated to allow a close.
   assert.ok(
     containsText(
       text,
       "evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。",
     ),
-    `${label}: missing step 4 detail`,
+    `${label}: missing unmet/unknown AC no-check/no-close statement`,
   );
   assert.ok(
     containsText(
@@ -82,26 +82,10 @@ function assertIssueClosureCompletionProtocol(text, label) {
     ),
     `${label}: missing no-fabricating-AC statement`,
   );
-  assert.ok(containsText(text, "completion comment"), `${label}: missing step 5 label`);
-  assert.ok(
-    containsText(
-      text,
-      "final SHA、verification 結果、review evidence（Review Protocol の Acquisition & Validity Contract に従う record / result locator を含む）、および未解決事項を、Issue 上の completion comment として記録します。",
-    ),
-    `${label}: missing step 5 detail`,
-  );
 
-  // The recommended sequence, verbatim from Issue #32.
-  assert.ok(
-    containsText(
-      text,
-      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
-    ),
-    `${label}: missing recommended sequence`,
-  );
-
-  // Authority separation mirrors Merge readiness and merge authority: no
-  // authority, no close — leave a completion comment and stop instead.
+  // Issue close execution authority separation mirrors Merge readiness and
+  // merge authority: no authority, no close — leave evidence-supported
+  // completion state on the record and stop instead.
   assert.ok(
     containsText(
       text,
@@ -119,7 +103,7 @@ function assertIssueClosureCompletionProtocol(text, label) {
   assert.ok(
     containsText(
       text,
-      "agent は Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか（または未達か）を手順 5 の completion comment として明示的に残した上で停止し、authority escalation / handoff します。",
+      "agent は Issue 本文の編集や close を実行せず、evidence-supported な completion state を記録した上で停止し、authority escalation / handoff します。",
     ),
     `${label}: missing no-authority stop-and-handoff statement`,
   );
@@ -133,28 +117,209 @@ function assertIssueClosureCompletionProtocol(text, label) {
     ),
     `${label}: missing auto-close-not-standard statement`,
   );
-
-  // Out of scope for #32: no new bot / workflow-engine / orchestrator machinery.
-  assert.ok(
-    containsText(
-      text,
-      "この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
-    ),
-    `${label}: missing no-new-machinery statement`,
-  );
 }
 
-test("core policy defines the Issue closure and Acceptance Criteria completion protocol (#32)", async () => {
+test("core policy keeps the minimum Issue closure Kernel safety boundary (#32, #114)", async () => {
   const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
 
-  assertIssueClosureCompletionProtocol(core, "policy/core.md");
+  assertIssueClosureKernelBoundary(core, "policy/core.md");
 
   // Stays provider-neutral, like the rest of the Kernel.
   assert.doesNotMatch(core, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
 });
 
-test("generated consumer AGENTS.md reflects the Issue closure completion protocol", async () => {
+test("generated consumer AGENTS.md reflects the Issue closure Kernel safety boundary", async () => {
   const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
 
-  assertIssueClosureCompletionProtocol(agents, "test/fixtures/consumer/AGENTS.md");
+  assertIssueClosureKernelBoundary(agents, "test/fixtures/consumer/AGENTS.md");
+});
+
+// #114: the 5-step procedure detail, recommended sequence, close-authority-absent
+// handoff detail, and no-new-machinery detail moved to skills/task-closure.md
+// and must not remain duplicated in the Kernel.
+test("core policy delegates the 5-step closure procedure detail to skills/task-closure.md (#114)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  for (const movedDetail of [
+    "close しようとする session 自身の記憶や過去の長文 handoff をそのまま正としてはいけません。",
+    "「実装が完了したように見える」という印象だけでは充足の根拠にしません。",
+    "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+    "final SHA、verification 結果、review evidence",
+    "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+    "GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
+    "手順 5 の completion comment として明示的に残した上で停止し",
+  ]) {
+    assert.ok(
+      !containsText(core, movedDetail),
+      `policy/core.md must no longer contain moved closure procedure detail: ${movedDetail}`,
+    );
+  }
+
+  assert.ok(
+    containsText(
+      core,
+      "5-step closure procedure（canonical context の再取得手順、Acceptance Criteria evidence 照合手順、checkbox 更新手順、未達・判断不能時の procedure detail、completion comment の field / record locator detail）、推奨する sequence、close authority が無い場合の completion-comment / handoff procedure detail、および closure-specific no-new-machinery detail の canonical source は、consumer context では `.ai-dev-foundation/skills/task-closure.md`、Foundation リポジトリ自身の Task では `skills/task-closure.md` です。",
+    ),
+  );
+});
+
+test("skills/task-closure.md owns the 5-step closure procedure detail (#114)", async () => {
+  const taskClosure = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+
+  assert.ok(taskClosure.includes("## Closure procedure"));
+  assert.ok(taskClosure.includes("## Close authority が無い場合"));
+  assert.ok(taskClosure.includes("## No new machinery"));
+
+  assert.ok(containsText(taskClosure, "canonical context の再取得"));
+  assert.ok(
+    containsText(
+      taskClosure,
+      "close しようとする session 自身の記憶や過去の長文 handoff をそのまま正としてはいけません。",
+    ),
+  );
+  assert.ok(containsText(taskClosure, "Acceptance Criteria evidence 照合"));
+  assert.ok(
+    containsText(taskClosure, "「実装が完了したように見える」という印象だけでは充足の根拠にしません。"),
+  );
+  assert.ok(containsText(taskClosure, "checkbox 更新"));
+  assert.ok(
+    containsText(
+      taskClosure,
+      "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+    ),
+  );
+  assert.ok(containsText(taskClosure, "未達・判断不能な項目の扱い"));
+  assert.ok(containsText(taskClosure, "completion comment"));
+  assert.ok(
+    containsText(
+      taskClosure,
+      "final SHA、verification 結果、review evidence（Review Protocol の Acquisition & Validity Contract に従う record / result locator を含む）、および未解決事項を、Issue 上の completion comment として記録します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      taskClosure,
+      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+    ),
+  );
+  assert.ok(
+    containsText(
+      taskClosure,
+      "agent は Issue 本文の編集や close を実行せず、どの Acceptance Criteria がどの evidence で満たされているか（または未達か）を、手順 5 の completion comment として明示的に残した上で停止し、authority escalation / handoff します。",
+    ),
+  );
+  assert.ok(
+    containsText(
+      taskClosure,
+      "この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
+    ),
+  );
+
+  assert.doesNotMatch(taskClosure, /Codex|CodeRabbit|claude-[a-z0-9-]+|gpt-[a-z0-9-]+/i);
+});
+
+// #114 (#112 lesson): the Kernel MUST-load pointer must name both the
+// consumer-distributed path and the Foundation-repository-self path, so a
+// Task running inside the Foundation repository itself can resolve it.
+test("core policy's task-closure pointer resolves in both consumer and Foundation-self context (#114)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+
+  const consumerOnlyPointerCount = (core.match(/`\.ai-dev-foundation\/skills\/task-closure\.md`/g) ?? []).length;
+  const selfContextPointerCount = (core.match(/`skills\/task-closure\.md`/g) ?? []).length;
+  assert.ok(consumerOnlyPointerCount > 0, "sanity check: consumer-context pointer must exist");
+  assert.ok(
+    selfContextPointerCount >= consumerOnlyPointerCount,
+    `every consumer-context task-closure.md pointer in core.md must be paired with a Foundation-self-context pointer (consumer-only refs: ${consumerOnlyPointerCount}, self-context refs: ${selfContextPointerCount})`,
+  );
+});
+
+// #114 (#112/#113 lesson): the Kernel must not verbatim-duplicate the
+// procedural detail canonically owned by skills/task-closure.md, and the
+// skill must not verbatim-duplicate the Kernel's own minimum safety boundary
+// sentences it references.
+test("policy/core.md and skills/task-closure.md do not verbatim-duplicate each other's canonical content (#114)", async () => {
+  const core = await readFile(path.join(root, "policy", "core.md"), "utf8");
+  const taskClosure = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+
+  for (const skillOwnedDetail of [
+    "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+    "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+  ]) {
+    assert.ok(
+      containsText(taskClosure, skillOwnedDetail),
+      `sanity check: detail must actually be in skills/task-closure.md: ${skillOwnedDetail}`,
+    );
+    assert.ok(
+      !containsText(core, skillOwnedDetail),
+      `policy/core.md must not verbatim-duplicate skill-owned procedural detail: ${skillOwnedDetail}`,
+    );
+  }
+
+  for (const kernelSentence of [
+    "evidence 不足または未達で判断できない Acceptance Criteria が 1 件でも残る場合、その項目を勝手に check せず、Issue も close しません。",
+    "Issue に Acceptance Criteria が存在しない場合、close のために新たな Acceptance Criteria を捏造しません。",
+    "Issue close の execution authority は、Merge readiness and merge authority と同じ分離に従います。",
+    "auto-close keyword（例: PR 本文の \"Closes #N\"）によって Acceptance Criteria 確認前に Issue が自動 close される運用を、標準運用にしません。",
+  ]) {
+    assert.ok(containsText(core, kernelSentence), `sanity check: sentence must actually be in core.md: ${kernelSentence}`);
+    assert.ok(
+      !containsText(taskClosure, kernelSentence),
+      `skills/task-closure.md must not verbatim-duplicate this Kernel sentence, only reference policy/core.md: ${kernelSentence}`,
+    );
+  }
+});
+
+test("materialized consumer skill bundle includes task-closure.md (#114)", async () => {
+  const materialized = await readFile(
+    path.join(root, "test", "fixtures", "consumer", ".ai-dev-foundation", "skills", "task-closure.md"),
+    "utf8",
+  );
+  const source = await readFile(path.join(root, "skills", "task-closure.md"), "utf8");
+  assert.equal(materialized, source);
+});
+
+// #114: the moved procedural detail must actually leave the generated
+// consumer artifact, not just gain new Kernel headings alongside stale
+// leftovers from a broken sync.
+test("generated consumer AGENTS.md does not carry the moved closure procedural detail (#114)", async () => {
+  const agents = await readFile(path.join(root, "test", "fixtures", "consumer", "AGENTS.md"), "utf8");
+
+  assert.ok(
+    !containsText(
+      agents,
+      "checkbox 更新は見た目上の cleanup ではなく、Task Contract completion evidence の一部として扱います。",
+    ),
+  );
+  assert.ok(
+    !containsText(
+      agents,
+      "merge/current main 確認 -> Acceptance Criteria evidence 照合 -> checkbox 更新 -> completion comment -> Issue close",
+    ),
+  );
+  assert.ok(
+    !containsText(
+      agents,
+      "この protocol は、GitHub Issue checkbox 専用 bot、generalized project-management workflow engine、または新しい orchestrator を要求しません。",
+    ),
+  );
+});
+
+// #114: an ordinary non-closure task must not be required to load
+// task-closure.md or duplicate its content — mirrors the #112 safety
+// scenario 6 pattern for the Review lane.
+test("review skills do not need to load or duplicate skills/task-closure.md (#114 safety scenario 1)", async () => {
+  const reviewCode = await readFile(path.join(root, "skills", "review-code.md"), "utf8");
+  const reviewDoc = await readFile(path.join(root, "skills", "review-doc.md"), "utf8");
+  const foundationChange = await readFile(path.join(root, "skills", "foundation-change.md"), "utf8");
+
+  for (const [name, skill] of [
+    ["review-code.md", reviewCode],
+    ["review-doc.md", reviewDoc],
+    ["foundation-change.md", foundationChange],
+  ]) {
+    assert.ok(
+      !skill.includes("task-closure"),
+      `${name} must not reference skills/task-closure.md; unrelated Tasks must not be forced into the closure lane`,
+    );
+  }
 });


### PR DESCRIPTION
Refs #114
Parent: #109

## Summary

`policy/core.md` の `### Issue closure and Acceptance Criteria completion` から、5-step closure procedure detail・推奨 sequence・close authority が無い場合の completion-comment / handoff procedure detail・closure-specific no-new-machinery detail を、新設した Foundation-owned `skills/task-closure.md` へ canonical ownership として委譲しました。

Kernel（`policy/core.md`）には次を minimum safety boundary として保持しています。

- act-shaped closure trigger + dual-context（consumer `.ai-dev-foundation/skills/task-closure.md` / Foundation-self `skills/task-closure.md`）MUST-load one-hop pointer（適用要否不明時も fail-closed で load）
- Task Contract completion ≠ Review Protocol の merge-readiness / merge
- fail-closed AC boundary（unmet / unknown な Acceptance Criteria がある場合の no-check / no-close、AC 不在 Issue への捏造禁止）
- Issue close execution authority separation
- auto-close keyword を標準運用にしない boundary

`## 責務の分離` の委譲 enumeration は変更していません。既存の case 2（「特定の trigger 発火時（および発火したかどうか不明な場合）にのみ必要となる場合」）をそのまま再利用しており、新しい case は追加していません。

## #112 lessons への対応

- **dual-context path**: MUST-load pointer は consumer path と Foundation-self path の両方を明示（`.ai-dev-foundation/skills/task-closure.md` と `skills/task-closure.md`）。
- **canonical duplication 回避**: Kernel が保持する規範文（fail-closed AC boundary・authority separation・auto-close boundary）を skill へ verbatim 再掲していません。skill 側は該当箇所で "`policy/core.md` の minimum safety boundary です。本 skill では複製しません。" と参照するのみです。
- **paraphrase weakening 回避**: Kernel 側の close-authority-absent 文は元の意味（evidence-supported な completion state を記録して停止・handoff）を保った一般化文にし、詳細な "手順 5 の completion comment として…" という procedural wording は skill 側にそのまま残しました。

## Verification

- `npm run sync:fixture` で reference consumer fixture（`test/fixtures/consumer/AGENTS.md` / 生成 skill bundle）を再生成
- `npm test`: 296 tests green（依存未インストールの初期状態では #114 と無関係な pre-existing 2 failures — `eslint-config-prettier` 未インストールによる import error — があったが、`npm install` 後は 296/296 green）
- `npm run test:guardrails`: green
- `npm run check:fixture`: green（drift なし）
- `git diff --check`: no issues
- `test/issue-closure-completion.test.mjs` を Kernel-retained invariant assertion（`assertIssueClosureKernelBoundary`）と skill-owned detail assertion へ再構成し、以下を新規追加
  - dual-context task-closure pointer regression test
  - Kernel/Skill canonical duplication regression test
  - 生成 consumer AGENTS.md から移動済み detail が消えていることを確認する test
  - 非 closure skill（review-code / review-doc / foundation-change）が `task-closure` を参照しない safety scenario 1 相当の test
- 実装 session 内 general-purpose agent による adversarial pre-review 1 round（no findings） — ただしこれは Selection されていない preflight 利用であり、required review 数には算入しません。normal Review Protocol（Selection → 独立 required reviewer の trigger/acquire → triage → merge-ready fence）は本 PR を Ready 化した上で別途実行します。

## Actual byte effect

- `policy/core.md`: 49,409 B → 49,011 B（closure 節の Kernel-retained 分のみ、**-398 B**）
- reference consumer 生成 `AGENTS.md`: 51,568 B → 51,170 B（**-398 B**、core.md を verbatim 埋め込むため同一 delta）
- Foundation skill bundle（`skills/*.md` 合計）: 69,127 B → 74,274 B（`task-closure.md` 5,147 B 追加）
- #107 planning estimate（2.2–2.5 KB）に対し実測は大幅に小さい（-398 B）。byte reduction は success condition ではないため、Gate 3 判断は navigation cost / discoverability / safety 面で行う。

## Real-consumer canary — `reitojike/stage-tracker`（bounded, non-committing）

fresh 取得した stage-tracker（`main`: `1ed5b6abc0aaf67286541aded571cd6189ee05e5`、Foundation pin: `407f403a498cf8186896a35bb6015296e66eb3db`、生成 `AGENTS.md`: 105,245 B）は issue 起票時の planning baseline と一致していることを確認しました。

stage-tracker リポジトリ自体へは一切 commit / repin していません。scratchpad 上へ non-committing にコピーした上で、以下 2 パターンを `tooling/sync.mjs` で bounded 材化しました。

1. candidate branch（本 PR、Phase1+2+3 込み） → 生成 `AGENTS.md` 98,403 B
2. 現行 `main`（`eed1d1a`、Phase1+2 込み・Phase3 なし） → 生成 `AGENTS.md` 98,801 B

Phase3 のみの isolated 効果は (2)→(1) で **-398 B**、reference consumer と byte-for-byte 一致。diff は closure 節のみに閉じており、stage-tracker の product-domain rule には無関係な変化がないことを確認しました。skill bundle は `task-closure.md` 追加分 +5,147 B のみ増加。

closure routing / false-completion / authority behavior の canary観点:

- consumer path (`.ai-dev-foundation/skills/task-closure.md`) と Foundation-self path (`skills/task-closure.md`) の両方が candidate artifact 上で一意に解決すること — 確認済み
- ordinary（非 closure）task で closure detail の load が要求されないこと — `review-code.md` / `review-doc.md` / `foundation-change.md` が `task-closure` を参照しない test で担保
- merge-ready / merged state と Task completion を混同しない Kernel 文が保持されていること — 確認済み
- unmet / unknown AC での false close を防ぐ fail-closed 文が保持されていること — 確認済み
- close authority 無しでの authority bypass を防ぐ分離文が保持されていること — 確認済み
- canonical duplication / semantic paraphrase drift が無いこと — 独立 review で確認済み

## Unresolved concern

- 実測 byte reduction（-398 B）は #107 planning estimate（2.2–2.5 KB）を大きく下回ります。Task closure 節はそもそも短く（3,399 B / 50 lines）、Kernel に残す minimum safety boundary の分量が相対的に大きいため構造的な上限です。kill condition の「final actual effect が maintenance/navigation cost に対して marginal」に該当し得るかは Gate 3 判断に委ねます。
- navigation cost: one-hop pointer 1 段のみで、新しい loader / registry は追加していません。maintenance cost: 新規 skill 1 ファイル・test 1 ファイルの改修で、既存 `foundation-change.md` パターンを踏襲しているため limited と考えます。
- normal Review Protocol（Selection Contract に基づく required reviewer の trigger/acquire/triage/merge-ready fence）はこの PR body 更新時点ではまだ未実行です。Ready 化後、reviewer capability record に従って実行します。

## Gate 3 recommendation

- 現時点では **暫定**: safety regression / #112 既知 failure mode の再発は無いと判断していますが、normal Review Protocol 完了と merge-ready fence の pass を待ってから確定します。
- release / stage-tracker permanent repin / Ticket Opportunity canary へは本 PR からは進みません（scope 外）。merge execution authority も本セッションにはありません。

## Final target SHA / base

- base: `main` (`eed1d1a314505195e6dbfa1a1eb3245657d88b80`)
- head: `claude/issue-114-task-closure-conditional-vfabnz`

## Exact move / remain inventory

**Kernel remain（`policy/core.md`）:**
- merge-readiness separation の 3 文（変更なし）
- act-shaped trigger + dual-context MUST-load pointer（新規追加）
- fail-closed AC boundary 2 文
- Issue close execution authority separation（一般化した no-authority stop-and-handoff 文を含む）
- auto-close bypass boundary

**Skill move（`skills/task-closure.md`）:**
- 5-step procedure detail（canonical context 再取得／AC evidence 照合／checkbox 更新／未達・判断不能時 detail／completion comment field detail）
- 推奨 sequence
- close authority が無い場合の completion-comment / handoff procedure detail（手順 5 参照を含む具体文）
- closure-specific no-new-machinery detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGHaoYEBa3R7ME5r5dvrSX